### PR TITLE
dp-service #183: mechanism for overriding URL and database name for integration tests

### DIFF
--- a/doc/running.md
+++ b/doc/running.md
@@ -131,6 +131,7 @@ services:
 Below is the list of environment variables referenced in the project's `application.yml`. Each variable maps to a configuration property; if not set, the YAML default applies.
 
 - `DP_MONGO_DB_URI` : Full MongoDB connection string. Example: `mongodb://user:pass@host:27017/?authSource=admin`
+- `DP_MONGO_TEST_DB_NAME` : Name of the MongoDB database used by integration tests (default: `dp-test`). **WARNING: this database is dropped and recreated at the start of every test run — never point it at a database containing data you want to keep.**
 - `DP_GRPC_CLIENT_HOSTNAME` : gRPC client hostname (default: `localhost`)
 - `DP_GRPC_CLIENT_KEEP_ALIVE_TIME_SECONDS` : gRPC client keepalive time in seconds (default: `45`)
 - `DP_GRPC_CLIENT_KEEP_ALIVE_TIMEOUT_SECONDS` : gRPC client keepalive timeout in seconds (default: `20`)
@@ -167,3 +168,37 @@ Below is the list of environment variables referenced in the project's `applicat
 - `DP_INGESTION_STREAM_TRIGGERED_EVENT_MANAGER_EVENT_CLEANUP_INTERVAL_MILLIS` : TriggeredEventManager cleanup interval in ms (default: `5000`)
 
 TODO: add a short example `docker-compose.yml` snippet that demonstrates mounting configuration files while still using environment overrides, I can add that as a follow-up.
+
+## Running integration tests against a non-local MongoDB cluster
+
+The integration test framework is designed for development use: it drops and recreates the test database before each test class runs, starting from a completely clean state. This is intentional — the tests are not designed to tolerate pre-existing data.
+
+### Prerequisites
+
+- The MongoDB user in the connection URI must have **`dbOwner`** (or equivalent `dbAdmin` + `readWrite`) privileges on the test database. The framework drops the entire database on each run; a `readWrite`-only user is insufficient.
+- The test database name must be a **dedicated throwaway name** that does not conflict with any production or shared database on the cluster.
+
+### Configuration
+
+Set two environment variables before running the tests:
+
+```bash
+# MongoDB connection URI for the target cluster
+export DP_MONGO_DB_URI="mongodb://testuser:testpass@cluster-host:27017/?authSource=admin"
+
+# Name of the dedicated test database (will be DROPPED before each test class)
+export DP_MONGO_TEST_DB_NAME="dp-test-functional"
+
+mvn test -Dtest=PvMetadataIT
+```
+
+Or to run all integration tests:
+
+```bash
+export DP_MONGO_DB_URI="mongodb://testuser:testpass@cluster-host:27017/?authSource=admin"
+export DP_MONGO_TEST_DB_NAME="dp-test-functional"
+
+mvn test
+```
+
+> **WARNING:** The database named by `DP_MONGO_TEST_DB_NAME` is **dropped without confirmation** at the start of every test run. Use a name that is reserved exclusively for this purpose.

--- a/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoClientBase.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoClientBase.java
@@ -315,7 +315,7 @@ public abstract class MongoClientBase {
         return uriOverride;
     }
 
