### PR TITLE
Changed property ${dp-grcp-version} to 1.3.0 (from 1.0.0).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <log4j-version>2.20.0</log4j-version>
         <io.grpc.version>1.49.0</io.grpc.version>
         <mongodb.version>4.9.1</mongodb.version>
-        <dp-grpc.version>1.0.0</dp-grpc.version>
+        <dp-grpc.version>1.3.0</dp-grpc.version>
         <snakeyaml.version>2.2</snakeyaml.version>
 
     </properties>


### PR DESCRIPTION
The old dp-grpc version (1.0.0) was still in the repository POM file.  dp-service branch dev-1.3 would not build on my platform.