### PR TITLE
dp-service #191: cheap distinct-based PV existence check for subscription and dataset validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,7 @@ The record being updated is excluded from the check via `Filters.ne(clientActiva
 - API method implementations follow: Handler → Job → Database Client → Dispatcher pattern
 - Jobs named as `<APIMethod>Job`, Dispatchers as `<APIMethod>Dispatcher`
 - Error handling uses DpException and structured logging
+- **Exception logging convention (new as of #191):** when logging a caught exception, pass the exception object as the final `logger` argument so the stack trace is captured — e.g. `logger.error("methodName database error: {}", ex.getMessage(), ex)`. Older code logs `ex.getMessage()` only (no trace); migrate those to include `ex` as you touch them.
 - Integration tests located in `integration.<service>` packages
 - Follow existing patterns for protobuf ↔ MongoDB document conversion
 - Result objects use `ResultStatus` class with `isError` (Boolean) and `msg` (String) fields

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/MongoAnnotationHandler.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/MongoAnnotationHandler.java
@@ -138,7 +138,7 @@ public class MongoAnnotationHandler extends QueueHandlerBase implements Annotati
         // every bucket for each PV and grows expensive as the archive grows.
         final Collection<String> existingPvNames = mongoQueryClient.executeQueryPvExistence(uniquePvNames);
         if (existingPvNames == null) {
-            return new ResultStatus(true, "error executing pv metadata query to validate request");
+            return new ResultStatus(true, "database error checking existence of PV names to validate request");
         }
 
         // remove each existing pv from the set, and make sure the set ends up empty

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/MongoAnnotationHandler.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/MongoAnnotationHandler.java
@@ -1,6 +1,5 @@
 package com.ospreydcs.dp.service.annotation.handler.mongo;
 
-import com.mongodb.client.MongoCursor;
 import com.ospreydcs.dp.grpc.v1.annotation.*;
 import com.ospreydcs.dp.service.annotation.handler.interfaces.AnnotationHandlerInterface;
 import com.ospreydcs.dp.service.annotation.handler.model.HandlerExportDataRequest;
@@ -8,7 +7,6 @@ import com.ospreydcs.dp.service.annotation.handler.mongo.client.MongoAnnotationC
 import com.ospreydcs.dp.service.annotation.handler.mongo.client.MongoSyncAnnotationClient;
 import com.ospreydcs.dp.service.annotation.handler.mongo.job.*;
 import com.ospreydcs.dp.service.annotation.service.AnnotationServiceImpl;
-import com.ospreydcs.dp.service.common.bson.PvMetadataQueryResultDocument;
 import com.ospreydcs.dp.service.common.bson.annotation.AnnotationDocument;
 import com.ospreydcs.dp.service.common.bson.dataset.DataSetDocument;
 import com.ospreydcs.dp.service.common.handler.QueueHandlerBase;
@@ -135,23 +133,18 @@ public class MongoAnnotationHandler extends QueueHandlerBase implements Annotati
             uniquePvNames.addAll(blockPvNames);
         }
 
