### PR TITLE
dp-service: bump version to 1.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>com.ospreydcs</groupId>
     <artifactId>dp-service</artifactId>
     <packaging>jar</packaging>
-    <version>1.14.0</version>
+    <version>1.15.0</version>
 
     <properties>
 
@@ -22,7 +22,7 @@
 
         <main.basedir>${project.basedir}</main.basedir>
 
-        <dp-grpc.version>1.14.0</dp-grpc.version>
+        <dp-grpc.version>1.15.0</dp-grpc.version>
         <mongodb.version>5.4.0</mongodb.version>
         <log4j-version>2.23.1</log4j-version>
         <snakeyaml.version>2.2</snakeyaml.version>


### PR DESCRIPTION
Bumps the project version and the `dp-grpc` dependency version from 1.14.0 to 1.15.0 for the 1.15 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)