-    public static String getMongoDatabaseName() {
+    protected static String getMongoDatabaseName() {
         if (mongoDatabaseName == null) {
             return MONGO_DATABASE_NAME;
         } else {
@@ -324,7 +324,7 @@ public abstract class MongoClientBase {
     }
 
     protected static void setMongoDatabaseName(String databaseName) {
-        if (databaseName.isBlank()) {
+        if (databaseName == null || databaseName.isBlank()) {
             logger.error("setDatabaseName specified database name is empty");
         } else {
             mongoDatabaseName = databaseName;

--- a/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoClientBase.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoClientBase.java
@@ -315,7 +315,7 @@ public abstract class MongoClientBase {
         return uriOverride;
     }
 
-    protected static String getMongoDatabaseName() {
+    public static String getMongoDatabaseName() {
         if (mongoDatabaseName == null) {
             return MONGO_DATABASE_NAME;
         } else {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,12 +8,6 @@ MongoClient:
   #   mongo-2.mongo-headless.ns.svc.cluster.local:27017/?replicaSet=rs0&authSource=admin
   uri: ${DP_MONGO_DB_URI:mongodb://admin:admin@localhost:27017/}
 
-  # MongoClient.testDatabaseName: Name of the MongoDB database used by integration tests.
-  # WARNING: This database is DROPPED and recreated at the start of every test run.
-  # Never point this at a database containing data you want to keep.
-  # Override via DP_MONGO_TEST_DB_NAME environment variable when running tests against a non-local cluster.
-  testDatabaseName: ${DP_MONGO_TEST_DB_NAME:dp-test}
-
 # GrpcClient: General settings for gRPC clients.
 GrpcClient:
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,12 @@ MongoClient:
   #   mongo-2.mongo-headless.ns.svc.cluster.local:27017/?replicaSet=rs0&authSource=admin
   uri: ${DP_MONGO_DB_URI:mongodb://admin:admin@localhost:27017/}
 
+  # MongoClient.testDatabaseName: Name of the MongoDB database used by integration tests.
+  # WARNING: This database is DROPPED and recreated at the start of every test run.
+  # Never point this at a database containing data you want to keep.
+  # Override via DP_MONGO_TEST_DB_NAME environment variable when running tests against a non-local cluster.
+  testDatabaseName: ${DP_MONGO_TEST_DB_NAME:dp-test}
+
 # GrpcClient: General settings for gRPC clients.
 GrpcClient:
 

--- a/src/test/java/com/ospreydcs/dp/service/common/mongo/MongoTestClient.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/mongo/MongoTestClient.java
@@ -32,15 +32,19 @@ public class MongoTestClient extends MongoSyncClient {
 
     // constants
     public static final String MONGO_TEST_DATABASE_NAME = "dp-test";
+    public static final String CFG_KEY_TEST_DATABASE_NAME = "MongoClient.testDatabaseName";
     public static final int MONGO_FIND_RETRY_COUNT = 300;
     public static final int MONGO_FIND_RETRY_INTERVAL_MILLIS = 100;
 
     @Override
     public boolean init() {
 
+        // resolve test database name from config (supports DP_MONGO_TEST_DB_NAME env override), falling back to constant
+        String testDatabaseName = configMgr().getConfigString(CFG_KEY_TEST_DATABASE_NAME, MONGO_TEST_DATABASE_NAME);
+
         // override the default database name globally
-        logger.info("overriding db name globally to: {}", MONGO_TEST_DATABASE_NAME);
-        MongoClientBase.setMongoDatabaseName(MONGO_TEST_DATABASE_NAME);
+        logger.warn("overriding db name globally to: {} — THIS DATABASE WILL BE DROPPED", testDatabaseName);
+        MongoClientBase.setMongoDatabaseName(testDatabaseName);
 
         // init so we have database client for dropping existing db
         super.init();
@@ -52,8 +56,9 @@ public class MongoTestClient extends MongoSyncClient {
     }
 
     public void dropTestDatabase() {
-        logger.info("dropping database: {}", MONGO_TEST_DATABASE_NAME);
-        MongoDatabase database = this.mongoClient.getDatabase(MONGO_TEST_DATABASE_NAME);
+        String dbName = MongoClientBase.getMongoDatabaseName();
+        logger.warn("dropping database: {}", dbName);
+        MongoDatabase database = this.mongoClient.getDatabase(dbName);
         database.drop();
     }
 

--- a/src/test/java/com/ospreydcs/dp/service/common/mongo/MongoTestClient.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/mongo/MongoTestClient.java
@@ -56,7 +56,11 @@ public class MongoTestClient extends MongoSyncClient {
     }
 
     public void dropTestDatabase() {
-        String dbName = MongoClientBase.getMongoDatabaseName();
+        String dbName = getMongoDatabaseName();
+        if (dbName.equals(MongoClientBase.MONGO_DATABASE_NAME)) {
+            throw new IllegalStateException(
+                    "dropTestDatabase() refused to drop production database: " + dbName);
+        }
         logger.warn("dropping database: {}", dbName);
         MongoDatabase database = this.mongoClient.getDatabase(dbName);
         database.drop();
@@ -65,6 +69,10 @@ public class MongoTestClient extends MongoSyncClient {
     public static void prepareTestDatabase() {
         MongoTestClient testClient = new MongoTestClient();
         testClient.init();
+    }
+
+    public static String getConfiguredTestDatabaseName() {
+        return getMongoDatabaseName();
     }
 
     public ProviderDocument findProvider(String providerId) {

--- a/src/test/java/com/ospreydcs/dp/service/common/mongo/driver/MongoAsyncDriverTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/mongo/driver/MongoAsyncDriverTest.java
@@ -35,7 +35,7 @@ public class MongoAsyncDriverTest {
         MongoTestClient.prepareTestDatabase();
 
         mongoClient = MongoClients.create(MongoClientBase.getMongoConnectString());
-        mongoDatabase = mongoClient.getDatabase(MongoTestClient.MONGO_TEST_DATABASE_NAME);
+        mongoDatabase = mongoClient.getDatabase(MongoClientBase.getMongoDatabaseName());
     }
 
     @AfterClass

--- a/src/test/java/com/ospreydcs/dp/service/common/mongo/driver/MongoAsyncDriverTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/mongo/driver/MongoAsyncDriverTest.java
@@ -6,7 +6,6 @@ import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 import com.mongodb.reactivestreams.client.MongoCollection;
-import com.ospreydcs.dp.service.common.mongo.MongoClientBase;
 import com.ospreydcs.dp.service.common.mongo.MongoTestClient;
 import com.ospreydcs.dp.service.ingest.handler.mongo.ObservableSubscriber;
 import org.bson.Document;
@@ -34,8 +33,8 @@ public class MongoAsyncDriverTest {
         // Use test db client to set database name globally to "dp-test" and remove that database if it already exists
         MongoTestClient.prepareTestDatabase();
 
-        mongoClient = MongoClients.create(MongoClientBase.getMongoConnectString());
-        mongoDatabase = mongoClient.getDatabase(MongoClientBase.getMongoDatabaseName());
+        mongoClient = MongoClients.create(MongoTestClient.getMongoConnectString());
+        mongoDatabase = mongoClient.getDatabase(MongoTestClient.getConfiguredTestDatabaseName());
     }
 
     @AfterClass

--- a/src/test/java/com/ospreydcs/dp/service/common/mongo/driver/MongoSyncDriverTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/mongo/driver/MongoSyncDriverTest.java
@@ -33,7 +33,7 @@ public class MongoSyncDriverTest {
         MongoTestClient.prepareTestDatabase();
 
         mongoClient = MongoClients.create(MongoClientBase.getMongoConnectString());
-        mongoDatabase = mongoClient.getDatabase(MongoTestClient.MONGO_TEST_DATABASE_NAME);
+        mongoDatabase = mongoClient.getDatabase(MongoClientBase.getMongoDatabaseName());
     }
 
     @AfterClass

--- a/src/test/java/com/ospreydcs/dp/service/common/mongo/driver/MongoSyncDriverTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/mongo/driver/MongoSyncDriverTest.java
@@ -6,7 +6,6 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.result.InsertManyResult;
-import com.ospreydcs.dp.service.common.mongo.MongoClientBase;
 import com.ospreydcs.dp.service.common.mongo.MongoTestClient;
 import org.bson.Document;
 import org.junit.AfterClass;
@@ -32,8 +31,8 @@ public class MongoSyncDriverTest {
         // Use test db client to set database name globally to "dp-test" and remove that database if it already exists
         MongoTestClient.prepareTestDatabase();
 
-        mongoClient = MongoClients.create(MongoClientBase.getMongoConnectString());
-        mongoDatabase = mongoClient.getDatabase(MongoClientBase.getMongoDatabaseName());
+        mongoClient = MongoClients.create(MongoTestClient.getMongoConnectString());
+        mongoDatabase = mongoClient.getDatabase(MongoTestClient.getConfiguredTestDatabaseName());
     }
 
     @AfterClass

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,7 +7,6 @@
 #  dbUri: mongodb://admin:admin@localhost:27017/?replicaSet=rs0&authSource=admin
 
 MongoClient:
-  uri: ${DP_MONGO_DB_URI:mongodb://admin:admin@localhost:27017/}
   testDatabaseName: ${DP_MONGO_TEST_DB_NAME:dp-test}
 
 Level1:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,6 +6,10 @@
 #  # This resource is required, and if not provided, the URI is assembled from the resources for host, port, user, and password.
 #  dbUri: mongodb://admin:admin@localhost:27017/?replicaSet=rs0&authSource=admin
 
+MongoClient:
+  uri: ${DP_MONGO_DB_URI:mongodb://admin:admin@localhost:27017/}
+  testDatabaseName: ${DP_MONGO_TEST_DB_NAME:dp-test}
+
 Level1:
   Level2:
     intValue: 60


### PR DESCRIPTION
## Summary

The integration test framework was hardwired to use a MongoDB database named `dp-test`. This was a deliberate safety rail to prevent accidental data loss on the production `dp` database, but it provided no flexibility for running tests against a non-local MongoDB cluster.

This PR adds support for overriding the test database name via the `DP_MONGO_TEST_DB_NAME` environment variable, consistent with the existing `DP_MONGO_DB_URI` pattern used for the connection string. The default remains `dp-test` so there is no behavioral change for existing development workflows.

- Add `MongoClient.testDatabaseName: ${DP_MONGO_TEST_DB_NAME:dp-test}` to `application.yml`
- `MongoTestClient.init()` reads the database name through `ConfigurationManager` instead of a hardwired constant, picking up the env var override when set
- `dropTestDatabase()` reads the active name from `MongoClientBase.getMongoDatabaseName()` so it always drops exactly what was configured
- Both methods now log at `warn` level to make the destructive drop visible in test output
- `doc/running.md`: add `DP_MONGO_TEST_DB_NAME` to the env vars table and a new section "Running integration tests against a non-local MongoDB cluster" covering prerequisites, required MongoDB privileges, and example commands

**WARNING:** The database named by `DP_MONGO_TEST_DB_NAME` is dropped without confirmation at the start of every test run. It must be a dedicated throwaway name. The connecting MongoDB user must have `dbOwner` (or equivalent `dbAdmin` + `readWrite`) privileges on that database.

## Test plan

- [ ] Verify existing tests pass with no env var set (default `dp-test` behavior unchanged)
- [ ] Verify tests pass with `DP_MONGO_TEST_DB_NAME` set to an alternate name — confirm the alternate database is used and dropped
- [ ] Verify `DP_MONGO_DB_URI` + `DP_MONGO_TEST_DB_NAME` together correctly target a non-local cluster

🤖 Generated with [Claude Code](https://claude.ai/claude-code)