-        // execute metadata query for list of pv names
-        final MongoCursor<PvMetadataQueryResultDocument> pvMetadata = mongoQueryClient.executeQueryPvStats(uniquePvNames);
-        if (pvMetadata == null) {
+        // validate that each pv exists in the archive using a cheap existence check (distinct on
+        // the pvName index) rather than the full stat aggregation, which sorts and groups over
+        // every bucket for each PV and grows expensive as the archive grows.
+        final Collection<String> existingPvNames = mongoQueryClient.executeQueryPvExistence(uniquePvNames);
+        if (existingPvNames == null) {
             return new ResultStatus(true, "error executing pv metadata query to validate request");
         }
 
-        // check that metadata is returned for each pv (try to remove each metadata from the set,
-        // and make sure set end up empty)
-        while (pvMetadata.hasNext()) {
-            final PvMetadataQueryResultDocument pvMetadataDocument = pvMetadata.next();
-            final String pvName = pvMetadataDocument.getPvName();
-            if (pvName != null) {
-                uniquePvNames.remove(pvName);
-            }
-        }
+        // remove each existing pv from the set, and make sure the set ends up empty
+        uniquePvNames.removeAll(existingPvNames);
 
-        // we should have removed all the pv names from the set of unique names, e.g., we received metadata for each
+        // we should have removed all the pv names from the set of unique names, e.g., each one exists
         if (uniquePvNames.isEmpty()) {
             return new ResultStatus(false, "");
         } else {

--- a/src/main/java/com/ospreydcs/dp/service/ingest/handler/mongo/job/SubscribeDataJob.java
+++ b/src/main/java/com/ospreydcs/dp/service/ingest/handler/mongo/job/SubscribeDataJob.java
@@ -1,9 +1,7 @@
 package com.ospreydcs.dp.service.ingest.handler.mongo.job;
 
-import com.mongodb.client.MongoCursor;
 import com.ospreydcs.dp.grpc.v1.ingestion.SubscribeDataRequest;
 import com.ospreydcs.dp.grpc.v1.ingestion.SubscribeDataResponse;
-import com.ospreydcs.dp.service.common.bson.PvMetadataQueryResultDocument;
 import com.ospreydcs.dp.service.common.config.ConfigurationManager;
 import com.ospreydcs.dp.service.common.handler.HandlerJob;
 import com.ospreydcs.dp.service.ingest.handler.mongo.SourceMonitorManager;
@@ -15,6 +13,7 @@ import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -67,29 +66,24 @@ public class SubscribeDataJob extends HandlerJob {
         logger.debug("executing SubscribeDataJob id: {}", this.responseObserver.hashCode());
 
         if (getConfigValidatePvs()) {
-            // validate that request PVs exist in archive
+            // validate that request PVs exist in archive using a cheap existence check (distinct on
+            // the pvName index) rather than the full stat aggregation, which sorts and groups over
+            // every bucket for each PV and grows expensive as the archive grows.
             final Set<String> uniquePvNames = new HashSet<>(request.getNewSubscription().getPvNamesList());
-            final MongoCursor<PvMetadataQueryResultDocument> pvMetadata = mongoQueryClient.executeQueryPvStats(uniquePvNames);
+            final Collection<String> existingPvNames = mongoQueryClient.executeQueryPvExistence(uniquePvNames);
 
             // check for error executing mongo query
-            if (pvMetadata == null) {
+            if (existingPvNames == null) {
                 final String errorMsg = "database error looking up metadata for PV names: " + uniquePvNames.toString();
                 logger.debug(errorMsg + " sending error response id: " + this.responseObserver.hashCode());
                 dispatcher.sendError(errorMsg);
                 return;
             }
 
-            // check that metadata is returned for each pv (try to remove each metadata from the set,
-            // and make sure set ends up empty)
-            while (pvMetadata.hasNext()) {
-                final PvMetadataQueryResultDocument pvMetadataDocument = pvMetadata.next();
-                final String pvName = pvMetadataDocument.getPvName();
-                if (pvName != null) {
-                    uniquePvNames.remove(pvName);
-                }
-            }
+            // remove each existing pv from the set, and make sure the set ends up empty
+            uniquePvNames.removeAll(existingPvNames);
 
-            // we should have removed all the pv names from the set of unique names, e.g., we received metadata for each
+            // we should have removed all the pv names from the set of unique names, e.g., each one exists
             if (!uniquePvNames.isEmpty()) {
                 final String errorMsg = "PV names not found in archive: " + uniquePvNames.toString();
                 logger.debug(errorMsg + " sending reject response id: " + this.responseObserver.hashCode());

--- a/src/main/java/com/ospreydcs/dp/service/ingest/handler/mongo/job/SubscribeDataJob.java
+++ b/src/main/java/com/ospreydcs/dp/service/ingest/handler/mongo/job/SubscribeDataJob.java
@@ -74,7 +74,7 @@ public class SubscribeDataJob extends HandlerJob {
 
             // check for error executing mongo query
             if (existingPvNames == null) {
-                final String errorMsg = "database error looking up metadata for PV names: " + uniquePvNames.toString();
+                final String errorMsg = "database error checking existence of PV names: " + uniquePvNames.toString();
                 logger.debug(errorMsg + " sending error response id: " + this.responseObserver.hashCode());
                 dispatcher.sendError(errorMsg);
                 return;

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
@@ -31,7 +31,13 @@ public interface MongoQueryClientInterface {
      * Returns the subset of the specified PV names that exist in the archive. This is a cheap
      * existence check backed by a {@code distinct} on the pvName index, avoiding the full stat
      * aggregation (sort + group over all buckets for each PV) performed by executeQueryPvStats().
-     * Returns null if a database error occurs.
+     * Returns an empty collection if pvNameList is null or empty, and null if a database error
+     * occurs.
+     * <p>
+     * The result is bounded by the size of the input {@code pvNameList} (a matched-names subset),
+     * so it is safe for the small name sets passed by subscription/dataset validation. It is NOT
+     * suitable for unbounded name sets: {@code distinct} materializes its result into a single
+     * 16MB BSON document, which a very large result could exceed.
      */
     Collection<String> executeQueryPvExistence(Collection<String> pvNameList);
 

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
@@ -27,6 +27,14 @@ public interface MongoQueryClientInterface {
 
     MongoCursor<PvMetadataQueryResultDocument> executeQueryPvStats(String pvNamePatternString);
 
+    /**
+     * Returns the subset of the specified PV names that exist in the archive. This is a cheap
+     * existence check backed by a {@code distinct} on the pvName index, avoiding the full stat
+     * aggregation (sort + group over all buckets for each PV) performed by executeQueryPvStats().
+     * Returns null if a database error occurs.
+     */
+    Collection<String> executeQueryPvExistence(Collection<String> pvNameList);
+
     MongoCursor<ProviderDocument> executeQueryProviders(QueryProvidersRequest request);
 
     MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(QueryProviderStatsRequest request);

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
@@ -21,7 +21,9 @@ import org.bson.types.ObjectId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import static com.mongodb.client.model.Filters.*;
@@ -224,6 +226,31 @@ public class MongoSyncQueryClient extends MongoSyncClient implements MongoQueryC
         final Pattern pvNamePattern = Pattern.compile(pvNamePatternString, Pattern.CASE_INSENSITIVE);
         final Bson pvNameFilter = Filters.regex(BsonConstants.BSON_KEY_PV_NAME, pvNamePattern);
         return executeQueryPvMetadata(pvNameFilter);
+    }
+
+    @Override
+    public Collection<String> executeQueryPvExistence(Collection<String> pvNameList) {
+
+        // Cheap existence check: a distinct on the pvName index restricted to the requested names.
+        // Unlike executeQueryPvStats(), this does not sort or group over every bucket for each PV -
+        // it only needs to know which of the requested names appear at all in the archive.
+        final Bson pvNameFilter = in(BsonConstants.BSON_KEY_PV_NAME, pvNameList);
+
+        try {
+            final Set<String> existingPvNames = new HashSet<>();
+            try (final MongoCursor<String> cursor = mongoCollectionBuckets
+                    .distinct(BsonConstants.BSON_KEY_PV_NAME, pvNameFilter, String.class)
+                    .iterator()) {
+                while (cursor.hasNext()) {
+                    existingPvNames.add(cursor.next());
+                }
+            }
+            return existingPvNames;
+
+        } catch (Exception ex) {
+            logger.error("executeQueryPvExistence database error: {}", ex.getMessage());
+            return null;
+        }
     }
 
     @Override

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
@@ -231,6 +231,12 @@ public class MongoSyncQueryClient extends MongoSyncClient implements MongoQueryC
     @Override
     public Collection<String> executeQueryPvExistence(Collection<String> pvNameList) {
 
+        // An empty (or null) list has no existing PVs by definition; short-circuit to avoid a
+        // round-trip to MongoDB and a null $in filter (which would throw).
+        if (pvNameList == null || pvNameList.isEmpty()) {
+            return new HashSet<>();
+        }
+
         // Cheap existence check: a distinct on the pvName index restricted to the requested names.
         // Unlike executeQueryPvStats(), this does not sort or group over every bucket for each PV -
         // it only needs to know which of the requested names appear at all in the archive.
@@ -248,7 +254,8 @@ public class MongoSyncQueryClient extends MongoSyncClient implements MongoQueryC
             return existingPvNames;
 
         } catch (Exception ex) {
-            logger.error("executeQueryPvExistence database error: {}", ex.getMessage());
+            logger.error("executeQueryPvExistence database error for {} pv name(s): {}",
+                    pvNameList.size(), ex.getMessage(), ex);
             return null;
         }
     }

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQueryHandlerTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQueryHandlerTest.java
@@ -8,7 +8,12 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class MongoSyncQueryHandlerTest extends MongoQueryHandlerTestBase {
 
@@ -54,5 +59,24 @@ public class MongoSyncQueryHandlerTest extends MongoQueryHandlerTestBase {
     @Test
     public void testResponseCursorDispatcher() {
         super.testResponseCursorDispatcher();
+    }
+
+    /**
+     * Verifies the null/empty short-circuit in executeQueryPvExistence: both null and empty input
+     * return a non-null empty collection without hitting MongoDB (and without a null $in filter).
+     * The regular callers guard against empty input upstream, so this branch is not exercised by
+     * the integration tests.
+     */
+    @Test
+    public void testExecuteQueryPvExistenceNullAndEmpty() {
+
+        final Collection<String> nullResult = clientTestInterface.executeQueryPvExistence(null);
+        assertNotNull("null pvNameList should return an empty collection, not null", nullResult);
+        assertTrue("null pvNameList should return an empty collection", nullResult.isEmpty());
+
+        final Collection<String> emptyResult =
+                clientTestInterface.executeQueryPvExistence(Collections.emptyList());
+        assertNotNull("empty pvNameList should return an empty collection, not null", emptyResult);
+        assertTrue("empty pvNameList should return an empty collection", emptyResult.isEmpty());
     }
 }


### PR DESCRIPTION
Fixes the PV-name validation performance problem reported in #191.

## Problem

`subscribeData()` PV validation (`IngestionHandler.SourceMonitor.validatePvs`, default `true`) and `saveDataSet` PV validation both called `executeQueryPvStats()` to confirm the requested PVs exist in the archive. That method runs a full stat aggregation over the `buckets` collection — `$match` → `$project` → `$sort (pvName, firstTime...)` → `$group` by pvName with first/last/count accumulators — sorting and grouping *every bucket for each PV* just to answer a yes/no existence question. The cost scales with buckets-per-PV and became slow on a large archive (~371M docs), which is what #191 reports.

Note: this validation is **not** on a startup/port-bind path — it only runs per subscription/save request. See #191 for the full diagnosis.

## Fix

Add `executeQueryPvExistence(Collection<String>)` to the query client: a `distinct` on the indexed `pvName` field filtered by the requested names. It returns near-instantly regardless of archive size because it does no sort or group. Both validation callers now use it:

- `SubscribeDataJob.execute()` (subscription validation)
- `MongoAnnotationHandler.validateSaveDataSetRequest()` (dataset validation)

Reject behavior and messages are unchanged — a subscription/save naming an unknown PV still fails explicitly (the #151 behavior), just without the archive scan.

The public `queryPvStats()` API is intentionally left on the full aggregation since it genuinely needs the per-PV stats. Its performance is a separate concern tracked for a follow-up issue.

## Testing

Verified against MongoDB 8.0. All pass:
- `SubscribeDataIT` (5/5) — incl. valid-PV positive path and the unknown-PV reject path
- `SaveDataSetIT` (1/1) — incl. the "no PV metadata found for names" reject path
- `SubscribeDataEventDataIT` (2/2), `SubscribeDataEventTriggerIT` (4/4) — internal subscribe flow
- `QueryPvStatsIT` (1/1) — confirms the public stats API is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
