### PR TITLE
dp-service #189: Query API V2 (queryBuckets / queryBucketsStream / querySamples / querySamplesStream)

### DIFF
--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/client/MongoSyncAnnotationClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/client/MongoSyncAnnotationClient.java
@@ -26,6 +26,7 @@ import com.ospreydcs.dp.service.common.model.MongoDeleteResult;
 import com.ospreydcs.dp.service.common.model.MongoInsertOneResult;
 import com.ospreydcs.dp.service.common.model.MongoSaveResult;
 import com.ospreydcs.dp.service.common.model.PvMetadataQueryResult;
+import com.ospreydcs.dp.service.common.mongo.MongoQueryFilterBuilder;
 import com.ospreydcs.dp.service.common.mongo.MongoSyncClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -564,58 +565,35 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
                 case PVNAMECRITERION -> {
                     final QueryPvMetadataRequest.QueryPvMetadataCriterion.PvNameCriterion c =
                             criterion.getPvNameCriterion();
-                    final List<Bson> nameFilters = new ArrayList<>();
-                    if (!c.getExactList().isEmpty()) {
-                        nameFilters.add(Filters.in(BsonConstants.BSON_KEY_PV_METADATA_PV_NAME, c.getExactList()));
-                    }
-                    for (String prefix : c.getPrefixList()) {
-                        nameFilters.add(Filters.regex(BsonConstants.BSON_KEY_PV_METADATA_PV_NAME,
-                                "^" + java.util.regex.Pattern.quote(prefix)));
-                    }
-                    for (String contains : c.getContainsList()) {
-                        nameFilters.add(Filters.regex(BsonConstants.BSON_KEY_PV_METADATA_PV_NAME,
-                                ".*" + java.util.regex.Pattern.quote(contains) + ".*"));
-                    }
-                    if (!nameFilters.isEmpty()) {
-                        filterList.add(nameFilters.size() == 1 ? nameFilters.get(0) : or(nameFilters));
+                    final Bson f = MongoQueryFilterBuilder.nameMatchFilter(
+                            BsonConstants.BSON_KEY_PV_METADATA_PV_NAME,
+                            c.getExactList(), c.getPrefixList(), c.getContainsList());
+                    if (f != null) {
+                        filterList.add(f);
                     }
                 }
 
                 case ALIASESCRITERION -> {
                     final QueryPvMetadataRequest.QueryPvMetadataCriterion.AliasesCriterion c =
                             criterion.getAliasesCriterion();
-                    final List<Bson> aliasFilters = new ArrayList<>();
-                    if (!c.getExactList().isEmpty()) {
-                        aliasFilters.add(Filters.in("aliases", c.getExactList()));
-                    }
-                    for (String prefix : c.getPrefixList()) {
-                        aliasFilters.add(Filters.regex("aliases",
-                                "^" + java.util.regex.Pattern.quote(prefix)));
-                    }
-                    for (String contains : c.getContainsList()) {
-                        aliasFilters.add(Filters.regex("aliases",
-                                ".*" + java.util.regex.Pattern.quote(contains) + ".*"));
-                    }
-                    if (!aliasFilters.isEmpty()) {
-                        filterList.add(aliasFilters.size() == 1 ? aliasFilters.get(0) : or(aliasFilters));
+                    final Bson f = MongoQueryFilterBuilder.nameMatchFilter(
+                            BsonConstants.BSON_KEY_PV_METADATA_ALIASES,
+                            c.getExactList(), c.getPrefixList(), c.getContainsList());
+                    if (f != null) {
+                        filterList.add(f);
                     }
                 }
 
                 case TAGSCRITERION -> {
                     final QueryPvMetadataRequest.QueryPvMetadataCriterion.TagsCriterion c =
                             criterion.getTagsCriterion();
-                    filterList.add(Filters.in(BsonConstants.BSON_KEY_TAGS, c.getValuesList()));
+                    filterList.add(MongoQueryFilterBuilder.tagsFilter(c.getValuesList()));
                 }
 
                 case ATTRIBUTESCRITERION -> {
                     final QueryPvMetadataRequest.QueryPvMetadataCriterion.AttributesCriterion c =
                             criterion.getAttributesCriterion();
-                    final String mapKey = BsonConstants.BSON_KEY_ATTRIBUTES + "." + c.getKey();
-                    if (c.getValuesList().isEmpty()) {
-                        filterList.add(Filters.exists(mapKey));
-                    } else {
-                        filterList.add(Filters.in(mapKey, c.getValuesList()));
-                    }
+                    filterList.add(MongoQueryFilterBuilder.attributeFilter(c.getKey(), c.getValuesList()));
                 }
 
                 default -> {
@@ -678,7 +656,7 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
         try {
             final Bson filter = or(
                     eq(BsonConstants.BSON_KEY_PV_METADATA_PV_NAME, pvNameOrAlias),
-                    eq("aliases", pvNameOrAlias));
+                    eq(BsonConstants.BSON_KEY_PV_METADATA_ALIASES, pvNameOrAlias));
             mongoCollectionPvMetadata.find(filter).into(matchingDocuments);
         } catch (Exception ex) {
             final String errorMsg = "findPvMetadataByNameOrAlias: mongo exception: " + ex.getMessage();
@@ -1110,26 +1088,14 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
                 case TIMESTAMPCRITERION -> {
                     final Instant ts = com.ospreydcs.dp.service.common.protobuf.TimestampUtility
                             .instantFromTimestamp(criterion.getTimestampCriterion().getTimestamp());
-                    filterList.add(and(
-                            lte(BsonConstants.BSON_KEY_ACTIVATION_START_TIME, ts),
-                            or(
-                                    exists(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, false),
-                                    gt(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, ts)
-                            )
-                    ));
+                    filterList.add(MongoQueryFilterBuilder.activationContainsInstantFilter(ts));
                 }
                 case TIMERANGECRITERION -> {
                     final Instant rangeStart = com.ospreydcs.dp.service.common.protobuf.TimestampUtility
                             .instantFromTimestamp(criterion.getTimeRangeCriterion().getStartTime());
                     final Instant rangeEnd = com.ospreydcs.dp.service.common.protobuf.TimestampUtility
                             .instantFromTimestamp(criterion.getTimeRangeCriterion().getEndTime());
-                    filterList.add(and(
-                            lt(BsonConstants.BSON_KEY_ACTIVATION_START_TIME, rangeEnd),
-                            or(
-                                    exists(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, false),
-                                    gt(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, rangeStart)
-                            )
-                    ));
+                    filterList.add(MongoQueryFilterBuilder.activationOverlapsRangeFilter(rangeStart, rangeEnd));
                 }
                 case CONFIGURATIONNAMECRITERION -> {
                     filterList.add(in(BsonConstants.BSON_KEY_ACTIVATION_CONFIGURATION_NAME,
@@ -1144,16 +1110,12 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
                             criterion.getCategoryCriterion().getValuesList()));
                 }
                 case TAGSCRITERION -> {
-                    filterList.add(in(BsonConstants.BSON_KEY_TAGS,
+                    filterList.add(MongoQueryFilterBuilder.tagsFilter(
                             criterion.getTagsCriterion().getValuesList()));
                 }
                 case ATTRIBUTESCRITERION -> {
                     final var ac = criterion.getAttributesCriterion();
-                    if (ac.getValuesList().isEmpty()) {
-                        filterList.add(exists("attributes." + ac.getKey()));
-                    } else {
-                        filterList.add(in("attributes." + ac.getKey(), ac.getValuesList()));
-                    }
+                    filterList.add(MongoQueryFilterBuilder.attributeFilter(ac.getKey(), ac.getValuesList()));
                 }
                 default -> {
                     // unknown criterion — ignored

--- a/src/main/java/com/ospreydcs/dp/service/common/bson/BsonConstants.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/bson/BsonConstants.java
@@ -56,6 +56,7 @@ public class BsonConstants {
     public static final String BSON_KEY_CALCULATIONS_ID = "_id";
 
     public static final String BSON_KEY_PV_METADATA_PV_NAME = "pvName";
+    public static final String BSON_KEY_PV_METADATA_ALIASES = "aliases";
     public static final String BSON_KEY_PV_METADATA_LAST_BUCKET_ID = "lastBucketId";
     public static final String BSON_KEY_PV_METADATA_LAST_BUCKET_DATA_TYPE_CASE = "lastBucketDataTypeCase";
     public static final String BSON_KEY_PV_METADATA_LAST_BUCKET_DATA_TYPE = "lastBucketDataType";

--- a/src/main/java/com/ospreydcs/dp/service/common/bson/bucket/BucketDocument.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/bson/bucket/BucketDocument.java
@@ -255,4 +255,81 @@ public class BucketDocument extends DpBsonDocumentBase {
         return bucketBuilder.build();
     }
 
+    /**
+     * Builds a Query API V2 {@link DataBucket} from a stored bucket document, honoring the V2
+     * representation flags.
+     *
+     * <p><b>excludeColumnMetadata</b> (Q8): the default (false) includes column metadata, which
+     * {@code addColumnToBucket}/{@code applyMetadataToProto} already restores; when true, the
+     * {@code metadata} field is cleared on the emitted column.
+     *
+     * <p><b>useSerializedColumns</b> (Q5, pass-through-only per plan 11.2.4(ii)): columns that were
+     * stored serialized are emitted as {@code SerializedDataColumn} (already the behavior of
+     * {@code addColumnToBucket} for {@code SerializedDataColumnDocument}); typed/scalar-stored columns
+     * are emitted in their typed form regardless of this flag — no typed-to-serialized conversion and
+     * no fabricated {@code encoding} contract in this phase. The flag is accepted for API symmetry and
+     * has no effect on typed columns.
+     */
+    public static DataBucket dataBucketFromDocumentV2(
+            BucketDocument document,
+            boolean useSerializedColumns,
+            boolean excludeColumnMetadata
+    ) throws DpException {
+
+        final DataBucket.Builder bucketBuilder = DataBucket.newBuilder();
+
+        bucketBuilder.setPvName(document.getPvName());
+        bucketBuilder.setDataTimestamps(document.getDataTimestamps().toDataTimestamps());
+
+        // add data values (polymorphic: serialized-stored columns pass through as SerializedDataColumn,
+        // typed/legacy columns emit their typed form) — useSerializedColumns is pass-through-only here.
+        document.getDataColumn().addColumnToBucket(bucketBuilder);
+
+        if (excludeColumnMetadata && bucketBuilder.hasDataValues()) {
+            bucketBuilder.setDataValues(clearColumnMetadata(bucketBuilder.getDataValues()));
+        }
+
+        if (document.getProviderId() != null) {
+            bucketBuilder.setProviderId(document.getProviderId());
+        }
+        if (document.getProviderName() != null) {
+            bucketBuilder.setProviderName(document.getProviderName());
+        }
+
+        return bucketBuilder.build();
+    }
+
+    /**
+     * Returns a copy of the given {@link DataValues} with the {@code metadata} field cleared on
+     * whichever column type is set in the oneof. Uses reflection to invoke {@code clearMetadata()} on
+     * the set column's builder, mirroring the reflective approach used to set metadata on ingest, so
+     * all column types are handled uniformly without an 18-arm switch.
+     */
+    private static DataValues clearColumnMetadata(DataValues dataValues) {
+        final DataValues.ValuesCase valuesCase = dataValues.getValuesCase();
+        if (valuesCase == DataValues.ValuesCase.VALUES_NOT_SET) {
+            return dataValues;
+        }
+        try {
+            final DataValues.Builder dataValuesBuilder = dataValues.toBuilder();
+            // find the getter for the set column, clear metadata on it, set it back
+            final com.google.protobuf.Descriptors.FieldDescriptor fieldDescriptor =
+                    dataValues.getDescriptorForType().findFieldByNumber(valuesCase.getNumber());
+            final com.google.protobuf.Message columnMessage =
+                    (com.google.protobuf.Message) dataValues.getField(fieldDescriptor);
+            final com.google.protobuf.Message.Builder columnBuilder = columnMessage.toBuilder();
+            final com.google.protobuf.Descriptors.FieldDescriptor metadataField =
+                    columnBuilder.getDescriptorForType().findFieldByName("metadata");
+            if (metadataField != null && columnBuilder.hasField(metadataField)) {
+                columnBuilder.clearField(metadataField);
+                dataValuesBuilder.setField(fieldDescriptor, columnBuilder.build());
+                return dataValuesBuilder.build();
+            }
+            return dataValues;
+        } catch (Exception ex) {
+            // metadata suppression is best-effort formatting, not correctness — never fail the query.
+            return dataValues;
+        }
+    }
+
 }

--- a/src/main/java/com/ospreydcs/dp/service/common/exception/NonScalarColumnException.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/exception/NonScalarColumnException.java
@@ -1,0 +1,30 @@
+package com.ospreydcs.dp.service.common.exception;
+
+/**
+ * Thrown when a non-scalar column (array, image, struct, serialized) is encountered where only
+ * scalar columns can be represented in a tabular (row/column) form. Carries the offending PV name
+ * and stored column type so each caller can phrase context-appropriate guidance: the export
+ * framework points at specialized export formats; the Query API V2 {@code querySamples} path points
+ * the caller at {@code queryBuckets} (Q4). The message itself is neutral (no caller-specific wording)
+ * so it reads correctly wherever it surfaces un-translated.
+ */
+public class NonScalarColumnException extends DpException {
+
+    private final String pvName;
+    private final String columnType;
+
+    public NonScalarColumnException(String pvName, String columnType) {
+        super("PV '" + pvName + "' has non-scalar column type " + columnType
+                + ", which has no tabular (row/column) representation");
+        this.pvName = pvName;
+        this.columnType = columnType;
+    }
+
+    public String getPvName() {
+        return pvName;
+    }
+
+    public String getColumnType() {
+        return columnType;
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoQueryFilterBuilder.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoQueryFilterBuilder.java
@@ -91,7 +91,9 @@ public class MongoQueryFilterBuilder {
      * half-open range {@code [rangeStart, rangeEnd)}:
      * {@code startTime < rangeEnd AND (endTime absent OR endTime > rangeStart)}.
      *
-     * <p>Also the natural building block for a Query API V2 configuration-fragment overlap predicate.
+     * <p>Operates on the {@code configurationActivations} time fields. This is NOT the bucket overlap
+     * predicate — see {@link #bucketOverlapsRangeFilter} for that (different fields, different
+     * collection, {@code lastTime >=} inclusive semantics).
      */
     public static Bson activationOverlapsRangeFilter(Instant rangeStart, Instant rangeEnd) {
         return Filters.and(
@@ -99,5 +101,37 @@ public class MongoQueryFilterBuilder {
                 Filters.or(
                         Filters.exists(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, false),
                         Filters.gt(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, rangeStart)));
+    }
+
+    /**
+     * Builds the bucket overlap predicate selecting buckets whose {@code [firstTime, lastTime]} data
+     * span intersects the half-open query range {@code [begin, end)}:
+     * {@code firstTime < end AND lastTime >= begin} (with {@code (seconds, nanos)} lexicographic
+     * comparison). This is the single source for the overlap condition shared by the V1 data/table
+     * retrieval path ({@code executeBucketDocumentQuery}) and the Query API V2 {@code $or}
+     * configuration-fragment retrieval, so the two cannot drift.
+     *
+     * <p>Distinct from {@link #activationOverlapsRangeFilter}: this operates on the buckets
+     * collection's {@code dataTimestamps.firstTime}/{@code lastTime} fields, and the lower bound is
+     * inclusive ({@code lastTime >= begin}) matching the long-standing V1 semantics.
+     */
+    public static Bson bucketOverlapsRangeFilter(
+            long beginSeconds, long beginNanos, long endSeconds, long endNanos) {
+
+        // firstTime < end : firstSecs < endSecs OR (firstSecs == endSecs AND firstNanos < endNanos)
+        final Bson endTimeFilter = Filters.or(
+                Filters.lt(BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_SECS, endSeconds),
+                Filters.and(
+                        Filters.eq(BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_SECS, endSeconds),
+                        Filters.lt(BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_NANOS, endNanos)));
+
+        // lastTime >= begin : lastSecs > beginSecs OR (lastSecs == beginSecs AND lastNanos >= beginNanos)
+        final Bson startTimeFilter = Filters.or(
+                Filters.gt(BsonConstants.BSON_KEY_BUCKET_LAST_TIME_SECS, beginSeconds),
+                Filters.and(
+                        Filters.eq(BsonConstants.BSON_KEY_BUCKET_LAST_TIME_SECS, beginSeconds),
+                        Filters.gte(BsonConstants.BSON_KEY_BUCKET_LAST_TIME_NANOS, beginNanos)));
+
+        return Filters.and(endTimeFilter, startTimeFilter);
     }
 }

--- a/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoQueryFilterBuilder.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoQueryFilterBuilder.java
@@ -1,0 +1,103 @@
+package com.ospreydcs.dp.service.common.mongo;
+
+import com.mongodb.client.model.Filters;
+import com.ospreydcs.dp.service.common.bson.BsonConstants;
+import org.bson.conversions.Bson;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Shared, proto-neutral builders for the MongoDB filter fragments used by both the annotation
+ * metadata/activation queries (V1) and the Query API V2 planner. Each method takes neutral inputs
+ * (name lists, tag lists, attribute key/values, {@link Instant}s) and returns a {@link Bson}, so a
+ * single implementation of each mapping serves every caller and the two APIs cannot drift.
+ *
+ * <p>The methods are behavior-preserving relative to the previously inline logic in
+ * {@code MongoSyncAnnotationClient}: they emit byte-identical {@code Bson} for the same inputs.
+ */
+public class MongoQueryFilterBuilder {
+
+    /**
+     * Builds a name/alias match filter combining exact, prefix, and contains matches with OR.
+     *
+     * <p>Exact matches become a single {@code in(field, exact)}. Each prefix becomes
+     * {@code regex(field, "^" + Pattern.quote(prefix))} and each contains becomes
+     * {@code regex(field, ".*" + Pattern.quote(contains) + ".*")} — the substrings are treated as
+     * literals (regex-special characters are escaped by {@link Pattern#quote}).
+     *
+     * @return the combined filter, or {@code null} if all three lists are empty (the caller decides
+     *     whether to add it to a filter list, preserving the "only add if non-empty" behavior).
+     */
+    public static Bson nameMatchFilter(
+            String field, List<String> exact, List<String> prefix, List<String> contains) {
+
+        final List<Bson> nameFilters = new ArrayList<>();
+        if (exact != null && !exact.isEmpty()) {
+            nameFilters.add(Filters.in(field, exact));
+        }
+        if (prefix != null) {
+            for (String p : prefix) {
+                nameFilters.add(Filters.regex(field, "^" + Pattern.quote(p)));
+            }
+        }
+        if (contains != null) {
+            for (String c : contains) {
+                nameFilters.add(Filters.regex(field, ".*" + Pattern.quote(c) + ".*"));
+            }
+        }
+        if (nameFilters.isEmpty()) {
+            return null;
+        }
+        return nameFilters.size() == 1 ? nameFilters.get(0) : Filters.or(nameFilters);
+    }
+
+    /**
+     * Builds a tags membership filter: {@code in(BSON_KEY_TAGS, values)}.
+     */
+    public static Bson tagsFilter(List<String> values) {
+        return Filters.in(BsonConstants.BSON_KEY_TAGS, values);
+    }
+
+    /**
+     * Builds an attribute filter for the {@code attributes.<key>} map field. With no values, matches
+     * documents that have the key at all ({@code exists}); otherwise matches any of the given values
+     * ({@code in}).
+     */
+    public static Bson attributeFilter(String key, List<String> values) {
+        final String mapKey = BsonConstants.BSON_KEY_ATTRIBUTES + "." + key;
+        if (values == null || values.isEmpty()) {
+            return Filters.exists(mapKey);
+        }
+        return Filters.in(mapKey, values);
+    }
+
+    /**
+     * Builds the filter for activations whose {@code [startTime, endTime)} interval contains the
+     * given instant: {@code startTime <= ts AND (endTime absent OR endTime > ts)}.
+     */
+    public static Bson activationContainsInstantFilter(Instant ts) {
+        return Filters.and(
+                Filters.lte(BsonConstants.BSON_KEY_ACTIVATION_START_TIME, ts),
+                Filters.or(
+                        Filters.exists(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, false),
+                        Filters.gt(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, ts)));
+    }
+
+    /**
+     * Builds the filter for activations whose {@code [startTime, endTime)} interval overlaps the
+     * half-open range {@code [rangeStart, rangeEnd)}:
+     * {@code startTime < rangeEnd AND (endTime absent OR endTime > rangeStart)}.
+     *
+     * <p>Also the natural building block for a Query API V2 configuration-fragment overlap predicate.
+     */
+    public static Bson activationOverlapsRangeFilter(Instant rangeStart, Instant rangeEnd) {
+        return Filters.and(
+                Filters.lt(BsonConstants.BSON_KEY_ACTIVATION_START_TIME, rangeEnd),
+                Filters.or(
+                        Filters.exists(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, false),
+                        Filters.gt(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, rangeStart)));
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/common/utility/TabularDataUtility.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/utility/TabularDataUtility.java
@@ -9,6 +9,7 @@ import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
 import com.ospreydcs.dp.service.common.bson.calculations.CalculationsDataFrameDocument;
 import com.ospreydcs.dp.service.common.bson.calculations.CalculationsDocument;
 import com.ospreydcs.dp.service.common.exception.DpException;
+import com.ospreydcs.dp.service.common.exception.NonScalarColumnException;
 import com.ospreydcs.dp.service.common.protobuf.DataTimestampsUtility;
 import com.ospreydcs.dp.service.common.model.TimestampDataMap;
 
@@ -70,9 +71,10 @@ public class TabularDataUtility {
             // Legacy DataColumn documents can be converted directly
             bucketColumn = ((DataColumnDocument) columnDocument).toDataColumn();
         } else {
-            // Binary columns (arrays, images, structs) cannot be converted to tabular format
-            throw new DpException("Column type " + columnDocument.getClass().getSimpleName() + 
-                                " cannot be exported to tabular format (CSV/Excel/etc). Binary column types require specialized export formats.");
+            // Non-scalar columns (arrays, images, structs) have no tabular (row/column) representation.
+            // Throw a neutral, PV-named exception; each caller phrases its own guidance (the export
+            // framework and querySamples both catch this and translate for their context, Q4).
+            throw new NonScalarColumnException(bucket.getPvName(), columnDocument.getClass().getSimpleName());
         }
 
         return addColumnsToTable(

--- a/src/main/java/com/ospreydcs/dp/service/common/utility/TabularDataUtility.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/utility/TabularDataUtility.java
@@ -39,6 +39,17 @@ public class TabularDataUtility {
             int bucketDataSize = addBucketToTable(
                     bucket, tableValueMap, beginSeconds, beginNanos, endSeconds, endNanos);
             currentDataSize = currentDataSize + bucketDataSize;
+            // Size accounting is per-BUCKET, not per-timestamp: a whole bucket is added to the table
+            // before the limit is checked, so currentDataSize can overshoot sizeLimit by up to one
+            // bucket's worth of data. This is intentional and benign for the callers that pass a
+            // sizeLimit as a HARD ceiling (queryTable and the export job both discard the result and
+            // return an error when sizeLimitExceeded() is true — overshooting by one bucket vs. one
+            // byte yields the same error outcome). The V2 querySamples unary dispatcher instead uses
+            // the flag as a PAGING boundary (drain-then-truncate) and owns the zero-progress guard for
+            // the case where the overshoot collapses to a single indivisible timestamp. Do NOT tighten
+            // this to per-timestamp granularity without revisiting those callers — for the hard-ceiling
+            // callers it would change nothing observable, and V2's boundary handling already accounts
+            // for the overshoot.
             if (sizeLimit != null && currentDataSize > sizeLimit) {
                 cursor.close();
                 return new TimestampDataMapSizeStats(currentDataSize, true);

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/QueryV2Resolver.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/QueryV2Resolver.java
@@ -147,10 +147,11 @@ public class QueryV2Resolver {
         }
 
         // ---- Q3: resolve ConfigurationSelector to effective retrieval intervals ----
-        final List<TimeInterval> intervals = resolveIntervals(querySpec, queryRange);
-        if (intervals == null) {
-            return ResolutionResult.reject("configuration selector resolution failed (database error)");
+        final ResolvedIntervals resolvedIntervals = resolveIntervals(querySpec, queryRange);
+        if (resolvedIntervals.error != null) {
+            return ResolutionResult.reject(resolvedIntervals.error);
         }
+        final List<TimeInterval> intervals = resolvedIntervals.intervals;
 
         final boolean useSerialized = resultRepresentation.getUseSerializedColumns();
         final boolean excludeMetadata = resultRepresentation.getExcludeColumnMetadata();
@@ -294,45 +295,69 @@ public class QueryV2Resolver {
 
     /**
      * @return the effective retrieval intervals, or null on database error. An empty list means the
-     *     selector matched nothing inside the query range (caller yields an empty result).
+     *     selector matched nothing inside the query range (caller yields an empty result). A
+     *     malformed selector (empty criteria list, or a criterion with no arm set) is a client error
+     *     and rejects — distinct from a well-formed selector that simply matches no activations, so a
+     *     mis-built request is not silently indistinguishable from "no data" (mirrors the PvSelector
+     *     metadata path and V1 {@code queryProviders}, both of which reject malformed criteria).
      */
-    private List<TimeInterval> resolveIntervals(QuerySpec querySpec, TimeInterval queryRange) {
+    private ResolvedIntervals resolveIntervals(QuerySpec querySpec, TimeInterval queryRange) {
 
         if (!querySpec.hasConfigurationSelector()) {
             // no selector → the whole query range is the single retrieval interval
             final List<TimeInterval> single = new ArrayList<>();
             single.add(queryRange);
-            return single;
+            return ResolvedIntervals.ok(single);
         }
 
         final ConfigurationSelector selector = querySpec.getConfigurationSelector();
         if (selector.getCriteriaList().isEmpty()) {
-            // selector present but no criteria → matches nothing → empty result
-            return new ArrayList<>();
+            // selector present but no criteria → malformed request (cf. queryProviders "criteria list
+            // must not be empty"), not a "match nothing" intent → reject
+            return ResolvedIntervals.reject("configurationSelector.criteria list must not be empty");
         }
 
         final List<Bson> criteriaFilters = new ArrayList<>();
         for (ConfigurationSelector.Criterion criterion : selector.getCriteriaList()) {
             final Bson f = configCriterionToFilter(criterion);
             if (f == null) {
-                // exactly-one-criterion violation surfaces as an empty (no-match) selector rather than
-                // a hard reject here; the request-level validator can reject earlier if desired.
-                logger.warn("configuration selector criterion has no arm set; ignoring");
-                continue;
+                // exactly-one-criterion violation → reject (a client build error, not "no match")
+                return ResolvedIntervals.reject("configurationSelector criterion must set exactly one arm");
             }
             criteriaFilters.add(f);
-        }
-        if (criteriaFilters.isEmpty()) {
-            return new ArrayList<>();
         }
 
         final List<TimeInterval> activationIntervals = mongoClient.resolveConfigurationIntervals(criteriaFilters);
         if (activationIntervals == null) {
-            return null; // database error
+            return ResolvedIntervals.reject("configuration selector resolution failed (database error)");
         }
 
         // union the activation intervals, then intersect with the query range → fragmented result
-        return TimeInterval.intersectAll(activationIntervals, queryRange);
+        // (an empty result here is a valid "selector matched no activations in range" outcome)
+        return ResolvedIntervals.ok(TimeInterval.intersectAll(activationIntervals, queryRange));
+    }
+
+    /**
+     * Result of resolving the {@link ConfigurationSelector}: either the effective retrieval intervals
+     * (possibly empty = well-formed selector matched nothing in range) or a reject message (malformed
+     * selector or database error). Exactly one of the two is non-null.
+     */
+    private static final class ResolvedIntervals {
+        final List<TimeInterval> intervals;
+        final String error;
+
+        private ResolvedIntervals(List<TimeInterval> intervals, String error) {
+            this.intervals = intervals;
+            this.error = error;
+        }
+
+        static ResolvedIntervals ok(List<TimeInterval> intervals) {
+            return new ResolvedIntervals(intervals, null);
+        }
+
+        static ResolvedIntervals reject(String error) {
+            return new ResolvedIntervals(null, error);
+        }
     }
 
     private static Bson configCriterionToFilter(ConfigurationSelector.Criterion criterion) {

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/QueryV2Resolver.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/QueryV2Resolver.java
@@ -1,0 +1,367 @@
+package com.ospreydcs.dp.service.query.handler;
+
+import com.ospreydcs.dp.grpc.v1.common.TimeRange;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.grpc.v1.query.ConfigurationSelector;
+import com.ospreydcs.dp.grpc.v1.query.ExecutionOptions;
+import com.ospreydcs.dp.grpc.v1.query.PvSelector;
+import com.ospreydcs.dp.grpc.v1.query.QuerySpec;
+import com.ospreydcs.dp.grpc.v1.query.ResultRepresentation;
+import com.ospreydcs.dp.service.common.bson.BsonConstants;
+import com.ospreydcs.dp.service.common.mongo.MongoQueryFilterBuilder;
+import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
+import com.ospreydcs.dp.service.query.handler.model.ResolutionResult;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
+import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
+import com.ospreydcs.dp.service.query.handler.paging.PageToken;
+import com.ospreydcs.dp.service.query.handler.paging.PageTokenException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bson.conversions.Bson;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Query API V2 request resolver — turns a validated {@code QuerySpec + ExecutionOptions +
+ * ResultRepresentation} into an internal {@link ResolvedQuery} (the "planner + ExecutionPlan").
+ * Validates the §6 invariants proto3 cannot enforce, resolves the {@link PvSelector} to a concrete
+ * PV name list (Q9), resolves the {@link ConfigurationSelector} to effective retrieval intervals
+ * (Q3), normalizes paging (Q7), and decodes the continuation token (Q1/Q2).
+ *
+ * <p>Resolution steps that touch MongoDB go through {@link MongoQueryClientInterface}; the criterion
+ * → {@code Bson} mapping reuses the shared {@link MongoQueryFilterBuilder} helpers (Q6), so V1 and
+ * V2 build identical filters.
+ */
+public class QueryV2Resolver {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final MongoQueryClientInterface mongoClient;
+    private final int defaultPageSize;
+    private final int maxPageSize;
+    private final int maxResolvedPvCount;
+
+    public QueryV2Resolver(
+            MongoQueryClientInterface mongoClient,
+            int defaultPageSize,
+            int maxPageSize,
+            int maxResolvedPvCount) {
+        this.mongoClient = mongoClient;
+        this.defaultPageSize = defaultPageSize;
+        this.maxPageSize = maxPageSize;
+        this.maxResolvedPvCount = maxResolvedPvCount;
+    }
+
+    /**
+     * Validates and resolves a V2 request.
+     *
+     * @param querySpec the request's QuerySpec (required)
+     * @param executionOptions paging options (may be default/empty)
+     * @param resultRepresentation representation flags (may be default/empty)
+     * @param mode BUCKET or SAMPLE result mode (set by the calling handler)
+     * @param streaming true for the *Stream variants (set by the calling handler)
+     * @return a ResolutionResult carrying either the ResolvedQuery or a reject/error status
+     */
+    public ResolutionResult resolve(
+            QuerySpec querySpec,
+            ExecutionOptions executionOptions,
+            ResultRepresentation resultRepresentation,
+            ResolvedQuery.ResultMode mode,
+            boolean streaming) {
+
+        // ---- §6: TimeRange presence + ordering ----
+        if (!querySpec.hasTimeRange()) {
+            return ResolutionResult.reject("querySpec.timeRange must be specified");
+        }
+        final TimeRange timeRange = querySpec.getTimeRange();
+        if (!timeRange.hasBeginTime()) {
+            return ResolutionResult.reject("querySpec.timeRange.beginTime must be specified");
+        }
+        if (!timeRange.hasEndTime()) {
+            return ResolutionResult.reject("querySpec.timeRange.endTime must be specified");
+        }
+        final Timestamp begin = timeRange.getBeginTime();
+        final Timestamp end = timeRange.getEndTime();
+        if (TimeInterval.compareInstant(
+                end.getEpochSeconds(), end.getNanoseconds(),
+                begin.getEpochSeconds(), begin.getNanoseconds()) <= 0) {
+            return ResolutionResult.reject("querySpec.timeRange endTime must be > beginTime");
+        }
+        final TimeInterval queryRange = new TimeInterval(
+                begin.getEpochSeconds(), begin.getNanoseconds(),
+                end.getEpochSeconds(), end.getNanoseconds());
+
+        // ---- §6: PvSelector presence + exactly-one arm ----
+        if (!querySpec.hasPvSelector()) {
+            return ResolutionResult.reject("querySpec.pvSelector must be specified");
+        }
+        final PvSelector pvSelector = querySpec.getPvSelector();
+        if (pvSelector.getSelectorCase() == PvSelector.SelectorCase.SELECTOR_NOT_SET) {
+            return ResolutionResult.reject("querySpec.pvSelector must set one of pvNameList, pvNamePattern, metadataQuery");
+        }
+
+        // ---- §6/§Q7: paging normalization + streaming token rule ----
+        final String pageToken = executionOptions.getPageToken();
+        final boolean hasToken = pageToken != null && !pageToken.isBlank();
+        if (streaming && hasToken) {
+            return ResolutionResult.reject("pageToken must not be set on a streaming query");
+        }
+
+        KeysetPosition pageStart = null;
+        if (hasToken) {
+            try {
+                pageStart = PageToken.decode(pageToken);
+            } catch (PageTokenException ex) {
+                return ResolutionResult.reject("invalid pageToken: " + ex.getMessage());
+            }
+            // guard against a token from the wrong result mode (bucket token on a sample query, etc.)
+            final KeysetPosition.Kind expected = (mode == ResolvedQuery.ResultMode.BUCKET)
+                    ? KeysetPosition.Kind.BUCKET : KeysetPosition.Kind.SAMPLE;
+            if (pageStart.getKind() != expected) {
+                return ResolutionResult.reject("pageToken is not valid for this query type");
+            }
+        }
+
+        int pageSize = executionOptions.getLimit();
+        if (pageSize <= 0) {
+            pageSize = defaultPageSize;
+        } else if (pageSize > maxPageSize) {
+            pageSize = maxPageSize; // Q7: silent clamp
+        }
+
+        // ---- Q9: resolve PvSelector to a concrete, sorted PV name list ----
+        final ResolvedNames resolvedNames = resolvePvNames(pvSelector);
+        if (resolvedNames.error != null) {
+            return ResolutionResult.reject(resolvedNames.error);
+        }
+        // sort + dedup (Q9 column order derives from this)
+        final List<String> pvNames = new ArrayList<>(new TreeSet<>(resolvedNames.names));
+        if (pvNames.size() > maxResolvedPvCount) {
+            return ResolutionResult.reject(
+                    "selector resolved to " + pvNames.size() + " PVs, exceeding the maximum of "
+                            + maxResolvedPvCount + "; narrow the selector");
+        }
+
+        // ---- Q3: resolve ConfigurationSelector to effective retrieval intervals ----
+        final List<TimeInterval> intervals = resolveIntervals(querySpec, queryRange);
+        if (intervals == null) {
+            return ResolutionResult.reject("configuration selector resolution failed (database error)");
+        }
+
+        final boolean useSerialized = resultRepresentation.getUseSerializedColumns();
+        final boolean excludeMetadata = resultRepresentation.getExcludeColumnMetadata();
+
+        final ResolvedQuery resolved = new ResolvedQuery(
+                pvNames, intervals, pageSize, pageStart, useSerialized, excludeMetadata, mode, streaming);
+        return ResolutionResult.of(resolved);
+    }
+
+    // -----------------------------------------------------------------------
+    // PvSelector resolution
+    // -----------------------------------------------------------------------
+
+    private static final class ResolvedNames {
+        final List<String> names;
+        final String error;
+
+        private ResolvedNames(List<String> names, String error) {
+            this.names = names;
+            this.error = error;
+        }
+
+        static ResolvedNames ok(List<String> names) {
+            return new ResolvedNames(names, null);
+        }
+
+        static ResolvedNames err(String error) {
+            return new ResolvedNames(null, error);
+        }
+    }
+
+    private ResolvedNames resolvePvNames(PvSelector pvSelector) {
+        switch (pvSelector.getSelectorCase()) {
+
+            case PVNAMELIST -> {
+                final List<String> names = new ArrayList<>(pvSelector.getPvNameList().getPvNamesList());
+                if (names.isEmpty()) {
+                    return ResolvedNames.err("pvSelector.pvNameList is empty");
+                }
+                return ResolvedNames.ok(names);
+            }
+
+            case PVNAMEPATTERN -> {
+                final String pattern = pvSelector.getPvNamePattern().getPattern();
+                if (pattern == null || pattern.isBlank()) {
+                    return ResolvedNames.err("pvSelector.pvNamePattern.pattern is empty");
+                }
+                final List<String> names;
+                try {
+                    names = mongoClient.resolvePvNamesByPattern(pattern);
+                } catch (PatternSyntaxException ex) {
+                    return ResolvedNames.err("pvSelector.pvNamePattern is not a valid regex: " + ex.getMessage());
+                }
+                if (names == null) {
+                    return ResolvedNames.err("pv name pattern resolution failed (database error)");
+                }
+                return ResolvedNames.ok(names);
+            }
+
+            case METADATAQUERY -> {
+                final PvSelector.MetadataQuery metadataQuery = pvSelector.getMetadataQuery();
+                final List<Bson> criteriaFilters = new ArrayList<>();
+                for (PvSelector.MetadataQuery.Criterion criterion : metadataQuery.getCriteriaList()) {
+                    final CriterionFilter cf = metadataCriterionToFilter(criterion);
+                    if (cf.invalid) {
+                        return ResolvedNames.err("metadataQuery criterion must set exactly one arm");
+                    }
+                    if (cf.filter != null) {
+                        criteriaFilters.add(cf.filter);
+                    }
+                }
+                final List<String> names = mongoClient.resolvePvNamesByMetadata(criteriaFilters);
+                if (names == null) {
+                    return ResolvedNames.err("metadata query resolution failed (database error)");
+                }
+                return ResolvedNames.ok(names);
+            }
+
+            default -> {
+                return ResolvedNames.err("pvSelector has no selector set");
+            }
+        }
+    }
+
+    /**
+     * Result of mapping one metadata criterion: a filter (possibly null when the criterion's value
+     * lists are all empty, which is a valid no-op arm), or {@code invalid} when no arm is set
+     * (exactly-one-criterion violation, §6).
+     */
+    private static final class CriterionFilter {
+        final Bson filter;
+        final boolean invalid;
+
+        private CriterionFilter(Bson filter, boolean invalid) {
+            this.filter = filter;
+            this.invalid = invalid;
+        }
+
+        static CriterionFilter of(Bson filter) {
+            return new CriterionFilter(filter, false);
+        }
+
+        static CriterionFilter invalid() {
+            return new CriterionFilter(null, true);
+        }
+    }
+
+    private static CriterionFilter metadataCriterionToFilter(PvSelector.MetadataQuery.Criterion criterion) {
+        switch (criterion.getCriterionCase()) {
+            case PVNAMECRITERION -> {
+                final var c = criterion.getPvNameCriterion();
+                return CriterionFilter.of(MongoQueryFilterBuilder.nameMatchFilter(
+                        BsonConstants.BSON_KEY_PV_METADATA_PV_NAME,
+                        c.getExactList(), c.getPrefixList(), c.getContainsList()));
+            }
+            case ALIASESCRITERION -> {
+                final var c = criterion.getAliasesCriterion();
+                return CriterionFilter.of(MongoQueryFilterBuilder.nameMatchFilter(
+                        BsonConstants.BSON_KEY_PV_METADATA_ALIASES,
+                        c.getExactList(), c.getPrefixList(), c.getContainsList()));
+            }
+            case TAGSCRITERION -> {
+                return CriterionFilter.of(
+                        MongoQueryFilterBuilder.tagsFilter(criterion.getTagsCriterion().getValuesList()));
+            }
+            case ATTRIBUTESCRITERION -> {
+                final var c = criterion.getAttributesCriterion();
+                return CriterionFilter.of(
+                        MongoQueryFilterBuilder.attributeFilter(c.getKey(), c.getValuesList()));
+            }
+            default -> {
+                // CRITERION_NOT_SET or unknown → exactly-one-criterion violation
+                return CriterionFilter.invalid();
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // ConfigurationSelector resolution (Q3)
+    // -----------------------------------------------------------------------
+
+    /**
+     * @return the effective retrieval intervals, or null on database error. An empty list means the
+     *     selector matched nothing inside the query range (caller yields an empty result).
+     */
+    private List<TimeInterval> resolveIntervals(QuerySpec querySpec, TimeInterval queryRange) {
+
+        if (!querySpec.hasConfigurationSelector()) {
+            // no selector → the whole query range is the single retrieval interval
+            final List<TimeInterval> single = new ArrayList<>();
+            single.add(queryRange);
+            return single;
+        }
+
+        final ConfigurationSelector selector = querySpec.getConfigurationSelector();
+        if (selector.getCriteriaList().isEmpty()) {
+            // selector present but no criteria → matches nothing → empty result
+            return new ArrayList<>();
+        }
+
+        final List<Bson> criteriaFilters = new ArrayList<>();
+        for (ConfigurationSelector.Criterion criterion : selector.getCriteriaList()) {
+            final Bson f = configCriterionToFilter(criterion);
+            if (f == null) {
+                // exactly-one-criterion violation surfaces as an empty (no-match) selector rather than
+                // a hard reject here; the request-level validator can reject earlier if desired.
+                logger.warn("configuration selector criterion has no arm set; ignoring");
+                continue;
+            }
+            criteriaFilters.add(f);
+        }
+        if (criteriaFilters.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        final List<TimeInterval> activationIntervals = mongoClient.resolveConfigurationIntervals(criteriaFilters);
+        if (activationIntervals == null) {
+            return null; // database error
+        }
+
+        // union the activation intervals, then intersect with the query range → fragmented result
+        return TimeInterval.intersectAll(activationIntervals, queryRange);
+    }
+
+    private static Bson configCriterionToFilter(ConfigurationSelector.Criterion criterion) {
+        switch (criterion.getCriterionCase()) {
+            case CONFIGURATIONNAMECRITERION -> {
+                return com.mongodb.client.model.Filters.in(
+                        BsonConstants.BSON_KEY_ACTIVATION_CONFIGURATION_NAME,
+                        criterion.getConfigurationNameCriterion().getValuesList());
+            }
+            case CLIENTACTIVATIONIDCRITERION -> {
+                return com.mongodb.client.model.Filters.in(
+                        BsonConstants.BSON_KEY_ACTIVATION_CLIENT_ID,
+                        criterion.getClientActivationIdCriterion().getValuesList());
+            }
+            case CATEGORYCRITERION -> {
+                return com.mongodb.client.model.Filters.in(
+                        BsonConstants.BSON_KEY_ACTIVATION_INTERNAL_CATEGORY,
+                        criterion.getCategoryCriterion().getValuesList());
+            }
+            case TAGSCRITERION -> {
+                return MongoQueryFilterBuilder.tagsFilter(criterion.getTagsCriterion().getValuesList());
+            }
+            case ATTRIBUTESCRITERION -> {
+                final var c = criterion.getAttributesCriterion();
+                return MongoQueryFilterBuilder.attributeFilter(c.getKey(), c.getValuesList());
+            }
+            default -> {
+                return null;
+            }
+        }
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/interfaces/QueryHandlerInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/interfaces/QueryHandlerInterface.java
@@ -39,4 +39,7 @@ public interface QueryHandlerInterface {
     void handleQueryBuckets(
             QueryBucketsRequest request, StreamObserver<QueryBucketsResponse> responseObserver);
 
+    void handleQueryBucketsStream(
+            QueryBucketsRequest request, StreamObserver<QueryBucketsResponse> responseObserver);
+
 }

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/interfaces/QueryHandlerInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/interfaces/QueryHandlerInterface.java
@@ -42,4 +42,7 @@ public interface QueryHandlerInterface {
     void handleQueryBucketsStream(
             QueryBucketsRequest request, StreamObserver<QueryBucketsResponse> responseObserver);
 
+    void handleQuerySamples(
+            QuerySamplesRequest request, StreamObserver<QuerySamplesResponse> responseObserver);
+
 }

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/interfaces/QueryHandlerInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/interfaces/QueryHandlerInterface.java
@@ -36,4 +36,7 @@ public interface QueryHandlerInterface {
     void handleQueryProviderStats(
             QueryProviderStatsRequest request, StreamObserver<QueryProviderStatsResponse> responseObserver);
 
+    void handleQueryBuckets(
+            QueryBucketsRequest request, StreamObserver<QueryBucketsResponse> responseObserver);
+
 }

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/interfaces/QueryHandlerInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/interfaces/QueryHandlerInterface.java
@@ -45,4 +45,7 @@ public interface QueryHandlerInterface {
     void handleQuerySamples(
             QuerySamplesRequest request, StreamObserver<QuerySamplesResponse> responseObserver);
 
+    void handleQuerySamplesStream(
+            QuerySamplesRequest request, StreamObserver<QuerySamplesResponse> responseObserver);
+
 }

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/model/KeysetPosition.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/model/KeysetPosition.java
@@ -1,0 +1,87 @@
+package com.ospreydcs.dp.service.query.handler.model;
+
+import java.util.Objects;
+
+/**
+ * A page-continuation position for Query API V2 paging — a pure position marker, never server state
+ * (Q1/Q2/Q3: stateless, best-effort, position-only tokens). Two shapes:
+ *
+ * <ul>
+ *   <li><b>Bucket</b> (Q2): the last-emitted {@code (pvName, firstTimeSeconds, firstTimeNanos)}
+ *       tuple; the next page seeks strictly after it in the compound bucket sort order.</li>
+ *   <li><b>Sample</b> (Q1): the resume timestamp {@code (epochSeconds, nanos)}; the next page
+ *       re-runs the overlap query with begin advanced to this timestamp.</li>
+ * </ul>
+ *
+ * <p>The <em>meaning</em> of a position is kept decoupled from its <em>encoding</em> (owned by
+ * {@code PageToken}), so a future server-side cached-cursor implementation can still accept a
+ * position-only token as a cache-miss fallback without any proto or client change.
+ */
+public final class KeysetPosition {
+
+    public enum Kind { BUCKET, SAMPLE }
+
+    private final Kind kind;
+
+    // BUCKET fields
+    private final String pvName;
+
+    // shared time fields: BUCKET => firstTime; SAMPLE => resume timestamp
+    private final long seconds;
+    private final long nanos;
+
+    private KeysetPosition(Kind kind, String pvName, long seconds, long nanos) {
+        this.kind = kind;
+        this.pvName = pvName;
+        this.seconds = seconds;
+        this.nanos = nanos;
+    }
+
+    /** Bucket-path position: seek strictly after {@code (pvName, firstTimeSeconds, firstTimeNanos)}. */
+    public static KeysetPosition ofBucket(String pvName, long firstTimeSeconds, long firstTimeNanos) {
+        return new KeysetPosition(Kind.BUCKET, pvName, firstTimeSeconds, firstTimeNanos);
+    }
+
+    /** Sample-path position: resume at {@code (epochSeconds, nanos)}. */
+    public static KeysetPosition ofSample(long epochSeconds, long nanos) {
+        return new KeysetPosition(Kind.SAMPLE, null, epochSeconds, nanos);
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+
+    public String getPvName() {
+        return pvName;
+    }
+
+    public long getSeconds() {
+        return seconds;
+    }
+
+    public long getNanos() {
+        return nanos;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof KeysetPosition that)) return false;
+        return seconds == that.seconds
+                && nanos == that.nanos
+                && kind == that.kind
+                && Objects.equals(pvName, that.pvName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, pvName, seconds, nanos);
+    }
+
+    @Override
+    public String toString() {
+        return kind == Kind.BUCKET
+                ? "KeysetPosition[BUCKET " + pvName + " @ " + seconds + "." + nanos + "]"
+                : "KeysetPosition[SAMPLE @ " + seconds + "." + nanos + "]";
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/model/ResolutionResult.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/model/ResolutionResult.java
@@ -1,0 +1,42 @@
+package com.ospreydcs.dp.service.query.handler.model;
+
+import com.ospreydcs.dp.service.common.model.ResultStatus;
+
+/**
+ * Outcome of Query API V2 request resolution: either a successful {@link ResolvedQuery}, or a
+ * {@link ResultStatus} describing a validation/resolution rejection or error. Exactly one of the two
+ * is non-null. A {@code ResultStatus} with {@code isError == false} is not used here — a resolution
+ * failure is always a reject or error, and an empty-but-valid result is represented by a
+ * {@link ResolvedQuery} whose {@link ResolvedQuery#isEmptyResult()} is true.
+ */
+public final class ResolutionResult {
+
+    private final ResolvedQuery resolvedQuery;
+    private final ResultStatus errorStatus;
+
+    private ResolutionResult(ResolvedQuery resolvedQuery, ResultStatus errorStatus) {
+        this.resolvedQuery = resolvedQuery;
+        this.errorStatus = errorStatus;
+    }
+
+    public static ResolutionResult of(ResolvedQuery resolvedQuery) {
+        return new ResolutionResult(resolvedQuery, null);
+    }
+
+    /** A rejection (client error, e.g. bad request / cap exceeded) — maps to RESULT_STATUS_REJECT. */
+    public static ResolutionResult reject(String message) {
+        return new ResolutionResult(null, new ResultStatus(true, message));
+    }
+
+    public boolean isError() {
+        return errorStatus != null;
+    }
+
+    public ResolvedQuery getResolvedQuery() {
+        return resolvedQuery;
+    }
+
+    public ResultStatus getErrorStatus() {
+        return errorStatus;
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/model/ResolvedQuery.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/model/ResolvedQuery.java
@@ -1,0 +1,91 @@
+package com.ospreydcs.dp.service.query.handler.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Internal (non-proto) resolved-query object for Query API V2 — the "ExecutionPlan" seam between
+ * request resolution (step 2) and retrieval/formatting (steps 3/5). Built by the resolver from a
+ * validated {@code QuerySpec + ExecutionOptions + ResultRepresentation}; immutable; carried into the
+ * V2 job and dispatcher.
+ *
+ * <p>Holds the concrete resolved PV <b>name list</b> (Q9 requires the list, not just a filter, so
+ * every resolved PV can get a column even with no data in range), the effective — possibly
+ * fragmented — retrieval intervals (Q3), the normalized page size (Q7), the decoded continuation
+ * position (Q1/Q2, {@code null} on the first page), and the representation flags (Q5/Q8).
+ */
+public final class ResolvedQuery {
+
+    public enum ResultMode { BUCKET, SAMPLE }
+
+    private final List<String> pvNames;
+    private final List<TimeInterval> retrievalIntervals;
+    private final int pageSize;
+    private final KeysetPosition pageStart; // null on first page
+    private final boolean useSerializedColumns;
+    private final boolean excludeColumnMetadata;
+    private final ResultMode mode;
+    private final boolean streaming;
+
+    public ResolvedQuery(
+            List<String> pvNames,
+            List<TimeInterval> retrievalIntervals,
+            int pageSize,
+            KeysetPosition pageStart,
+            boolean useSerializedColumns,
+            boolean excludeColumnMetadata,
+            ResultMode mode,
+            boolean streaming) {
+        this.pvNames = Collections.unmodifiableList(pvNames);
+        this.retrievalIntervals = Collections.unmodifiableList(retrievalIntervals);
+        this.pageSize = pageSize;
+        this.pageStart = pageStart;
+        this.useSerializedColumns = useSerializedColumns;
+        this.excludeColumnMetadata = excludeColumnMetadata;
+        this.mode = mode;
+        this.streaming = streaming;
+    }
+
+    /** Sorted-ascending list of resolved PV names; drives Q9 column order/presence. */
+    public List<String> getPvNames() {
+        return pvNames;
+    }
+
+    /** Sorted, disjoint effective retrieval intervals (single element = whole timeRange). */
+    public List<TimeInterval> getRetrievalIntervals() {
+        return retrievalIntervals;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    /** Decoded continuation position, or {@code null} on the first page. */
+    public KeysetPosition getPageStart() {
+        return pageStart;
+    }
+
+    public boolean isUseSerializedColumns() {
+        return useSerializedColumns;
+    }
+
+    public boolean isExcludeColumnMetadata() {
+        return excludeColumnMetadata;
+    }
+
+    public ResultMode getMode() {
+        return mode;
+    }
+
+    public boolean isStreaming() {
+        return streaming;
+    }
+
+    /**
+     * True when this query resolves to no PVs or no retrieval intervals — the retrieval layer should
+     * short-circuit to an empty (not exceptional) result.
+     */
+    public boolean isEmptyResult() {
+        return pvNames.isEmpty() || retrievalIntervals.isEmpty();
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/model/TimeInterval.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/model/TimeInterval.java
@@ -1,0 +1,164 @@
+package com.ospreydcs.dp.service.query.handler.model;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A half-open time interval {@code [begin, end)} expressed in epoch seconds + nanoseconds, used by
+ * the Query API V2 resolver to represent effective retrieval ranges (a single interval for the whole
+ * {@code QuerySpec.timeRange}, or a possibly-fragmented set derived from a
+ * {@code ConfigurationSelector}).
+ *
+ * <p>The endpoints are compared lexicographically on {@code (seconds, nanos)}. An interval is empty
+ * (and therefore invalid as a retrieval range) when {@code end <= begin}. The union/intersect
+ * helpers here are pure functions with no MongoDB dependency, so they are directly unit-testable.
+ */
+public final class TimeInterval {
+
+    private final long beginSeconds;
+    private final long beginNanos;
+    private final long endSeconds;
+    private final long endNanos;
+
+    public TimeInterval(long beginSeconds, long beginNanos, long endSeconds, long endNanos) {
+        this.beginSeconds = beginSeconds;
+        this.beginNanos = beginNanos;
+        this.endSeconds = endSeconds;
+        this.endNanos = endNanos;
+    }
+
+    public long getBeginSeconds() {
+        return beginSeconds;
+    }
+
+    public long getBeginNanos() {
+        return beginNanos;
+    }
+
+    public long getEndSeconds() {
+        return endSeconds;
+    }
+
+    public long getEndNanos() {
+        return endNanos;
+    }
+
+    /** Lexicographic compare of a {@code (seconds, nanos)} instant pair. */
+    public static int compareInstant(long aSecs, long aNanos, long bSecs, long bNanos) {
+        if (aSecs != bSecs) {
+            return Long.compare(aSecs, bSecs);
+        }
+        return Long.compare(aNanos, bNanos);
+    }
+
+    /** True when {@code end <= begin} (an empty / degenerate interval). */
+    public boolean isEmpty() {
+        return compareInstant(endSeconds, endNanos, beginSeconds, beginNanos) <= 0;
+    }
+
+    /**
+     * Intersects this interval with {@code [beginSecs,beginNanos) .. [endSecs,endNanos)} and returns
+     * the overlap, or {@code null} if the two do not overlap. Result begin = max of begins, result
+     * end = min of ends.
+     */
+    public TimeInterval intersect(long beginSecs, long beginNanos, long endSecs, long endNanos) {
+        // begin = max(this.begin, other.begin)
+        final long bSecs, bNanos;
+        if (compareInstant(this.beginSeconds, this.beginNanos, beginSecs, beginNanos) >= 0) {
+            bSecs = this.beginSeconds;
+            bNanos = this.beginNanos;
+        } else {
+            bSecs = beginSecs;
+            bNanos = beginNanos;
+        }
+        // end = min(this.end, other.end)
+        final long eSecs, eNanos;
+        if (compareInstant(this.endSeconds, this.endNanos, endSecs, endNanos) <= 0) {
+            eSecs = this.endSeconds;
+            eNanos = this.endNanos;
+        } else {
+            eSecs = endSecs;
+            eNanos = endNanos;
+        }
+        final TimeInterval result = new TimeInterval(bSecs, bNanos, eSecs, eNanos);
+        return result.isEmpty() ? null : result;
+    }
+
+    /**
+     * Coalesces a list of possibly-overlapping/adjacent intervals into a minimal sorted set of
+     * disjoint intervals (the union). Empty inputs and empty intervals are dropped. Adjacent
+     * intervals (one's end equal to the next's begin) are merged, since the ranges are half-open and
+     * abut with no gap.
+     */
+    public static List<TimeInterval> union(List<TimeInterval> intervals) {
+        final List<TimeInterval> sorted = new ArrayList<>();
+        for (TimeInterval iv : intervals) {
+            if (iv != null && !iv.isEmpty()) {
+                sorted.add(iv);
+            }
+        }
+        sorted.sort(Comparator
+                .comparingLong(TimeInterval::getBeginSeconds)
+                .thenComparingLong(TimeInterval::getBeginNanos));
+
+        final List<TimeInterval> merged = new ArrayList<>();
+        for (TimeInterval iv : sorted) {
+            if (merged.isEmpty()) {
+                merged.add(iv);
+                continue;
+            }
+            final TimeInterval last = merged.get(merged.size() - 1);
+            // merge when iv.begin <= last.end (overlap or adjacency, half-open)
+            if (compareInstant(iv.beginSeconds, iv.beginNanos, last.endSeconds, last.endNanos) <= 0) {
+                // extend last to max(last.end, iv.end)
+                if (compareInstant(iv.endSeconds, iv.endNanos, last.endSeconds, last.endNanos) > 0) {
+                    merged.set(merged.size() - 1,
+                            new TimeInterval(last.beginSeconds, last.beginNanos, iv.endSeconds, iv.endNanos));
+                }
+                // else iv is fully contained in last — drop it
+            } else {
+                merged.add(iv);
+            }
+        }
+        return merged;
+    }
+
+    /**
+     * Intersects a set of intervals with a single bounding interval, returning the (sorted, disjoint)
+     * pieces that fall within the bound. Input is unioned first, so the result is minimal and
+     * disjoint. An empty result means the selector matches nothing inside the bound.
+     */
+    public static List<TimeInterval> intersectAll(List<TimeInterval> intervals, TimeInterval bound) {
+        final List<TimeInterval> result = new ArrayList<>();
+        for (TimeInterval iv : union(intervals)) {
+            final TimeInterval clipped = iv.intersect(
+                    bound.beginSeconds, bound.beginNanos, bound.endSeconds, bound.endNanos);
+            if (clipped != null) {
+                result.add(clipped);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TimeInterval that)) return false;
+        return beginSeconds == that.beginSeconds
+                && beginNanos == that.beginNanos
+                && endSeconds == that.endSeconds
+                && endNanos == that.endNanos;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(beginSeconds, beginNanos, endSeconds, endNanos);
+    }
+
+    @Override
+    public String toString() {
+        return "TimeInterval[" + beginSeconds + "." + beginNanos + " .. " + endSeconds + "." + endNanos + ")";
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/MongoQueryHandler.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/MongoQueryHandler.java
@@ -278,21 +278,49 @@ public class MongoQueryHandler extends QueueHandlerBase implements QueryHandlerI
             QuerySamplesRequest request,
             StreamObserver<QuerySamplesResponse> responseObserver
     ) {
+        final ResolvedQuery resolvedQuery = resolveSamplesOrReject(request, false, responseObserver);
+        if (resolvedQuery == null) {
+            return; // reject already sent
+        }
+        final QuerySamplesUnaryDispatcher dispatcher = new QuerySamplesUnaryDispatcher(responseObserver);
+        enqueueQueryV2Job(resolvedQuery, dispatcher, "querySamples", responseObserver.hashCode());
+    }
+
+    @Override
+    public void handleQuerySamplesStream(
+            QuerySamplesRequest request,
+            StreamObserver<QuerySamplesResponse> responseObserver
+    ) {
+        final ResolvedQuery resolvedQuery = resolveSamplesOrReject(request, true, responseObserver);
+        if (resolvedQuery == null) {
+            return; // reject already sent (includes the non-empty-pageToken streaming rule)
+        }
+        final QuerySamplesStreamDispatcher dispatcher = new QuerySamplesStreamDispatcher(responseObserver);
+        enqueueQueryV2Job(resolvedQuery, dispatcher, "querySamplesStream", responseObserver.hashCode());
+    }
+
+    /**
+     * Validates + resolves a sample request (mode=SAMPLE). On error, sends an ExceptionalResult
+     * reject and returns null; otherwise returns the ResolvedQuery. The {@code streaming} flag drives
+     * the paging-token rule (Q7).
+     */
+    private ResolvedQuery resolveSamplesOrReject(
+            QuerySamplesRequest request, boolean streaming,
+            StreamObserver<QuerySamplesResponse> responseObserver) {
+
         final ResolutionResult resolution = queryV2Resolver.resolve(
                 request.getQuerySpec(),
                 request.getExecutionOptions(),
                 request.getResultRepresentation(),
                 ResolvedQuery.ResultMode.SAMPLE,
-                false /* not streaming */);
+                streaming);
 
         if (resolution.isError()) {
             QueryServiceImpl.sendQuerySamplesResponseReject(
                     resolution.getErrorStatus().msg, responseObserver);
-            return;
+            return null;
         }
-
-        final QuerySamplesUnaryDispatcher dispatcher = new QuerySamplesUnaryDispatcher(responseObserver);
-        enqueueQueryV2Job(resolution.getResolvedQuery(), dispatcher, "querySamples", responseObserver.hashCode());
+        return resolution.getResolvedQuery();
     }
 
     private void enqueueQueryV2Job(

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/MongoQueryHandler.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/MongoQueryHandler.java
@@ -228,25 +228,58 @@ public class MongoQueryHandler extends QueueHandlerBase implements QueryHandlerI
             QueryBucketsRequest request,
             StreamObserver<QueryBucketsResponse> responseObserver
     ) {
-        // validate + resolve the request (§6 invariants, PV/config resolution, paging normalization)
+        final ResolvedQuery resolvedQuery = resolveBucketsOrReject(request, false, responseObserver);
+        if (resolvedQuery == null) {
+            return; // reject already sent
+        }
+        final QueryBucketsUnaryDispatcher dispatcher = new QueryBucketsUnaryDispatcher(responseObserver);
+        enqueueQueryV2Job(resolvedQuery, dispatcher, "queryBuckets", responseObserver.hashCode());
+    }
+
+    @Override
+    public void handleQueryBucketsStream(
+            QueryBucketsRequest request,
+            StreamObserver<QueryBucketsResponse> responseObserver
+    ) {
+        final ResolvedQuery resolvedQuery = resolveBucketsOrReject(request, true, responseObserver);
+        if (resolvedQuery == null) {
+            return; // reject already sent (includes the non-empty-pageToken streaming rule)
+        }
+        final QueryBucketsStreamDispatcher dispatcher = new QueryBucketsStreamDispatcher(responseObserver);
+        enqueueQueryV2Job(resolvedQuery, dispatcher, "queryBucketsStream", responseObserver.hashCode());
+    }
+
+    /**
+     * Validates + resolves a bucket request (§6 invariants, PV/config resolution, paging
+     * normalization). On error, sends an ExceptionalResult reject and returns null; otherwise returns
+     * the ResolvedQuery. The {@code streaming} flag drives the paging-token rule (Q7).
+     */
+    private ResolvedQuery resolveBucketsOrReject(
+            QueryBucketsRequest request, boolean streaming,
+            StreamObserver<QueryBucketsResponse> responseObserver) {
+
         final ResolutionResult resolution = queryV2Resolver.resolve(
                 request.getQuerySpec(),
                 request.getExecutionOptions(),
                 request.getResultRepresentation(),
                 ResolvedQuery.ResultMode.BUCKET,
-                false /* not streaming */);
+                streaming);
 
         if (resolution.isError()) {
             QueryServiceImpl.sendQueryBucketsResponseReject(
                     resolution.getErrorStatus().msg, responseObserver);
-            return;
+            return null;
         }
+        return resolution.getResolvedQuery();
+    }
 
-        final QueryBucketsUnaryDispatcher dispatcher = new QueryBucketsUnaryDispatcher(responseObserver);
-        final QueryV2Job job = new QueryV2Job(resolution.getResolvedQuery(), dispatcher, mongoQueryClient);
+    private void enqueueQueryV2Job(
+            ResolvedQuery resolvedQuery,
+            com.ospreydcs.dp.service.query.handler.mongo.dispatch.QueryV2Dispatcher dispatcher,
+            String label, int observerId) {
 
-        logger.debug("adding QueryV2Job (queryBuckets) id: {} to queue", responseObserver.hashCode());
-
+        final QueryV2Job job = new QueryV2Job(resolvedQuery, dispatcher, mongoQueryClient);
+        logger.debug("adding QueryV2Job ({}) id: {} to queue", label, observerId);
         try {
             requestQueue.put(job);
         } catch (InterruptedException e) {

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/MongoQueryHandler.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/MongoQueryHandler.java
@@ -273,6 +273,28 @@ public class MongoQueryHandler extends QueueHandlerBase implements QueryHandlerI
         return resolution.getResolvedQuery();
     }
 
+    @Override
+    public void handleQuerySamples(
+            QuerySamplesRequest request,
+            StreamObserver<QuerySamplesResponse> responseObserver
+    ) {
+        final ResolutionResult resolution = queryV2Resolver.resolve(
+                request.getQuerySpec(),
+                request.getExecutionOptions(),
+                request.getResultRepresentation(),
+                ResolvedQuery.ResultMode.SAMPLE,
+                false /* not streaming */);
+
+        if (resolution.isError()) {
+            QueryServiceImpl.sendQuerySamplesResponseReject(
+                    resolution.getErrorStatus().msg, responseObserver);
+            return;
+        }
+
+        final QuerySamplesUnaryDispatcher dispatcher = new QuerySamplesUnaryDispatcher(responseObserver);
+        enqueueQueryV2Job(resolution.getResolvedQuery(), dispatcher, "querySamples", responseObserver.hashCode());
+    }
+
     private void enqueueQueryV2Job(
             ResolvedQuery resolvedQuery,
             com.ospreydcs.dp.service.query.handler.mongo.dispatch.QueryV2Dispatcher dispatcher,

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/MongoQueryHandler.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/MongoQueryHandler.java
@@ -4,11 +4,15 @@ import com.ospreydcs.dp.grpc.v1.query.*;
 import com.ospreydcs.dp.service.common.handler.QueueHandlerBase;
 import com.ospreydcs.dp.service.common.model.ResultStatus;
 import com.ospreydcs.dp.service.query.handler.QueryHandlerUtility;
+import com.ospreydcs.dp.service.query.handler.QueryV2Resolver;
 import com.ospreydcs.dp.service.query.handler.interfaces.QueryHandlerInterface;
+import com.ospreydcs.dp.service.query.handler.model.ResolutionResult;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
 import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
 import com.ospreydcs.dp.service.query.handler.mongo.client.MongoSyncQueryClient;
 import com.ospreydcs.dp.service.query.handler.mongo.dispatch.*;
 import com.ospreydcs.dp.service.query.handler.mongo.job.*;
+import com.ospreydcs.dp.service.query.service.QueryServiceImpl;
 import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,11 +28,26 @@ public class MongoQueryHandler extends QueueHandlerBase implements QueryHandlerI
     private static final String CFG_KEY_OUTGOING_MESSAGE_SIZE_LIMIT_BYTES = "GrpcServer.incomingMessageSizeLimitBytes";
     private static final int DEFAULT_OUTGOING_MESSAGE_SIZE_LIMIT_BYTES = 4_096_000;
 
+    // Query API V2 paging / resolution limits (Q7/Q10)
+    private static final String CFG_KEY_QUERY_V2_DEFAULT_PAGE_SIZE = "QueryHandler.queryV2DefaultPageSize";
+    private static final int DEFAULT_QUERY_V2_DEFAULT_PAGE_SIZE = 10_000;
+    private static final String CFG_KEY_QUERY_V2_MAX_PAGE_SIZE = "QueryHandler.queryV2MaxPageSize";
+    private static final int DEFAULT_QUERY_V2_MAX_PAGE_SIZE = 100_000;
+    private static final String CFG_KEY_QUERY_V2_MAX_RESOLVED_PV_COUNT = "QueryHandler.queryV2MaxResolvedPvCount";
+    private static final int DEFAULT_QUERY_V2_MAX_RESOLVED_PV_COUNT = 10_000;
+
     // instance variables
     private final MongoQueryClientInterface mongoQueryClient;
+    private final QueryV2Resolver queryV2Resolver;
 
     public MongoQueryHandler(MongoQueryClientInterface clientInterface) {
         this.mongoQueryClient = clientInterface;
+        this.queryV2Resolver = new QueryV2Resolver(
+                clientInterface,
+                configMgr().getConfigInteger(CFG_KEY_QUERY_V2_DEFAULT_PAGE_SIZE, DEFAULT_QUERY_V2_DEFAULT_PAGE_SIZE),
+                configMgr().getConfigInteger(CFG_KEY_QUERY_V2_MAX_PAGE_SIZE, DEFAULT_QUERY_V2_MAX_PAGE_SIZE),
+                configMgr().getConfigInteger(
+                        CFG_KEY_QUERY_V2_MAX_RESOLVED_PV_COUNT, DEFAULT_QUERY_V2_MAX_RESOLVED_PV_COUNT));
     }
 
     public static MongoQueryHandler newMongoSyncQueryHandler() {
@@ -195,6 +214,38 @@ public class MongoQueryHandler extends QueueHandlerBase implements QueryHandlerI
                 new QueryProviderStatsJob(request, responseObserver, mongoQueryClient);
 
         logger.debug("adding QueryProviderStatsJob id: {} to queue", responseObserver.hashCode());
+
+        try {
+            requestQueue.put(job);
+        } catch (InterruptedException e) {
+            logger.error("InterruptedException waiting for requestQueue.put");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void handleQueryBuckets(
+            QueryBucketsRequest request,
+            StreamObserver<QueryBucketsResponse> responseObserver
+    ) {
+        // validate + resolve the request (§6 invariants, PV/config resolution, paging normalization)
+        final ResolutionResult resolution = queryV2Resolver.resolve(
+                request.getQuerySpec(),
+                request.getExecutionOptions(),
+                request.getResultRepresentation(),
+                ResolvedQuery.ResultMode.BUCKET,
+                false /* not streaming */);
+
+        if (resolution.isError()) {
+            QueryServiceImpl.sendQueryBucketsResponseReject(
+                    resolution.getErrorStatus().msg, responseObserver);
+            return;
+        }
+
+        final QueryBucketsUnaryDispatcher dispatcher = new QueryBucketsUnaryDispatcher(responseObserver);
+        final QueryV2Job job = new QueryV2Job(resolution.getResolvedQuery(), dispatcher, mongoQueryClient);
+
+        logger.debug("adding QueryV2Job (queryBuckets) id: {} to queue", responseObserver.hashCode());
 
         try {
             requestQueue.put(job);

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
@@ -82,6 +82,14 @@ public interface MongoQueryClientInterface {
      */
     MongoCursor<BucketDocument> executeQueryBucketsV2(ResolvedQuery resolvedQuery);
 
+    /**
+     * Retrieves the full, unbounded bucket cursor for a Query API V2 streaming bucket query. Same
+     * PV-name filter and {@code $or} fragment overlap as {@link #executeQueryBucketsV2}, but with no
+     * keyset seek and no limit — the entire result is streamed to exhaustion and chunked into
+     * messages downstream (fire-and-consume). Returns null on a null/empty resolution.
+     */
+    MongoCursor<BucketDocument> executeQueryBucketsV2Stream(ResolvedQuery resolvedQuery);
+
     MongoCursor<ProviderDocument> executeQueryProviders(QueryProvidersRequest request);
 
     MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(QueryProviderStatsRequest request);

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
@@ -7,8 +7,11 @@ import com.ospreydcs.dp.service.common.bson.ProviderDocument;
 import com.ospreydcs.dp.service.common.bson.ProviderMetadataQueryResultDocument;
 import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
 import com.ospreydcs.dp.service.common.bson.dataset.DataBlockDocument;
+import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
+import org.bson.conversions.Bson;
 
 import java.util.Collection;
+import java.util.List;
 
 public interface MongoQueryClientInterface {
 
@@ -40,6 +43,32 @@ public interface MongoQueryClientInterface {
      * 16MB BSON document, which a very large result could exceed.
      */
     Collection<String> executeQueryPvExistence(Collection<String> pvNameList);
+
+    /**
+     * Resolves a PV-name regex pattern to the concrete set of PV names present in the buckets
+     * collection ({@code distinct} on the indexed pvName restricted by the pattern). Query API V2
+     * uses this so pattern selectors materialize a concrete name list (Q9). Returns the matched
+     * names, or null on database error. Throws {@link java.util.regex.PatternSyntaxException} if the
+     * pattern does not compile (caller catches → reject, Q10).
+     */
+    List<String> resolvePvNamesByPattern(String pvNamePattern);
+
+    /**
+     * Resolves a set of PV-metadata criterion filters (built from the shared filter helpers) to the
+     * concrete set of PV names, then intersects with archive existence — dropping names that have no
+     * buckets at all (Q11 decision b). Returns the intersected names, or null on database error.
+     * An empty {@code criteriaFilters} matches all metadata records.
+     */
+    List<String> resolvePvNamesByMetadata(List<Bson> criteriaFilters);
+
+    /**
+     * Resolves a set of configuration-activation criterion filters (built from the shared filter
+     * helpers, non-temporal arms only) to the matching activations' {@code [startTime, endTime)}
+     * intervals. Open-ended activations (absent endTime) use {@code Long.MAX_VALUE} seconds as the
+     * end sentinel; the caller intersects with the query timeRange (Q3). Returns the intervals
+     * (un-unioned), or null on database error.
+     */
+    List<TimeInterval> resolveConfigurationIntervals(List<Bson> criteriaFilters);
 
     MongoCursor<ProviderDocument> executeQueryProviders(QueryProvidersRequest request);
 

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
@@ -90,6 +90,20 @@ public interface MongoQueryClientInterface {
      */
     MongoCursor<BucketDocument> executeQueryBucketsV2Stream(ResolvedQuery resolvedQuery);
 
+    /**
+     * Retrieves buckets for a Query API V2 sample (column-table) query, over the page window
+     * {@code [windowBeginSecs.windowBeginNanos, endTime)} intersected with the resolved config
+     * fragments (Q3), for the resolved PV list. The window begin is the resume timestamp
+     * ({@code pageStart}) on a continuation page, or each fragment's own begin on the first page;
+     * the caller passes the effective window-begin so the same overlap machinery is reused. Sorted
+     * by {@code (pvName, firstTimeSecs, firstTimeNanos)}. Unlike the bucket path there is no keyset
+     * seek and no {@code pageSize+1} probe — the sample page is bounded by distinct-timestamp count
+     * and the byte budget during assembly, not by a bucket-count limit. Returns null on a null/empty
+     * resolution.
+     */
+    MongoCursor<BucketDocument> executeQuerySamplesV2(
+            ResolvedQuery resolvedQuery, long windowBeginSecs, long windowBeginNanos);
+
     MongoCursor<ProviderDocument> executeQueryProviders(QueryProvidersRequest request);
 
     MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(QueryProviderStatsRequest request);

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
@@ -7,6 +7,7 @@ import com.ospreydcs.dp.service.common.bson.ProviderDocument;
 import com.ospreydcs.dp.service.common.bson.ProviderMetadataQueryResultDocument;
 import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
 import com.ospreydcs.dp.service.common.bson.dataset.DataBlockDocument;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
 import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
 import org.bson.conversions.Bson;
 
@@ -69,6 +70,17 @@ public interface MongoQueryClientInterface {
      * (un-unioned), or null on database error.
      */
     List<TimeInterval> resolveConfigurationIntervals(List<Bson> criteriaFilters);
+
+    /**
+     * Retrieves one page of buckets for a Query API V2 bucket query. Builds a bounded, resumable
+     * cursor: AND of the resolved PV-name filter, an {@code $or} of the per-fragment bucket-overlap
+     * predicates (Q3), and — when the resolved query carries a bucket keyset position — a seek
+     * strictly after that {@code (pvName, firstTimeSecs, firstTimeNanos)} tuple (Q2). Sorted by the
+     * compound {@code (pvName, firstTimeSecs, firstTimeNanos)} key and limited to
+     * {@code pageSize + 1} (the extra probe row lets the caller detect a following page). Returns
+     * null on a null/empty resolution.
+     */
+    MongoCursor<BucketDocument> executeQueryBucketsV2(ResolvedQuery resolvedQuery);
 
     MongoCursor<ProviderDocument> executeQueryProviders(QueryProvidersRequest request);
 

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
@@ -11,13 +11,17 @@ import com.ospreydcs.dp.service.common.bson.PvMetadataQueryResultDocument;
 import com.ospreydcs.dp.service.common.bson.ProviderDocument;
 import com.ospreydcs.dp.service.common.bson.ProviderMetadataQueryResultDocument;
 import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
+import com.ospreydcs.dp.service.common.bson.configuration.ConfigurationActivationDocument;
 import com.ospreydcs.dp.service.common.bson.dataset.DataBlockDocument;
+import com.ospreydcs.dp.service.common.bson.pvmetadata.PvMetadataDocument;
 import com.ospreydcs.dp.service.common.mongo.MongoSyncClient;
+import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -256,6 +260,104 @@ public class MongoSyncQueryClient extends MongoSyncClient implements MongoQueryC
         } catch (Exception ex) {
             logger.error("executeQueryPvExistence database error for {} pv name(s): {}",
                     pvNameList.size(), ex.getMessage(), ex);
+            return null;
+        }
+    }
+
+    @Override
+    public List<String> resolvePvNamesByPattern(String pvNamePattern) {
+
+        // Compile the pattern up front so an invalid regex surfaces as a PatternSyntaxException the
+        // caller can turn into a clean reject (Q10), rather than failing deep in the driver.
+        final Pattern compiled = Pattern.compile(pvNamePattern, Pattern.CASE_INSENSITIVE);
+        final Bson pvNameFilter = Filters.regex(BsonConstants.BSON_KEY_PV_NAME, compiled);
+
+        try {
+            final List<String> pvNames = new ArrayList<>();
+            try (final MongoCursor<String> cursor = mongoCollectionBuckets
+                    .distinct(BsonConstants.BSON_KEY_PV_NAME, pvNameFilter, String.class)
+                    .iterator()) {
+                while (cursor.hasNext()) {
+                    pvNames.add(cursor.next());
+                }
+            }
+            return pvNames;
+        } catch (Exception ex) {
+            logger.error("resolvePvNamesByPattern database error: {}", ex.getMessage(), ex);
+            return null;
+        }
+    }
+
+    @Override
+    public List<String> resolvePvNamesByMetadata(List<Bson> criteriaFilters) {
+
+        // An empty criteria list matches all metadata records.
+        final Bson metadataFilter = (criteriaFilters == null || criteriaFilters.isEmpty())
+                ? Filters.exists(BsonConstants.BSON_KEY_PV_METADATA_PV_NAME)
+                : and(criteriaFilters);
+
+        try {
+            // Collect the pvName of every matching metadata record.
+            final Set<String> matchedNames = new HashSet<>();
+            try (final MongoCursor<PvMetadataDocument> cursor =
+                         mongoCollectionPvMetadata.find(metadataFilter).iterator()) {
+                while (cursor.hasNext()) {
+                    matchedNames.add(cursor.next().getPvName());
+                }
+            }
+
+            if (matchedNames.isEmpty()) {
+                return new ArrayList<>();
+            }
+
+            // Intersect with archive existence (Q11 b): drop names that have no buckets at all.
+            final List<String> existing = new ArrayList<>();
+            final Bson existenceFilter = in(BsonConstants.BSON_KEY_PV_NAME, matchedNames);
+            try (final MongoCursor<String> cursor = mongoCollectionBuckets
+                    .distinct(BsonConstants.BSON_KEY_PV_NAME, existenceFilter, String.class)
+                    .iterator()) {
+                while (cursor.hasNext()) {
+                    existing.add(cursor.next());
+                }
+            }
+            return existing;
+
+        } catch (Exception ex) {
+            logger.error("resolvePvNamesByMetadata database error: {}", ex.getMessage(), ex);
+            return null;
+        }
+    }
+
+    @Override
+    public List<TimeInterval> resolveConfigurationIntervals(List<Bson> criteriaFilters) {
+
+        // A configuration selector with no criteria matches nothing (empty result); the caller
+        // handles that case before calling. Here an empty list is treated as match-all for safety.
+        final Bson activationFilter = (criteriaFilters == null || criteriaFilters.isEmpty())
+                ? new org.bson.Document()
+                : and(criteriaFilters);
+
+        try {
+            final List<TimeInterval> intervals = new ArrayList<>();
+            try (final MongoCursor<ConfigurationActivationDocument> cursor =
+                         mongoCollectionConfigurationActivations.find(activationFilter).iterator()) {
+                while (cursor.hasNext()) {
+                    final ConfigurationActivationDocument activation = cursor.next();
+                    final Instant start = activation.getStartTime();
+                    if (start == null) {
+                        continue; // an activation with no start time cannot bound a retrieval range
+                    }
+                    final Instant end = activation.getEndTime(); // null = open-ended
+                    final long endSecs = (end == null) ? Long.MAX_VALUE : end.getEpochSecond();
+                    final long endNanos = (end == null) ? 0L : end.getNano();
+                    intervals.add(new TimeInterval(
+                            start.getEpochSecond(), start.getNano(), endSecs, endNanos));
+                }
+            }
+            return intervals;
+
+        } catch (Exception ex) {
+            logger.error("resolveConfigurationIntervals database error: {}", ex.getMessage(), ex);
             return null;
         }
     }

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
@@ -14,7 +14,10 @@ import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
 import com.ospreydcs.dp.service.common.bson.configuration.ConfigurationActivationDocument;
 import com.ospreydcs.dp.service.common.bson.dataset.DataBlockDocument;
 import com.ospreydcs.dp.service.common.bson.pvmetadata.PvMetadataDocument;
+import com.ospreydcs.dp.service.common.mongo.MongoQueryFilterBuilder;
 import com.ospreydcs.dp.service.common.mongo.MongoSyncClient;
+import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
 import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,15 +47,11 @@ public class MongoSyncQueryClient extends MongoSyncClient implements MongoQueryC
             long endTimeSeconds,
             long endTimeNanos
     ) {
-        final Bson endTimeFilter =
-                or(lt(BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_SECS, endTimeSeconds),
-                        and(eq(BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_SECS, endTimeSeconds),
-                                lt(BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_NANOS, endTimeNanos)));
-        final Bson startTimeFilter =
-                or(gt(BsonConstants.BSON_KEY_BUCKET_LAST_TIME_SECS, startTimeSeconds),
-                        and(eq(BsonConstants.BSON_KEY_BUCKET_LAST_TIME_SECS, startTimeSeconds),
-                                gte(BsonConstants.BSON_KEY_BUCKET_LAST_TIME_NANOS, startTimeNanos)));
-        final Bson filter = and(columnNameFilter, endTimeFilter, startTimeFilter);
+        // Bucket overlap predicate (firstTime < end AND lastTime >= begin) built from the shared
+        // filter builder so the V1 retrieval path and the V2 $or fragmentation cannot drift.
+        final Bson overlapFilter = MongoQueryFilterBuilder.bucketOverlapsRangeFilter(
+                startTimeSeconds, startTimeNanos, endTimeSeconds, endTimeNanos);
+        final Bson filter = and(columnNameFilter, overlapFilter);
 
         logger.debug("executing query columns: " + columnNameFilter
                 + " startSeconds: " + startTimeSeconds
@@ -360,6 +359,76 @@ public class MongoSyncQueryClient extends MongoSyncClient implements MongoQueryC
             logger.error("resolveConfigurationIntervals database error: {}", ex.getMessage(), ex);
             return null;
         }
+    }
+
+    @Override
+    public MongoCursor<BucketDocument> executeQueryBucketsV2(ResolvedQuery resolvedQuery) {
+
+        if (resolvedQuery == null || resolvedQuery.isEmptyResult()) {
+            return null;
+        }
+
+        // PV-name filter over the resolved concrete name list
+        final Bson pvNameFilter = in(BsonConstants.BSON_KEY_PV_NAME, resolvedQuery.getPvNames());
+
+        // Per-fragment bucket-overlap predicates, combined with $or (single fragment → no wrapper).
+        // Built from the shared filter builder so V1 and V2 overlap semantics cannot drift.
+        final List<Bson> fragmentFilters = new ArrayList<>();
+        for (TimeInterval interval : resolvedQuery.getRetrievalIntervals()) {
+            fragmentFilters.add(MongoQueryFilterBuilder.bucketOverlapsRangeFilter(
+                    interval.getBeginSeconds(), interval.getBeginNanos(),
+                    interval.getEndSeconds(), interval.getEndNanos()));
+        }
+        final Bson overlapFilter = (fragmentFilters.size() == 1)
+                ? fragmentFilters.get(0)
+                : or(fragmentFilters);
+
+        // Assemble the top-level filter. The keyset seek is ANDed at top level, NOT distributed into
+        // the $or branches (Q3 correctness note).
+        final List<Bson> andParts = new ArrayList<>();
+        andParts.add(pvNameFilter);
+        andParts.add(overlapFilter);
+
+        final KeysetPosition pageStart = resolvedQuery.getPageStart();
+        if (pageStart != null) {
+            andParts.add(bucketKeysetSeekFilter(pageStart));
+        }
+
+        final Bson filter = and(andParts);
+
+        try {
+            return mongoCollectionBuckets
+                    .find(filter)
+                    .sort(ascending(
+                            BsonConstants.BSON_KEY_PV_NAME,
+                            BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_SECS,
+                            BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_NANOS))
+                    .limit(resolvedQuery.getPageSize() + 1) // +1 probe row to detect a following page
+                    .cursor();
+        } catch (Exception ex) {
+            logger.error("executeQueryBucketsV2 database error: {}", ex.getMessage(), ex);
+            return null;
+        }
+    }
+
+    /**
+     * Keyset seek predicate selecting buckets strictly after {@code (pvName, firstTimeSecs,
+     * firstTimeNanos)} in the compound sort order (Q2). Lexicographic tuple {@code >}. No tiebreaker
+     * needed — the composite bucket {@code _id} proves {@code (pvName, firstTime)} uniqueness.
+     */
+    private static Bson bucketKeysetSeekFilter(KeysetPosition pos) {
+        final String p = pos.getPvName();
+        final long s = pos.getSeconds();
+        final long n = pos.getNanos();
+        return or(
+                gt(BsonConstants.BSON_KEY_PV_NAME, p),
+                and(
+                        eq(BsonConstants.BSON_KEY_PV_NAME, p),
+                        gt(BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_SECS, s)),
+                and(
+                        eq(BsonConstants.BSON_KEY_PV_NAME, p),
+                        eq(BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_SECS, s),
+                        gt(BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_NANOS, n)));
     }
 
     @Override

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
@@ -411,6 +411,63 @@ public class MongoSyncQueryClient extends MongoSyncClient implements MongoQueryC
         }
     }
 
+    @Override
+    public MongoCursor<BucketDocument> executeQuerySamplesV2(
+            ResolvedQuery resolvedQuery, long windowBeginSecs, long windowBeginNanos) {
+
+        if (resolvedQuery == null || resolvedQuery.isEmptyResult()) {
+            return null;
+        }
+
+        final Bson pvNameFilter = in(BsonConstants.BSON_KEY_PV_NAME, resolvedQuery.getPvNames());
+
+        // Per-fragment overlap predicates with each fragment's lower bound clamped to the page window
+        // begin (windowBegin = resume timestamp on a continuation page, or timeRange begin on page 1).
+        // Fragments that end at or before the window begin contribute nothing to this page.
+        final List<Bson> fragmentFilters = new ArrayList<>();
+        for (TimeInterval interval : resolvedQuery.getRetrievalIntervals()) {
+            final long clampedBeginSecs;
+            final long clampedBeginNanos;
+            if (TimeInterval.compareInstant(
+                    interval.getBeginSeconds(), interval.getBeginNanos(),
+                    windowBeginSecs, windowBeginNanos) >= 0) {
+                clampedBeginSecs = interval.getBeginSeconds();
+                clampedBeginNanos = interval.getBeginNanos();
+            } else {
+                clampedBeginSecs = windowBeginSecs;
+                clampedBeginNanos = windowBeginNanos;
+            }
+            // drop fragments entirely before the window begin (clamped begin >= fragment end)
+            if (TimeInterval.compareInstant(
+                    clampedBeginSecs, clampedBeginNanos,
+                    interval.getEndSeconds(), interval.getEndNanos()) >= 0) {
+                continue;
+            }
+            fragmentFilters.add(MongoQueryFilterBuilder.bucketOverlapsRangeFilter(
+                    clampedBeginSecs, clampedBeginNanos,
+                    interval.getEndSeconds(), interval.getEndNanos()));
+        }
+
+        if (fragmentFilters.isEmpty()) {
+            // nothing overlaps the page window
+            return null;
+        }
+
+        final Bson overlapFilter = (fragmentFilters.size() == 1)
+                ? fragmentFilters.get(0)
+                : or(fragmentFilters);
+
+        try {
+            return mongoCollectionBuckets
+                    .find(and(pvNameFilter, overlapFilter))
+                    .sort(bucketV2Sort())
+                    .cursor();
+        } catch (Exception ex) {
+            logger.error("executeQuerySamplesV2 database error: {}", ex.getMessage(), ex);
+            return null;
+        }
+    }
+
     /**
      * Base V2 bucket filter shared by the unary and streaming retrieval paths: the resolved PV-name
      * {@code in(...)} filter AND the {@code $or} of the per-fragment bucket-overlap predicates

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
@@ -330,11 +330,13 @@ public class MongoSyncQueryClient extends MongoSyncClient implements MongoQueryC
     @Override
     public List<TimeInterval> resolveConfigurationIntervals(List<Bson> criteriaFilters) {
 
-        // A configuration selector with no criteria matches nothing (empty result); the caller
-        // handles that case before calling. Here an empty list is treated as match-all for safety.
-        final Bson activationFilter = (criteriaFilters == null || criteriaFilters.isEmpty())
-                ? new org.bson.Document()
-                : and(criteriaFilters);
+        // A configuration selector with no criteria matches nothing (the resolver short-circuits this
+        // case before calling). Defensively honor that contract here too: an empty filter list yields
+        // no intervals rather than scanning and unioning every activation in the collection.
+        if (criteriaFilters == null || criteriaFilters.isEmpty()) {
+            return new ArrayList<>();
+        }
+        final Bson activationFilter = and(criteriaFilters);
 
         try {
             final List<TimeInterval> intervals = new ArrayList<>();

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
@@ -368,11 +368,58 @@ public class MongoSyncQueryClient extends MongoSyncClient implements MongoQueryC
             return null;
         }
 
-        // PV-name filter over the resolved concrete name list
+        // Base filter: PV-name filter AND the $or of per-fragment overlap predicates.
+        final List<Bson> andParts = new ArrayList<>();
+        andParts.add(bucketBaseFilterV2(resolvedQuery));
+
+        // Keyset seek (unary paging) is ANDed at top level, NOT distributed into the $or branches
+        // (Q3 correctness note). Absent on the first page and on streaming queries.
+        final KeysetPosition pageStart = resolvedQuery.getPageStart();
+        if (pageStart != null) {
+            andParts.add(bucketKeysetSeekFilter(pageStart));
+        }
+
+        try {
+            return mongoCollectionBuckets
+                    .find(and(andParts))
+                    .sort(bucketV2Sort())
+                    .limit(resolvedQuery.getPageSize() + 1) // +1 probe row to detect a following page
+                    .cursor();
+        } catch (Exception ex) {
+            logger.error("executeQueryBucketsV2 database error: {}", ex.getMessage(), ex);
+            return null;
+        }
+    }
+
+    @Override
+    public MongoCursor<BucketDocument> executeQueryBucketsV2Stream(ResolvedQuery resolvedQuery) {
+
+        if (resolvedQuery == null || resolvedQuery.isEmptyResult()) {
+            return null;
+        }
+
+        // Streaming is fire-and-consume: no keyset seek and no limit — the full result of the
+        // (resolved intervals × PV list) overlap query is streamed to exhaustion, chunked downstream.
+        try {
+            return mongoCollectionBuckets
+                    .find(bucketBaseFilterV2(resolvedQuery))
+                    .sort(bucketV2Sort())
+                    .cursor();
+        } catch (Exception ex) {
+            logger.error("executeQueryBucketsV2Stream database error: {}", ex.getMessage(), ex);
+            return null;
+        }
+    }
+
+    /**
+     * Base V2 bucket filter shared by the unary and streaming retrieval paths: the resolved PV-name
+     * {@code in(...)} filter AND the {@code $or} of the per-fragment bucket-overlap predicates
+     * (single fragment → no {@code $or} wrapper). Built from the shared filter builder so V1 and V2
+     * overlap semantics cannot drift.
+     */
+    private static Bson bucketBaseFilterV2(ResolvedQuery resolvedQuery) {
         final Bson pvNameFilter = in(BsonConstants.BSON_KEY_PV_NAME, resolvedQuery.getPvNames());
 
-        // Per-fragment bucket-overlap predicates, combined with $or (single fragment → no wrapper).
-        // Built from the shared filter builder so V1 and V2 overlap semantics cannot drift.
         final List<Bson> fragmentFilters = new ArrayList<>();
         for (TimeInterval interval : resolvedQuery.getRetrievalIntervals()) {
             fragmentFilters.add(MongoQueryFilterBuilder.bucketOverlapsRangeFilter(
@@ -383,32 +430,15 @@ public class MongoSyncQueryClient extends MongoSyncClient implements MongoQueryC
                 ? fragmentFilters.get(0)
                 : or(fragmentFilters);
 
-        // Assemble the top-level filter. The keyset seek is ANDed at top level, NOT distributed into
-        // the $or branches (Q3 correctness note).
-        final List<Bson> andParts = new ArrayList<>();
-        andParts.add(pvNameFilter);
-        andParts.add(overlapFilter);
+        return and(pvNameFilter, overlapFilter);
+    }
 
-        final KeysetPosition pageStart = resolvedQuery.getPageStart();
-        if (pageStart != null) {
-            andParts.add(bucketKeysetSeekFilter(pageStart));
-        }
-
-        final Bson filter = and(andParts);
-
-        try {
-            return mongoCollectionBuckets
-                    .find(filter)
-                    .sort(ascending(
-                            BsonConstants.BSON_KEY_PV_NAME,
-                            BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_SECS,
-                            BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_NANOS))
-                    .limit(resolvedQuery.getPageSize() + 1) // +1 probe row to detect a following page
-                    .cursor();
-        } catch (Exception ex) {
-            logger.error("executeQueryBucketsV2 database error: {}", ex.getMessage(), ex);
-            return null;
-        }
+    /** Compound V2 bucket sort {@code (pvName, firstTimeSecs, firstTimeNanos)}. */
+    private static Bson bucketV2Sort() {
+        return ascending(
+                BsonConstants.BSON_KEY_PV_NAME,
+                BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_SECS,
+                BsonConstants.BSON_KEY_BUCKET_FIRST_TIME_NANOS);
     }
 
     /**

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQueryBucketsDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQueryBucketsDispatcher.java
@@ -1,0 +1,40 @@
+package com.ospreydcs.dp.service.query.handler.mongo.dispatch;
+
+import com.ospreydcs.dp.grpc.v1.common.DataBucket;
+import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
+import com.ospreydcs.dp.service.common.exception.DpException;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+
+/**
+ * Shared base for the Query API V2 bucket dispatchers (unary {@link QueryBucketsUnaryDispatcher} and
+ * streaming {@code QueryBucketsStreamDispatcher}). Holds the outgoing message-size budget and the
+ * per-bucket build + representation-flag handling, so the two dispatchers differ only in their
+ * accumulate-and-flush (stream) vs. accumulate-one-page (unary) control flow.
+ */
+public abstract class AbstractQueryBucketsDispatcher extends QueryV2Dispatcher {
+
+    protected final long byteBudget;
+
+    protected AbstractQueryBucketsDispatcher(long byteBudget) {
+        this.byteBudget = byteBudget;
+    }
+
+    /**
+     * Builds a V2 {@link DataBucket} from a stored bucket document, honoring the resolved query's
+     * representation flags (useSerializedColumns pass-through, excludeColumnMetadata suppression).
+     */
+    protected DataBucket buildBucket(BucketDocument document, ResolvedQuery resolvedQuery) throws DpException {
+        return BucketDocument.dataBucketFromDocumentV2(
+                document,
+                resolvedQuery.isUseSerializedColumns(),
+                resolvedQuery.isExcludeColumnMetadata());
+    }
+
+    /**
+     * True when a single bucket is larger than the entire message-size budget and therefore cannot be
+     * paged/chunked out of (an indivisible-oversized error condition, Q7).
+     */
+    protected boolean isIndivisibleOversized(int bucketBytes) {
+        return bucketBytes > byteBudget;
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQuerySamplesDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQuerySamplesDispatcher.java
@@ -1,0 +1,142 @@
+package com.ospreydcs.dp.service.query.handler.mongo.dispatch;
+
+import com.ospreydcs.dp.grpc.v1.common.DataColumn;
+import com.ospreydcs.dp.grpc.v1.common.DataValue;
+import com.ospreydcs.dp.grpc.v1.common.SerializedDataColumn;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.grpc.v1.common.TimestampList;
+import com.ospreydcs.dp.grpc.v1.query.ColumnTable;
+import com.ospreydcs.dp.service.common.model.TimestampDataMap;
+import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared base for the Query API V2 sample dispatchers (unary {@link QuerySamplesUnaryDispatcher} and
+ * streaming {@code QuerySamplesStreamDispatcher}). Holds the outgoing message-size budget and the
+ * column-table assembly building blocks — page-window computation, column seeding from the resolved
+ * PV list (Q9), distinct-timestamp collection, and the V2 {@link ColumnTable} builder over a row
+ * range (with the useSerializedColumns handling, Q5) — so the two dispatchers differ only in how they
+ * bound rows (single truncated page vs. successive row-chunks).
+ */
+public abstract class AbstractQuerySamplesDispatcher extends QueryV2Dispatcher {
+
+    protected final long byteBudget;
+
+    protected AbstractQuerySamplesDispatcher(long byteBudget) {
+        this.byteBudget = byteBudget;
+    }
+
+    /**
+     * Computes the page/stream window {@code [begin, end)} for the resolved query: begin = the resume
+     * timestamp (from a continuation token) or the earliest fragment begin; end = the latest fragment
+     * end. Returns {@code {beginSecs, beginNanos, endSecs, endNanos}}.
+     */
+    protected static long[] computeWindow(ResolvedQuery resolvedQuery) {
+        final List<TimeInterval> intervals = resolvedQuery.getRetrievalIntervals();
+        final KeysetPosition pageStart = resolvedQuery.getPageStart();
+
+        final long beginSecs;
+        final long beginNanos;
+        if (pageStart != null) {
+            beginSecs = pageStart.getSeconds();
+            beginNanos = pageStart.getNanos();
+        } else {
+            beginSecs = intervals.get(0).getBeginSeconds();
+            beginNanos = intervals.get(0).getBeginNanos();
+        }
+
+        long endSecs = intervals.get(0).getEndSeconds();
+        long endNanos = intervals.get(0).getEndNanos();
+        for (TimeInterval iv : intervals) {
+            if (TimeInterval.compareInstant(iv.getEndSeconds(), iv.getEndNanos(), endSecs, endNanos) > 0) {
+                endSecs = iv.getEndSeconds();
+                endNanos = iv.getEndNanos();
+            }
+        }
+        return new long[]{beginSecs, beginNanos, endSecs, endNanos};
+    }
+
+    /**
+     * Creates a {@link TimestampDataMap} with its column index map pre-seeded from the resolved PV
+     * list (sorted), so every resolved PV gets a stable column even with no data in the window (Q9).
+     */
+    protected static TimestampDataMap seededTable(ResolvedQuery resolvedQuery) {
+        final TimestampDataMap tableValueMap = new TimestampDataMap();
+        for (String pvName : resolvedQuery.getPvNames()) {
+            tableValueMap.getColumnIndex(pvName);
+        }
+        return tableValueMap;
+    }
+
+    /** Collects the map's distinct {@code (second, nano)} timestamps in sorted order. */
+    protected static List<long[]> collectTimestamps(TimestampDataMap tableValueMap) {
+        final List<long[]> timestamps = new ArrayList<>();
+        for (Map.Entry<Long, Map<Long, Map<Integer, DataValue>>> secondEntry : tableValueMap.entrySet()) {
+            final long second = secondEntry.getKey();
+            for (Long nano : secondEntry.getValue().keySet()) {
+                timestamps.add(new long[]{second, nano});
+            }
+        }
+        return timestamps;
+    }
+
+    /**
+     * Builds a V2 {@link ColumnTable} from the map rows {@code [fromRow, toRow)} of the given sorted
+     * timestamp list. Every seeded column is emitted (all-unset {@link DataValue} where a PV has no
+     * sample at a row, Q9). When {@code useSerializedColumns}, each column is serialized into
+     * {@code serializedDataColumns} (exactly one list populated), empty encoding (Q5).
+     */
+    protected static ColumnTable buildColumnTable(
+            TimestampDataMap tableValueMap,
+            List<long[]> timestamps,
+            int fromRow,
+            int toRow,
+            boolean useSerializedColumns) {
+
+        final List<String> columnNames = tableValueMap.getColumnNameList();
+        final TimestampList.Builder timestampListBuilder = TimestampList.newBuilder();
+        final List<DataColumn.Builder> columnBuilders = new ArrayList<>(columnNames.size());
+        for (String name : columnNames) {
+            columnBuilders.add(DataColumn.newBuilder().setName(name));
+        }
+
+        for (int rowIndex = fromRow; rowIndex < toRow; rowIndex++) {
+            final long second = timestamps.get(rowIndex)[0];
+            final long nano = timestamps.get(rowIndex)[1];
+            timestampListBuilder.addTimestamps(
+                    Timestamp.newBuilder().setEpochSeconds(second).setNanoseconds(nano).build());
+            final Map<Integer, DataValue> rowValues = tableValueMap.get(second, nano);
+            for (int columnIndex = 0; columnIndex < columnBuilders.size(); columnIndex++) {
+                DataValue value = rowValues.get(columnIndex);
+                if (value == null) {
+                    value = DataValue.newBuilder().build(); // unset => missing sample (Q9)
+                }
+                columnBuilders.get(columnIndex).addDataValues(value);
+            }
+        }
+
+        final ColumnTable.Builder columnTableBuilder = ColumnTable.newBuilder()
+                .setTimestampList(timestampListBuilder.build());
+
+        if (useSerializedColumns) {
+            for (DataColumn.Builder columnBuilder : columnBuilders) {
+                final DataColumn column = columnBuilder.build();
+                columnTableBuilder.addSerializedDataColumns(SerializedDataColumn.newBuilder()
+                        .setName(column.getName())
+                        .setPayload(column.toByteString())
+                        .build());
+            }
+        } else {
+            for (DataColumn.Builder columnBuilder : columnBuilders) {
+                columnTableBuilder.addDataColumns(columnBuilder.build());
+            }
+        }
+
+        return columnTableBuilder.build();
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QueryBucketsStreamDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QueryBucketsStreamDispatcher.java
@@ -1,0 +1,140 @@
+package com.ospreydcs.dp.service.query.handler.mongo.dispatch;
+
+import com.mongodb.client.MongoCursor;
+import com.ospreydcs.dp.grpc.v1.common.DataBucket;
+import com.ospreydcs.dp.grpc.v1.query.QueryBucketsResponse;
+import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
+import com.ospreydcs.dp.service.common.exception.DpException;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.mongo.MongoQueryHandler;
+import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
+import com.ospreydcs.dp.service.query.service.QueryServiceImpl;
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Server-streaming {@code queryBucketsStream} formatter (Q7/Q8). Fire-and-consume: streams the whole
+ * result of the (resolved intervals × PV list) overlap query to exhaustion, emitting
+ * {@code BucketQueryResult} messages chunked by {@code limit} (per-message bucket count) and the
+ * outgoing message-size budget — whichever bounds a chunk first.
+ *
+ * <p>{@code nextPageToken} is empty on every message (the stream itself signals completion via
+ * {@code onCompleted}). An empty result emits a single empty message, then completes. A single bucket
+ * larger than the whole budget is an indivisible-oversized error. Representation-flag handling is
+ * identical to the unary dispatcher (shared via {@link AbstractQueryBucketsDispatcher}).
+ */
+public class QueryBucketsStreamDispatcher extends AbstractQueryBucketsDispatcher {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final StreamObserver<QueryBucketsResponse> responseObserver;
+
+    public QueryBucketsStreamDispatcher(StreamObserver<QueryBucketsResponse> responseObserver) {
+        this(responseObserver, MongoQueryHandler.getOutgoingMessageSizeLimitBytes());
+    }
+
+    /** Package/test constructor allowing the outgoing message-size budget to be injected. */
+    public QueryBucketsStreamDispatcher(StreamObserver<QueryBucketsResponse> responseObserver, long byteBudget) {
+        super(byteBudget);
+        this.responseObserver = responseObserver;
+    }
+
+    @Override
+    public void executeAndDispatch(ResolvedQuery resolvedQuery, MongoQueryClientInterface mongoClient) {
+
+        // A query that resolves to no PVs or no retrieval intervals yields a single empty message.
+        if (resolvedQuery.isEmptyResult()) {
+            emitChunk(new ArrayList<>());
+            responseObserver.onCompleted();
+            return;
+        }
+
+        final MongoCursor<BucketDocument> cursor = mongoClient.executeQueryBucketsV2Stream(resolvedQuery);
+        if (cursor == null) {
+            final String msg = "executeQueryBucketsV2Stream returned null cursor";
+            logger.error(msg + " id: " + responseObserver.hashCode());
+            QueryServiceImpl.sendQueryBucketsResponseError(msg, responseObserver);
+            return;
+        }
+
+        try (cursor) {
+            if (!cursor.hasNext()) {
+                emitChunk(new ArrayList<>());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            // limit == per-message chunk size (count); combined with the byte budget as the two flush
+            // triggers. pageSize is normalized (default/clamped) by the resolver.
+            final int chunkSizeLimit = resolvedQuery.getPageSize();
+
+            final List<DataBucket> chunk = new ArrayList<>();
+            long chunkBytes = 0;
+
+            while (cursor.hasNext()) {
+                final BucketDocument document = cursor.next();
+
+                final DataBucket bucket;
+                try {
+                    bucket = buildBucket(document, resolvedQuery);
+                } catch (DpException e) {
+                    final String msg = "exception building bucket result: " + e.getMessage();
+                    logger.error(msg, e);
+                    QueryServiceImpl.sendQueryBucketsResponseError(msg, responseObserver);
+                    return;
+                }
+
+                final int bucketBytes = bucket.getSerializedSize();
+
+                // byte flush: if adding this bucket would overflow the budget, flush the current chunk
+                // first — but only if it already holds >= 1 bucket (zero-progress guard).
+                if (!chunk.isEmpty() && chunkBytes + bucketBytes > byteBudget) {
+                    emitChunk(chunk);
+                    chunk.clear();
+                    chunkBytes = 0;
+                }
+
+                // indivisible-oversized: a single bucket bigger than the whole budget cannot be chunked.
+                if (chunk.isEmpty() && isIndivisibleOversized(bucketBytes)) {
+                    final String msg = "single bucket for pv " + document.getPvName()
+                            + " exceeds the outgoing message size limit (" + bucketBytes + " > "
+                            + byteBudget + " bytes)";
+                    logger.error(msg);
+                    QueryServiceImpl.sendQueryBucketsResponseError(msg, responseObserver);
+                    return;
+                }
+
+                chunk.add(bucket);
+                chunkBytes += bucketBytes;
+
+                // count flush: chunk reached the per-message limit
+                if (chunk.size() >= chunkSizeLimit) {
+                    emitChunk(chunk);
+                    chunk.clear();
+                    chunkBytes = 0;
+                }
+            }
+
+            // flush any trailing partial chunk
+            if (!chunk.isEmpty()) {
+                emitChunk(chunk);
+            }
+
+            responseObserver.onCompleted();
+        }
+    }
+
+    /** Emits one streamed BucketQueryResult message with an empty nextPageToken. */
+    private void emitChunk(List<DataBucket> buckets) {
+        final QueryBucketsResponse.BucketQueryResult result =
+                QueryBucketsResponse.BucketQueryResult.newBuilder()
+                        .addAllDataBuckets(buckets)
+                        .setNextPageToken("") // stream signals completion; token always empty
+                        .build();
+        responseObserver.onNext(QueryServiceImpl.queryBucketsResponse(result));
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QueryBucketsUnaryDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QueryBucketsUnaryDispatcher.java
@@ -28,12 +28,11 @@ import java.util.List;
  * whole budget is an indivisible-oversized error. Empty result is an empty payload, not an
  * ExceptionalResult.
  */
-public class QueryBucketsUnaryDispatcher extends QueryV2Dispatcher {
+public class QueryBucketsUnaryDispatcher extends AbstractQueryBucketsDispatcher {
 
     private static final Logger logger = LogManager.getLogger();
 
     private final StreamObserver<QueryBucketsResponse> responseObserver;
-    private final long byteBudget;
 
     public QueryBucketsUnaryDispatcher(StreamObserver<QueryBucketsResponse> responseObserver) {
         this(responseObserver, MongoQueryHandler.getOutgoingMessageSizeLimitBytes());
@@ -44,8 +43,8 @@ public class QueryBucketsUnaryDispatcher extends QueryV2Dispatcher {
      * byte-budget page-split and indivisible-oversized paths can be exercised deterministically.
      */
     public QueryBucketsUnaryDispatcher(StreamObserver<QueryBucketsResponse> responseObserver, long byteBudget) {
+        super(byteBudget);
         this.responseObserver = responseObserver;
-        this.byteBudget = byteBudget;
     }
 
     @Override
@@ -89,10 +88,7 @@ public class QueryBucketsUnaryDispatcher extends QueryV2Dispatcher {
 
                 final DataBucket bucket;
                 try {
-                    bucket = BucketDocument.dataBucketFromDocumentV2(
-                            document,
-                            resolvedQuery.isUseSerializedColumns(),
-                            resolvedQuery.isExcludeColumnMetadata());
+                    bucket = buildBucket(document, resolvedQuery);
                 } catch (DpException e) {
                     final String msg = "exception building bucket result: " + e.getMessage();
                     logger.error(msg, e);
@@ -112,7 +108,7 @@ public class QueryBucketsUnaryDispatcher extends QueryV2Dispatcher {
                 }
 
                 // indivisible-oversized: a single bucket bigger than the whole budget cannot be paged.
-                if (pageBuckets.isEmpty() && bucketBytes > byteBudget) {
+                if (pageBuckets.isEmpty() && isIndivisibleOversized(bucketBytes)) {
                     final String msg = "single bucket for pv " + document.getPvName()
                             + " exceeds the outgoing message size limit (" + bucketBytes + " > "
                             + byteBudget + " bytes)";

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QueryBucketsUnaryDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QueryBucketsUnaryDispatcher.java
@@ -1,0 +1,142 @@
+package com.ospreydcs.dp.service.query.handler.mongo.dispatch;
+
+import com.mongodb.client.MongoCursor;
+import com.ospreydcs.dp.grpc.v1.common.DataBucket;
+import com.ospreydcs.dp.grpc.v1.query.QueryBucketsResponse;
+import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
+import com.ospreydcs.dp.service.common.exception.DpException;
+import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.mongo.MongoQueryHandler;
+import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
+import com.ospreydcs.dp.service.query.handler.paging.PageToken;
+import com.ospreydcs.dp.service.query.service.QueryServiceImpl;
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Unary {@code queryBuckets} formatter (Q2/Q7/Q8). Retrieves one bounded, keyset-paged page of
+ * buckets and emits a {@code BucketQueryResult} with a {@code nextPageToken} when more pages follow.
+ *
+ * <p>A page ends when either the count limit ({@code pageSize}) or the outgoing message-size budget
+ * would be exceeded, whichever comes first — both cases emit a normal page with a continuation token
+ * (Q7). Every page emits at least one bucket (zero-progress guard); a single bucket larger than the
+ * whole budget is an indivisible-oversized error. Empty result is an empty payload, not an
+ * ExceptionalResult.
+ */
+public class QueryBucketsUnaryDispatcher extends QueryV2Dispatcher {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final StreamObserver<QueryBucketsResponse> responseObserver;
+    private final long byteBudget;
+
+    public QueryBucketsUnaryDispatcher(StreamObserver<QueryBucketsResponse> responseObserver) {
+        this(responseObserver, MongoQueryHandler.getOutgoingMessageSizeLimitBytes());
+    }
+
+    /**
+     * Package/test constructor allowing the outgoing message-size budget to be injected, so the
+     * byte-budget page-split and indivisible-oversized paths can be exercised deterministically.
+     */
+    public QueryBucketsUnaryDispatcher(StreamObserver<QueryBucketsResponse> responseObserver, long byteBudget) {
+        this.responseObserver = responseObserver;
+        this.byteBudget = byteBudget;
+    }
+
+    @Override
+    public void executeAndDispatch(ResolvedQuery resolvedQuery, MongoQueryClientInterface mongoClient) {
+
+        // A query that resolves to no PVs or no retrieval intervals yields an empty result.
+        if (resolvedQuery.isEmptyResult()) {
+            QueryServiceImpl.sendQueryBucketsResponseEmpty(responseObserver);
+            return;
+        }
+
+        final MongoCursor<BucketDocument> cursor = mongoClient.executeQueryBucketsV2(resolvedQuery);
+        if (cursor == null) {
+            final String msg = "executeQueryBucketsV2 returned null cursor";
+            logger.error(msg + " id: " + responseObserver.hashCode());
+            QueryServiceImpl.sendQueryBucketsResponseError(msg, responseObserver);
+            return;
+        }
+
+        try (cursor) {
+            if (!cursor.hasNext()) {
+                QueryServiceImpl.sendQueryBucketsResponseEmpty(responseObserver);
+                return;
+            }
+
+            final int pageSize = resolvedQuery.getPageSize();
+
+            final List<DataBucket> pageBuckets = new ArrayList<>();
+            long pageBytes = 0;
+            KeysetPosition lastKept = null;
+            boolean hasMore = false;
+
+            while (cursor.hasNext()) {
+                final BucketDocument document = cursor.next();
+
+                // count page-ender: the pageSize+1-th bucket signals a following page exists
+                if (pageBuckets.size() >= pageSize) {
+                    hasMore = true;
+                    break;
+                }
+
+                final DataBucket bucket;
+                try {
+                    bucket = BucketDocument.dataBucketFromDocumentV2(
+                            document,
+                            resolvedQuery.isUseSerializedColumns(),
+                            resolvedQuery.isExcludeColumnMetadata());
+                } catch (DpException e) {
+                    final String msg = "exception building bucket result: " + e.getMessage();
+                    logger.error(msg, e);
+                    QueryServiceImpl.sendQueryBucketsResponseError(msg, responseObserver);
+                    return;
+                }
+
+                final int bucketBytes = bucket.getSerializedSize();
+
+                // byte page-ender: if this bucket would overflow the budget, end the page BEFORE it —
+                // but only if at least one bucket is already in the page (zero-progress guard).
+                if (!pageBuckets.isEmpty() && pageBytes + bucketBytes > byteBudget) {
+                    hasMore = true;
+                    // this bucket was consumed from the cursor but not emitted; the continuation token
+                    // resumes strictly after lastKept, so it will be re-read on the next page.
+                    break;
+                }
+
+                // indivisible-oversized: a single bucket bigger than the whole budget cannot be paged.
+                if (pageBuckets.isEmpty() && bucketBytes > byteBudget) {
+                    final String msg = "single bucket for pv " + document.getPvName()
+                            + " exceeds the outgoing message size limit (" + bucketBytes + " > "
+                            + byteBudget + " bytes)";
+                    logger.error(msg);
+                    QueryServiceImpl.sendQueryBucketsResponseError(msg, responseObserver);
+                    return;
+                }
+
+                pageBuckets.add(bucket);
+                pageBytes += bucketBytes;
+                lastKept = KeysetPosition.ofBucket(
+                        document.getPvName(),
+                        document.getDataTimestamps().getFirstTime().getSeconds(),
+                        document.getDataTimestamps().getFirstTime().getNanos());
+            }
+
+            final String nextPageToken = hasMore && lastKept != null ? PageToken.encode(lastKept) : "";
+
+            final QueryBucketsResponse.BucketQueryResult.Builder resultBuilder =
+                    QueryBucketsResponse.BucketQueryResult.newBuilder()
+                            .addAllDataBuckets(pageBuckets)
+                            .setNextPageToken(nextPageToken);
+
+            QueryServiceImpl.sendQueryBucketsResponse(resultBuilder.build(), responseObserver);
+        }
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
@@ -1,0 +1,170 @@
+package com.ospreydcs.dp.service.query.handler.mongo.dispatch;
+
+import com.mongodb.client.MongoCursor;
+import com.ospreydcs.dp.grpc.v1.common.DataValue;
+import com.ospreydcs.dp.grpc.v1.query.ColumnTable;
+import com.ospreydcs.dp.grpc.v1.query.QuerySamplesResponse;
+import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
+import com.ospreydcs.dp.service.common.exception.DpException;
+import com.ospreydcs.dp.service.common.exception.NonScalarColumnException;
+import com.ospreydcs.dp.service.common.model.TimestampDataMap;
+import com.ospreydcs.dp.service.common.utility.TabularDataUtility;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.mongo.MongoQueryHandler;
+import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
+import com.ospreydcs.dp.service.query.service.QueryServiceImpl;
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Server-streaming {@code querySamplesStream} formatter (Q4/Q5/Q8/Q9). Fire-and-consume: assembles
+ * the complete union table for the whole window <em>once</em> (like V1 queryTable), then emits it in
+ * row-chunks of {@code limit} timestamps — sidestepping the unary path's window-sizing/token
+ * machinery entirely (there is no resumable boundary).
+ *
+ * <p>Column seeding (Q9) is computed once, so the column set and order are trivially stable across
+ * streamed chunks. Each chunk also respects the outgoing message-size budget: a chunk is flushed
+ * before adding a row that would exceed the wire limit, even if it holds fewer than {@code limit}
+ * rows. {@code nextPageToken} is empty on every message (the stream signals completion via
+ * {@code onCompleted}). An empty result emits a single empty message. A non-scalar PV is rejected
+ * (Q4), same as the unary path.
+ *
+ * <p><b>Memory note:</b> this materializes the full table server-side (bounded by heap, not the
+ * per-message byte limit); for very large ranges the bounded-memory, resumable unary
+ * {@code querySamples} is the intended path.
+ */
+public class QuerySamplesStreamDispatcher extends AbstractQuerySamplesDispatcher {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final StreamObserver<QuerySamplesResponse> responseObserver;
+
+    public QuerySamplesStreamDispatcher(StreamObserver<QuerySamplesResponse> responseObserver) {
+        this(responseObserver, MongoQueryHandler.getOutgoingMessageSizeLimitBytes());
+    }
+
+    /** Package/test constructor allowing the outgoing message-size budget to be injected. */
+    public QuerySamplesStreamDispatcher(StreamObserver<QuerySamplesResponse> responseObserver, long byteBudget) {
+        super(byteBudget);
+        this.responseObserver = responseObserver;
+    }
+
+    @Override
+    public void executeAndDispatch(ResolvedQuery resolvedQuery, MongoQueryClientInterface mongoClient) {
+
+        if (resolvedQuery.isEmptyResult()) {
+            emitEmptyChunkAndComplete();
+            return;
+        }
+
+        final long[] window = computeWindow(resolvedQuery);
+
+        final MongoCursor<BucketDocument> cursor =
+                mongoClient.executeQuerySamplesV2(resolvedQuery, window[0], window[1]);
+
+        if (cursor == null) {
+            emitEmptyChunkAndComplete();
+            return;
+        }
+
+        final TimestampDataMap tableValueMap = seededTable(resolvedQuery);
+
+        try (cursor) {
+            // Assemble the full window once. No sizeLimit: streaming materializes the whole table
+            // (memory-bounded, per the class note); the byte budget bounds each emitted chunk, below.
+            TabularDataUtility.addBucketsToTable(
+                    tableValueMap, cursor, 0, null, window[0], window[1], window[2], window[3]);
+        } catch (NonScalarColumnException e) {
+            final String msg = "querySamples supports scalar PVs only: PV '" + e.getPvName()
+                    + "' has non-scalar column type " + e.getColumnType() + "; use queryBuckets";
+            logger.debug(msg);
+            QueryServiceImpl.sendQuerySamplesResponseReject(msg, responseObserver);
+            return;
+        } catch (DpException e) {
+            final String msg = "exception building sample result: " + e.getMessage();
+            logger.error(msg, e);
+            QueryServiceImpl.sendQuerySamplesResponseError(msg, responseObserver);
+            return;
+        }
+
+        final List<long[]> timestamps = collectTimestamps(tableValueMap);
+        if (timestamps.isEmpty()) {
+            emitEmptyChunkAndComplete();
+            return;
+        }
+
+        final int chunkRowLimit = resolvedQuery.getPageSize();
+        final int columnCount = tableValueMap.getColumnNameList().size();
+        final boolean useSerialized = resolvedQuery.isUseSerializedColumns();
+
+        int chunkStart = 0;
+        long chunkBytes = 0;
+
+        for (int rowIndex = 0; rowIndex < timestamps.size(); rowIndex++) {
+            final long rowBytes = rowByteEstimate(tableValueMap, timestamps, rowIndex, columnCount);
+            final int rowsInChunk = rowIndex - chunkStart;
+
+            // byte flush: adding this row would overflow the budget and the chunk already has >= 1 row
+            if (rowsInChunk >= 1 && chunkBytes + rowBytes > byteBudget) {
+                emitChunk(tableValueMap, timestamps, chunkStart, rowIndex, useSerialized);
+                chunkStart = rowIndex;
+                chunkBytes = 0;
+            }
+
+            chunkBytes += rowBytes;
+
+            // count flush: the chunk reached the per-message row limit (inclusive of this row)
+            if (rowIndex - chunkStart + 1 >= chunkRowLimit) {
+                emitChunk(tableValueMap, timestamps, chunkStart, rowIndex + 1, useSerialized);
+                chunkStart = rowIndex + 1;
+                chunkBytes = 0;
+            }
+        }
+
+        // flush the trailing partial chunk
+        if (chunkStart < timestamps.size()) {
+            emitChunk(tableValueMap, timestamps, chunkStart, timestamps.size(), useSerialized);
+        }
+
+        responseObserver.onCompleted();
+    }
+
+    /** Approximate serialized size contributed by one table row (timestamp + per-column values). */
+    private static long rowByteEstimate(
+            TimestampDataMap tableValueMap, List<long[]> timestamps, int rowIndex, int columnCount) {
+        final long second = timestamps.get(rowIndex)[0];
+        final long nano = timestamps.get(rowIndex)[1];
+        long bytes = 12; // rough per-row Timestamp overhead (two varints + framing)
+        final Map<Integer, DataValue> rowValues = tableValueMap.get(second, nano);
+        for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+            final DataValue value = rowValues.get(columnIndex);
+            bytes += (value != null) ? value.getSerializedSize() : 1; // unset value ~ 1 byte of framing
+        }
+        return bytes;
+    }
+
+    private void emitChunk(
+            TimestampDataMap tableValueMap, List<long[]> timestamps,
+            int fromRow, int toRow, boolean useSerialized) {
+        final ColumnTable columnTable = buildColumnTable(tableValueMap, timestamps, fromRow, toRow, useSerialized);
+        emit(columnTable);
+    }
+
+    private void emitEmptyChunkAndComplete() {
+        emit(ColumnTable.getDefaultInstance());
+        responseObserver.onCompleted();
+    }
+
+    private void emit(ColumnTable columnTable) {
+        final QuerySamplesResponse.SampleQueryResult result =
+                QuerySamplesResponse.SampleQueryResult.newBuilder()
+                        .setColumnTable(columnTable)
+                        .setNextPageToken("") // stream signals completion; token always empty
+                        .build();
+        responseObserver.onNext(QueryServiceImpl.querySamplesResponse(result));
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
@@ -98,15 +98,33 @@ public class QuerySamplesStreamDispatcher extends AbstractQuerySamplesDispatcher
         }
 
         final int chunkRowLimit = resolvedQuery.getPageSize();
-        final int columnCount = tableValueMap.getColumnNameList().size();
+        final List<String> columnNames = tableValueMap.getColumnNameList();
+        final int columnCount = columnNames.size();
         final boolean useSerialized = resolvedQuery.isUseSerializedColumns();
+        // fixed per-column overhead (column name + repeated-field framing), counted once per row so
+        // the estimate stays a conservative upper bound of the emitted ColumnTable size.
+        final long perColumnOverhead = columnOverhead(columnNames, useSerialized);
 
         int chunkStart = 0;
         long chunkBytes = 0;
 
         for (int rowIndex = 0; rowIndex < timestamps.size(); rowIndex++) {
-            final long rowBytes = rowByteEstimate(tableValueMap, timestamps, rowIndex, columnCount);
+            final long rowBytes = rowByteEstimate(
+                    tableValueMap, timestamps, rowIndex, columnCount, perColumnOverhead);
             final int rowsInChunk = rowIndex - chunkStart;
+
+            // indivisible-oversized guard (mirrors the buckets streaming dispatcher): a single row
+            // larger than the whole budget cannot be chunked. Error out naming the timestamp rather
+            // than emit an over-limit message that gRPC would abort the whole stream on.
+            if (rowsInChunk == 0 && rowBytes > byteBudget) {
+                final String msg = "single querySamples row at timestamp "
+                        + timestamps.get(rowIndex)[0] + "." + timestamps.get(rowIndex)[1]
+                        + " exceeds the outgoing message size limit (" + rowBytes + " > "
+                        + byteBudget + " bytes); narrow the PV set or time range";
+                logger.error(msg);
+                QueryServiceImpl.sendQuerySamplesResponseError(msg, responseObserver);
+                return;
+            }
 
             // byte flush: adding this row would overflow the budget and the chunk already has >= 1 row
             if (rowsInChunk >= 1 && chunkBytes + rowBytes > byteBudget) {
@@ -133,18 +151,50 @@ public class QuerySamplesStreamDispatcher extends AbstractQuerySamplesDispatcher
         responseObserver.onCompleted();
     }
 
-    /** Approximate serialized size contributed by one table row (timestamp + per-column values). */
+    /**
+     * Conservative <b>upper bound</b> on the serialized size one table row contributes to the emitted
+     * {@link ColumnTable} — the timestamp entry plus, for every column, the value's serialized size
+     * (or the unset-value framing) and this row's share of the per-column name/framing overhead
+     * ({@code perColumnOverhead}, precomputed by {@link #columnOverhead}). It must not under-count:
+     * the chunk boundary relies on it to keep each emitted message under the gRPC wire limit.
+     */
     private static long rowByteEstimate(
-            TimestampDataMap tableValueMap, List<long[]> timestamps, int rowIndex, int columnCount) {
+            TimestampDataMap tableValueMap, List<long[]> timestamps, int rowIndex, int columnCount,
+            long perColumnOverhead) {
         final long second = timestamps.get(rowIndex)[0];
         final long nano = timestamps.get(rowIndex)[1];
-        long bytes = 12; // rough per-row Timestamp overhead (two varints + framing)
+        // Timestamp: two int64 fields (up to 10 bytes varint each) + field tags/length framing.
+        long bytes = 24;
         final Map<Integer, DataValue> rowValues = tableValueMap.get(second, nano);
         for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
             final DataValue value = rowValues.get(columnIndex);
-            bytes += (value != null) ? value.getSerializedSize() : 1; // unset value ~ 1 byte of framing
+            // value payload + repeated DataValue tag+length framing (a few bytes); unset value is one
+            // empty DataValue message which still costs its framing.
+            bytes += ((value != null) ? value.getSerializedSize() : 0) + 6;
         }
-        return bytes;
+        return bytes + perColumnOverhead;
+    }
+
+    /**
+     * Per-row share of the fixed per-column overhead: each emitted column carries its UTF-8 name and
+     * repeated-field framing regardless of how many rows it holds. Amortizing the whole overhead onto
+     * every row keeps {@link #rowByteEstimate} a strict upper bound (a chunk of N rows is charged N×
+     * the overhead, never less than the single copy actually emitted). Under
+     * {@code useSerializedColumns} each column is additionally wrapped in a {@code SerializedDataColumn}
+     * (name + payload framing), so the per-column overhead is larger.
+     */
+    private static long columnOverhead(List<String> columnNames, boolean useSerialized) {
+        long overhead = 0;
+        for (String name : columnNames) {
+            final long nameBytes = name.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+            // column name field (tag+len+bytes) + repeated-column tag/length framing; serialized
+            // columns pay it twice (inner DataColumn name + outer SerializedDataColumn name/payload).
+            overhead += nameBytes + 8;
+            if (useSerialized) {
+                overhead += nameBytes + 8;
+            }
+        }
+        return overhead;
     }
 
     private void emitChunk(

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesUnaryDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesUnaryDispatcher.java
@@ -1,0 +1,234 @@
+package com.ospreydcs.dp.service.query.handler.mongo.dispatch;
+
+import com.mongodb.client.MongoCursor;
+import com.ospreydcs.dp.grpc.v1.common.DataColumn;
+import com.ospreydcs.dp.grpc.v1.common.DataValue;
+import com.ospreydcs.dp.grpc.v1.common.SerializedDataColumn;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.grpc.v1.common.TimestampList;
+import com.ospreydcs.dp.grpc.v1.query.ColumnTable;
+import com.ospreydcs.dp.grpc.v1.query.QuerySamplesResponse;
+import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
+import com.ospreydcs.dp.service.common.exception.DpException;
+import com.ospreydcs.dp.service.common.exception.NonScalarColumnException;
+import com.ospreydcs.dp.service.common.model.TimestampDataMap;
+import com.ospreydcs.dp.service.common.utility.TabularDataUtility;
+import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
+import com.ospreydcs.dp.service.query.handler.mongo.MongoQueryHandler;
+import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
+import com.ospreydcs.dp.service.query.handler.paging.PageToken;
+import com.ospreydcs.dp.service.query.service.QueryServiceImpl;
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unary {@code querySamples} formatter (Q1/Q4/Q5/Q7/Q8/Q9). Assembles one bounded page of aligned
+ * sample data — a column table over the resolved PV set, trimmed to the half-open query window — and
+ * emits a {@code SampleQueryResult} with a timestamp-advanced {@code nextPageToken} when more rows
+ * follow.
+ *
+ * <p><b>Paging (Q1, drain-then-truncate):</b> query the page window {@code [windowBegin, end)},
+ * assemble into a timestamp-ordered map, keep the first {@code pageSize} distinct timestamps (soft
+ * cap — a timestamp is never split across pages), and set the token to the timestamp immediately
+ * after the last kept row. The byte budget is a second stop condition (Q7): if assembly hits it the
+ * last (possibly incomplete) timestamp is dropped and becomes the resume point, so no partial row is
+ * emitted.
+ *
+ * <p><b>Column seeding (Q9):</b> every resolved PV gets a column (sorted by name), all-unset where it
+ * has no sample at a given row, by pre-seeding the column index map from the resolved PV list.
+ *
+ * <p><b>Non-scalar reject (Q4):</b> a {@link NonScalarColumnException} during assembly becomes a
+ * clean {@code querySamples}-specific reject naming the PV and pointing at {@code queryBuckets}.
+ *
+ * <p><b>excludeColumnMetadata (Q8)</b> is inert — the tabular path carries no column metadata.
+ */
+public class QuerySamplesUnaryDispatcher extends QueryV2Dispatcher {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final StreamObserver<QuerySamplesResponse> responseObserver;
+    private final long byteBudget;
+
+    public QuerySamplesUnaryDispatcher(StreamObserver<QuerySamplesResponse> responseObserver) {
+        this(responseObserver, MongoQueryHandler.getOutgoingMessageSizeLimitBytes());
+    }
+
+    /** Package/test constructor allowing the outgoing message-size budget to be injected. */
+    public QuerySamplesUnaryDispatcher(StreamObserver<QuerySamplesResponse> responseObserver, long byteBudget) {
+        this.responseObserver = responseObserver;
+        this.byteBudget = byteBudget;
+    }
+
+    @Override
+    public void executeAndDispatch(ResolvedQuery resolvedQuery, MongoQueryClientInterface mongoClient) {
+
+        if (resolvedQuery.isEmptyResult()) {
+            QueryServiceImpl.sendQuerySamplesResponseEmpty(responseObserver);
+            return;
+        }
+
+        // Page window: begin = resume timestamp (from token) or the earliest fragment begin; end =
+        // the latest fragment end. Fragments are disjoint and sorted, so the union window is
+        // [min begin, max end); executeQuerySamplesV2 re-applies the exact per-fragment overlap.
+        final List<TimeInterval> intervals = resolvedQuery.getRetrievalIntervals();
+        final KeysetPosition pageStart = resolvedQuery.getPageStart();
+        final long windowBeginSecs;
+        final long windowBeginNanos;
+        if (pageStart != null) {
+            windowBeginSecs = pageStart.getSeconds();
+            windowBeginNanos = pageStart.getNanos();
+        } else {
+            windowBeginSecs = intervals.get(0).getBeginSeconds();
+            windowBeginNanos = intervals.get(0).getBeginNanos();
+        }
+        long windowEndSecs = intervals.get(0).getEndSeconds();
+        long windowEndNanos = intervals.get(0).getEndNanos();
+        for (TimeInterval iv : intervals) {
+            if (TimeInterval.compareInstant(iv.getEndSeconds(), iv.getEndNanos(), windowEndSecs, windowEndNanos) > 0) {
+                windowEndSecs = iv.getEndSeconds();
+                windowEndNanos = iv.getEndNanos();
+            }
+        }
+
+        final MongoCursor<BucketDocument> cursor =
+                mongoClient.executeQuerySamplesV2(resolvedQuery, windowBeginSecs, windowBeginNanos);
+
+        if (cursor == null) {
+            // no buckets overlap the window → empty page (last page)
+            QueryServiceImpl.sendQuerySamplesResponseEmpty(responseObserver);
+            return;
+        }
+
+        // Seed the column set from the resolved PV list (sorted) so every resolved PV gets a column
+        // in a stable order, even if it has no sample in this page (Q9).
+        final TimestampDataMap tableValueMap = new TimestampDataMap();
+        for (String pvName : resolvedQuery.getPvNames()) {
+            tableValueMap.getColumnIndex(pvName);
+        }
+
+        final boolean byteBudgetHit;
+        try (cursor) {
+            final TabularDataUtility.TimestampDataMapSizeStats sizeStats = TabularDataUtility.addBucketsToTable(
+                    tableValueMap,
+                    cursor,
+                    0,
+                    (int) Math.min(Integer.MAX_VALUE, byteBudget),
+                    windowBeginSecs,
+                    windowBeginNanos,
+                    windowEndSecs,
+                    windowEndNanos);
+            byteBudgetHit = sizeStats.sizeLimitExceeded();
+        } catch (NonScalarColumnException e) {
+            // Q4: scalar-only. Translate the neutral shared exception into querySamples guidance.
+            final String msg = "querySamples supports scalar PVs only: PV '" + e.getPvName()
+                    + "' has non-scalar column type " + e.getColumnType() + "; use queryBuckets";
+            logger.debug(msg);
+            QueryServiceImpl.sendQuerySamplesResponseReject(msg, responseObserver);
+            return;
+        } catch (DpException e) {
+            final String msg = "exception building sample result: " + e.getMessage();
+            logger.error(msg, e);
+            QueryServiceImpl.sendQuerySamplesResponseError(msg, responseObserver);
+            return;
+        }
+
+        emitPage(resolvedQuery, tableValueMap, byteBudgetHit);
+    }
+
+    /**
+     * Truncates the assembled map to at most {@code pageSize} distinct timestamps and emits the V2
+     * ColumnTable. Sets the {@code nextPageToken} to the first dropped timestamp (empty if none).
+     */
+    private void emitPage(ResolvedQuery resolvedQuery, TimestampDataMap tableValueMap, boolean byteBudgetHit) {
+
+        final int pageSize = resolvedQuery.getPageSize();
+
+        // Collect distinct (second, nano) timestamps in sorted order.
+        final List<long[]> allTimestamps = new ArrayList<>();
+        for (Map.Entry<Long, Map<Long, Map<Integer, DataValue>>> secondEntry : tableValueMap.entrySet()) {
+            final long second = secondEntry.getKey();
+            for (Long nano : secondEntry.getValue().keySet()) {
+                allTimestamps.add(new long[]{second, nano});
+            }
+        }
+
+        // Determine how many rows to keep and the resume point.
+        int keepCount = allTimestamps.size();
+        long[] resumeAt = null;
+
+        if (allTimestamps.size() > pageSize) {
+            // count-driven page boundary: keep pageSize rows, resume at the next timestamp
+            keepCount = pageSize;
+            resumeAt = allTimestamps.get(pageSize);
+        } else if (byteBudgetHit && !allTimestamps.isEmpty()) {
+            // byte-driven boundary: the last assembled timestamp may be incomplete (later buckets
+            // that would contribute to it were not drained), so drop it and resume there. Keep >= 1
+            // row (zero-progress guard): if only one timestamp assembled under the byte cap, we still
+            // drop it and resume — the next page re-queries from it with a fresh budget.
+            keepCount = allTimestamps.size() - 1;
+            resumeAt = allTimestamps.get(allTimestamps.size() - 1);
+        }
+
+        // Build the V2 ColumnTable from the kept rows.
+        final List<String> columnNames = tableValueMap.getColumnNameList();
+        final TimestampList.Builder timestampListBuilder = TimestampList.newBuilder();
+        final List<DataColumn.Builder> columnBuilders = new ArrayList<>(columnNames.size());
+        for (String name : columnNames) {
+            columnBuilders.add(DataColumn.newBuilder().setName(name));
+        }
+
+        for (int rowIndex = 0; rowIndex < keepCount; rowIndex++) {
+            final long second = allTimestamps.get(rowIndex)[0];
+            final long nano = allTimestamps.get(rowIndex)[1];
+            timestampListBuilder.addTimestamps(
+                    Timestamp.newBuilder().setEpochSeconds(second).setNanoseconds(nano).build());
+            final Map<Integer, DataValue> rowValues = tableValueMap.get(second, nano);
+            for (int columnIndex = 0; columnIndex < columnBuilders.size(); columnIndex++) {
+                DataValue value = rowValues.get(columnIndex);
+                if (value == null) {
+                    value = DataValue.newBuilder().build(); // unset => missing sample (Q9)
+                }
+                columnBuilders.get(columnIndex).addDataValues(value);
+            }
+        }
+
+        final ColumnTable.Builder columnTableBuilder = ColumnTable.newBuilder()
+                .setTimestampList(timestampListBuilder.build());
+
+        if (resolvedQuery.isUseSerializedColumns()) {
+            // Q5: serialize each assembled column into serializedDataColumns; populate exactly one of
+            // the two lists. Empty encoding — no meaningful per-column encoding for a synthesized
+            // sample column; present for API symmetry with the bucket path, not as a perf optimization.
+            for (DataColumn.Builder columnBuilder : columnBuilders) {
+                final DataColumn column = columnBuilder.build();
+                columnTableBuilder.addSerializedDataColumns(SerializedDataColumn.newBuilder()
+                        .setName(column.getName())
+                        .setPayload(column.toByteString())
+                        .build());
+            }
+        } else {
+            for (DataColumn.Builder columnBuilder : columnBuilders) {
+                columnTableBuilder.addDataColumns(columnBuilder.build());
+            }
+        }
+
+        final String nextPageToken = (resumeAt != null)
+                ? PageToken.encode(KeysetPosition.ofSample(resumeAt[0], resumeAt[1]))
+                : "";
+
+        final QuerySamplesResponse.SampleQueryResult result =
+                QuerySamplesResponse.SampleQueryResult.newBuilder()
+                        .setColumnTable(columnTableBuilder.build())
+                        .setNextPageToken(nextPageToken)
+                        .build();
+
+        QueryServiceImpl.sendQuerySamplesResponse(result, responseObserver);
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesUnaryDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesUnaryDispatcher.java
@@ -1,11 +1,6 @@
 package com.ospreydcs.dp.service.query.handler.mongo.dispatch;
 
 import com.mongodb.client.MongoCursor;
-import com.ospreydcs.dp.grpc.v1.common.DataColumn;
-import com.ospreydcs.dp.grpc.v1.common.DataValue;
-import com.ospreydcs.dp.grpc.v1.common.SerializedDataColumn;
-import com.ospreydcs.dp.grpc.v1.common.Timestamp;
-import com.ospreydcs.dp.grpc.v1.common.TimestampList;
 import com.ospreydcs.dp.grpc.v1.query.ColumnTable;
 import com.ospreydcs.dp.grpc.v1.query.QuerySamplesResponse;
 import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
@@ -15,7 +10,6 @@ import com.ospreydcs.dp.service.common.model.TimestampDataMap;
 import com.ospreydcs.dp.service.common.utility.TabularDataUtility;
 import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
 import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
-import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
 import com.ospreydcs.dp.service.query.handler.mongo.MongoQueryHandler;
 import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
 import com.ospreydcs.dp.service.query.handler.paging.PageToken;
@@ -24,9 +18,7 @@ import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Unary {@code querySamples} formatter (Q1/Q4/Q5/Q7/Q8/Q9). Assembles one bounded page of aligned
@@ -41,20 +33,19 @@ import java.util.Map;
  * last (possibly incomplete) timestamp is dropped and becomes the resume point, so no partial row is
  * emitted.
  *
- * <p><b>Column seeding (Q9):</b> every resolved PV gets a column (sorted by name), all-unset where it
- * has no sample at a given row, by pre-seeding the column index map from the resolved PV list.
+ * <p><b>Column seeding (Q9)</b> and the V2 {@link ColumnTable} build (incl. useSerializedColumns, Q5)
+ * are shared with the streaming dispatcher via {@link AbstractQuerySamplesDispatcher}.
  *
  * <p><b>Non-scalar reject (Q4):</b> a {@link NonScalarColumnException} during assembly becomes a
  * clean {@code querySamples}-specific reject naming the PV and pointing at {@code queryBuckets}.
  *
  * <p><b>excludeColumnMetadata (Q8)</b> is inert — the tabular path carries no column metadata.
  */
-public class QuerySamplesUnaryDispatcher extends QueryV2Dispatcher {
+public class QuerySamplesUnaryDispatcher extends AbstractQuerySamplesDispatcher {
 
     private static final Logger logger = LogManager.getLogger();
 
     private final StreamObserver<QuerySamplesResponse> responseObserver;
-    private final long byteBudget;
 
     public QuerySamplesUnaryDispatcher(StreamObserver<QuerySamplesResponse> responseObserver) {
         this(responseObserver, MongoQueryHandler.getOutgoingMessageSizeLimitBytes());
@@ -62,8 +53,8 @@ public class QuerySamplesUnaryDispatcher extends QueryV2Dispatcher {
 
     /** Package/test constructor allowing the outgoing message-size budget to be injected. */
     public QuerySamplesUnaryDispatcher(StreamObserver<QuerySamplesResponse> responseObserver, long byteBudget) {
+        super(byteBudget);
         this.responseObserver = responseObserver;
-        this.byteBudget = byteBudget;
     }
 
     @Override
@@ -74,28 +65,11 @@ public class QuerySamplesUnaryDispatcher extends QueryV2Dispatcher {
             return;
         }
 
-        // Page window: begin = resume timestamp (from token) or the earliest fragment begin; end =
-        // the latest fragment end. Fragments are disjoint and sorted, so the union window is
-        // [min begin, max end); executeQuerySamplesV2 re-applies the exact per-fragment overlap.
-        final List<TimeInterval> intervals = resolvedQuery.getRetrievalIntervals();
-        final KeysetPosition pageStart = resolvedQuery.getPageStart();
-        final long windowBeginSecs;
-        final long windowBeginNanos;
-        if (pageStart != null) {
-            windowBeginSecs = pageStart.getSeconds();
-            windowBeginNanos = pageStart.getNanos();
-        } else {
-            windowBeginSecs = intervals.get(0).getBeginSeconds();
-            windowBeginNanos = intervals.get(0).getBeginNanos();
-        }
-        long windowEndSecs = intervals.get(0).getEndSeconds();
-        long windowEndNanos = intervals.get(0).getEndNanos();
-        for (TimeInterval iv : intervals) {
-            if (TimeInterval.compareInstant(iv.getEndSeconds(), iv.getEndNanos(), windowEndSecs, windowEndNanos) > 0) {
-                windowEndSecs = iv.getEndSeconds();
-                windowEndNanos = iv.getEndNanos();
-            }
-        }
+        final long[] window = computeWindow(resolvedQuery);
+        final long windowBeginSecs = window[0];
+        final long windowBeginNanos = window[1];
+        final long windowEndSecs = window[2];
+        final long windowEndNanos = window[3];
 
         final MongoCursor<BucketDocument> cursor =
                 mongoClient.executeQuerySamplesV2(resolvedQuery, windowBeginSecs, windowBeginNanos);
@@ -106,12 +80,7 @@ public class QuerySamplesUnaryDispatcher extends QueryV2Dispatcher {
             return;
         }
 
-        // Seed the column set from the resolved PV list (sorted) so every resolved PV gets a column
-        // in a stable order, even if it has no sample in this page (Q9).
-        final TimestampDataMap tableValueMap = new TimestampDataMap();
-        for (String pvName : resolvedQuery.getPvNames()) {
-            tableValueMap.getColumnIndex(pvName);
-        }
+        final TimestampDataMap tableValueMap = seededTable(resolvedQuery);
 
         final boolean byteBudgetHit;
         try (cursor) {
@@ -149,17 +118,8 @@ public class QuerySamplesUnaryDispatcher extends QueryV2Dispatcher {
     private void emitPage(ResolvedQuery resolvedQuery, TimestampDataMap tableValueMap, boolean byteBudgetHit) {
 
         final int pageSize = resolvedQuery.getPageSize();
+        final List<long[]> allTimestamps = collectTimestamps(tableValueMap);
 
-        // Collect distinct (second, nano) timestamps in sorted order.
-        final List<long[]> allTimestamps = new ArrayList<>();
-        for (Map.Entry<Long, Map<Long, Map<Integer, DataValue>>> secondEntry : tableValueMap.entrySet()) {
-            final long second = secondEntry.getKey();
-            for (Long nano : secondEntry.getValue().keySet()) {
-                allTimestamps.add(new long[]{second, nano});
-            }
-        }
-
-        // Determine how many rows to keep and the resume point.
         int keepCount = allTimestamps.size();
         long[] resumeAt = null;
 
@@ -169,55 +129,13 @@ public class QuerySamplesUnaryDispatcher extends QueryV2Dispatcher {
             resumeAt = allTimestamps.get(pageSize);
         } else if (byteBudgetHit && !allTimestamps.isEmpty()) {
             // byte-driven boundary: the last assembled timestamp may be incomplete (later buckets
-            // that would contribute to it were not drained), so drop it and resume there. Keep >= 1
-            // row (zero-progress guard): if only one timestamp assembled under the byte cap, we still
-            // drop it and resume — the next page re-queries from it with a fresh budget.
+            // that would contribute to it were not drained), so drop it and resume there.
             keepCount = allTimestamps.size() - 1;
             resumeAt = allTimestamps.get(allTimestamps.size() - 1);
         }
 
-        // Build the V2 ColumnTable from the kept rows.
-        final List<String> columnNames = tableValueMap.getColumnNameList();
-        final TimestampList.Builder timestampListBuilder = TimestampList.newBuilder();
-        final List<DataColumn.Builder> columnBuilders = new ArrayList<>(columnNames.size());
-        for (String name : columnNames) {
-            columnBuilders.add(DataColumn.newBuilder().setName(name));
-        }
-
-        for (int rowIndex = 0; rowIndex < keepCount; rowIndex++) {
-            final long second = allTimestamps.get(rowIndex)[0];
-            final long nano = allTimestamps.get(rowIndex)[1];
-            timestampListBuilder.addTimestamps(
-                    Timestamp.newBuilder().setEpochSeconds(second).setNanoseconds(nano).build());
-            final Map<Integer, DataValue> rowValues = tableValueMap.get(second, nano);
-            for (int columnIndex = 0; columnIndex < columnBuilders.size(); columnIndex++) {
-                DataValue value = rowValues.get(columnIndex);
-                if (value == null) {
-                    value = DataValue.newBuilder().build(); // unset => missing sample (Q9)
-                }
-                columnBuilders.get(columnIndex).addDataValues(value);
-            }
-        }
-
-        final ColumnTable.Builder columnTableBuilder = ColumnTable.newBuilder()
-                .setTimestampList(timestampListBuilder.build());
-
-        if (resolvedQuery.isUseSerializedColumns()) {
-            // Q5: serialize each assembled column into serializedDataColumns; populate exactly one of
-            // the two lists. Empty encoding — no meaningful per-column encoding for a synthesized
-            // sample column; present for API symmetry with the bucket path, not as a perf optimization.
-            for (DataColumn.Builder columnBuilder : columnBuilders) {
-                final DataColumn column = columnBuilder.build();
-                columnTableBuilder.addSerializedDataColumns(SerializedDataColumn.newBuilder()
-                        .setName(column.getName())
-                        .setPayload(column.toByteString())
-                        .build());
-            }
-        } else {
-            for (DataColumn.Builder columnBuilder : columnBuilders) {
-                columnTableBuilder.addDataColumns(columnBuilder.build());
-            }
-        }
+        final ColumnTable columnTable = buildColumnTable(
+                tableValueMap, allTimestamps, 0, keepCount, resolvedQuery.isUseSerializedColumns());
 
         final String nextPageToken = (resumeAt != null)
                 ? PageToken.encode(KeysetPosition.ofSample(resumeAt[0], resumeAt[1]))
@@ -225,7 +143,7 @@ public class QuerySamplesUnaryDispatcher extends QueryV2Dispatcher {
 
         final QuerySamplesResponse.SampleQueryResult result =
                 QuerySamplesResponse.SampleQueryResult.newBuilder()
-                        .setColumnTable(columnTableBuilder.build())
+                        .setColumnTable(columnTable)
                         .setNextPageToken(nextPageToken)
                         .build();
 

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesUnaryDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesUnaryDispatcher.java
@@ -132,6 +132,21 @@ public class QuerySamplesUnaryDispatcher extends AbstractQuerySamplesDispatcher 
             // that would contribute to it were not drained), so drop it and resume there.
             keepCount = allTimestamps.size() - 1;
             resumeAt = allTimestamps.get(allTimestamps.size() - 1);
+
+            // Indivisible-oversized guard (mirrors the buckets dispatchers' isIndivisibleOversized):
+            // if dropping the last timestamp leaves nothing to emit, this single row is larger than
+            // the whole byte budget. Dropping it and resuming there would re-assemble the identical
+            // oversized row on the next page and hit the same boundary forever (zero forward
+            // progress). Error out instead, naming the timestamp, rather than loop empty pages.
+            if (keepCount == 0) {
+                final String msg = "single querySamples row at timestamp "
+                        + resumeAt[0] + "." + resumeAt[1]
+                        + " exceeds the outgoing message size limit (" + byteBudget
+                        + " bytes); narrow the PV set or time range";
+                logger.error(msg);
+                QueryServiceImpl.sendQuerySamplesResponseError(msg, responseObserver);
+                return;
+            }
         }
 
         final ColumnTable columnTable = buildColumnTable(

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QueryV2Dispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QueryV2Dispatcher.java
@@ -1,0 +1,22 @@
+package com.ospreydcs.dp.service.query.handler.mongo.dispatch;
+
+import com.ospreydcs.dp.service.common.handler.Dispatcher;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
+
+/**
+ * Base class for Query API V2 result dispatchers (formatters). A single {@code QueryV2Job} drives any
+ * V2 query by delegating to {@link #executeAndDispatch}: the concrete dispatcher owns both its
+ * retrieval strategy (bucket keyset paging vs. sample timestamp-window assembly) and its response
+ * formatting, so bucket-vs-sample and unary-vs-stream are dispatcher variants over one job.
+ */
+public abstract class QueryV2Dispatcher extends Dispatcher {
+
+    /**
+     * Executes retrieval for the resolved query against the given client and dispatches the formatted
+     * response(s) to the response observer, closing the stream. Implementations must handle the empty
+     * result (empty payload, not an ExceptionalResult) and any retrieval/formatting error
+     * (ExceptionalResult) themselves.
+     */
+    public abstract void executeAndDispatch(ResolvedQuery resolvedQuery, MongoQueryClientInterface mongoClient);
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/job/QueryV2Job.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/job/QueryV2Job.java
@@ -1,0 +1,38 @@
+package com.ospreydcs.dp.service.query.handler.mongo.job;
+
+import com.ospreydcs.dp.service.common.handler.HandlerJob;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
+import com.ospreydcs.dp.service.query.handler.mongo.dispatch.QueryV2Dispatcher;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Shared worker job for all Query API V2 methods. Carries the resolved query and an injected V2
+ * dispatcher; on execution it hands both the resolved query and the client to the dispatcher, which
+ * owns retrieval and formatting (bucket vs. sample, unary vs. stream). One job, many dispatcher
+ * variants — mirroring how {@code QueryDataJob} serves the V1 unary/stream/bidi paths.
+ */
+public class QueryV2Job extends HandlerJob {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final ResolvedQuery resolvedQuery;
+    private final QueryV2Dispatcher dispatcher;
+    private final MongoQueryClientInterface mongoClient;
+
+    public QueryV2Job(
+            ResolvedQuery resolvedQuery,
+            QueryV2Dispatcher dispatcher,
+            MongoQueryClientInterface mongoClient) {
+        this.resolvedQuery = resolvedQuery;
+        this.dispatcher = dispatcher;
+        this.mongoClient = mongoClient;
+    }
+
+    @Override
+    public void execute() {
+        logger.debug("executing QueryV2Job");
+        dispatcher.executeAndDispatch(resolvedQuery, mongoClient);
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/paging/PageToken.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/paging/PageToken.java
@@ -1,0 +1,136 @@
+package com.ospreydcs.dp.service.query.handler.paging;
+
+import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Opaque, position-only codec for Query API V2 page tokens (Q1/Q2/Q3). Encodes a
+ * {@link KeysetPosition} to a URL-safe Base64 string and back. The token carries only a position —
+ * never server state — so a future server-side cached-cursor implementation can accept the same
+ * token as a cache-miss fallback with no proto or client change.
+ *
+ * <p>Wire format (before Base64): a version byte, a kind marker, then the fields. The bucket pvName
+ * is length-prefixed rather than delimited so arbitrary pvName characters (including delimiters)
+ * round-trip exactly. The exact byte layout is an implementation detail — callers must treat the
+ * emitted string as opaque.
+ */
+public class PageToken {
+
+    // Wire format version — bump if the layout changes so stale tokens are rejected, not misread.
+    private static final char VERSION = '1';
+    private static final char KIND_BUCKET = 'B';
+    private static final char KIND_SAMPLE = 'S';
+    private static final char SEP = '|';
+
+    private PageToken() {
+    }
+
+    /** Encodes a keyset position to an opaque URL-safe Base64 token. */
+    public static String encode(KeysetPosition position) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(VERSION).append(SEP);
+        switch (position.getKind()) {
+            case BUCKET -> {
+                final String pvName = position.getPvName() == null ? "" : position.getPvName();
+                sb.append(KIND_BUCKET).append(SEP);
+                // length-prefix the pvName so it may contain any character, including SEP
+                sb.append(pvName.length()).append(SEP).append(pvName).append(SEP);
+                sb.append(position.getSeconds()).append(SEP).append(position.getNanos());
+            }
+            case SAMPLE -> {
+                sb.append(KIND_SAMPLE).append(SEP);
+                sb.append(position.getSeconds()).append(SEP).append(position.getNanos());
+            }
+        }
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(sb.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Decodes an opaque token back to a keyset position. A blank token is not a valid position and
+     * callers should check {@code isEmpty()} on the raw token before calling this.
+     *
+     * @throws PageTokenException if the token is null/blank or cannot be parsed (malformed → reject).
+     */
+    public static KeysetPosition decode(String token) throws PageTokenException {
+        if (token == null || token.isBlank()) {
+            throw new PageTokenException("page token is empty");
+        }
+
+        final String decoded;
+        try {
+            decoded = new String(Base64.getUrlDecoder().decode(token), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ex) {
+            throw new PageTokenException("page token is not valid Base64", ex);
+        }
+
+        try {
+            int pos = 0;
+
+            // version
+            final int v1 = decoded.indexOf(SEP, pos);
+            if (v1 < 0) {
+                throw new PageTokenException("malformed page token (no version separator)");
+            }
+            final String version = decoded.substring(pos, v1);
+            if (!version.equals(String.valueOf(VERSION))) {
+                throw new PageTokenException("unsupported page token version: " + version);
+            }
+            pos = v1 + 1;
+
+            // kind
+            final int k1 = decoded.indexOf(SEP, pos);
+            if (k1 < 0) {
+                throw new PageTokenException("malformed page token (no kind separator)");
+            }
+            final String kind = decoded.substring(pos, k1);
+            pos = k1 + 1;
+
+            if (kind.equals(String.valueOf(KIND_BUCKET))) {
+                // length-prefixed pvName
+                final int len1 = decoded.indexOf(SEP, pos);
+                if (len1 < 0) {
+                    throw new PageTokenException("malformed bucket token (no pvName length)");
+                }
+                final int nameLen = Integer.parseInt(decoded.substring(pos, len1));
+                pos = len1 + 1;
+                if (nameLen < 0 || pos + nameLen > decoded.length()) {
+                    throw new PageTokenException("malformed bucket token (bad pvName length)");
+                }
+                final String pvName = decoded.substring(pos, pos + nameLen);
+                pos += nameLen;
+                if (pos >= decoded.length() || decoded.charAt(pos) != SEP) {
+                    throw new PageTokenException("malformed bucket token (pvName not terminated)");
+                }
+                pos += 1; // skip SEP after pvName
+
+                final int s1 = decoded.indexOf(SEP, pos);
+                if (s1 < 0) {
+                    throw new PageTokenException("malformed bucket token (no seconds separator)");
+                }
+                final long seconds = Long.parseLong(decoded.substring(pos, s1));
+                final long nanos = Long.parseLong(decoded.substring(s1 + 1));
+                return KeysetPosition.ofBucket(pvName, seconds, nanos);
+
+            } else if (kind.equals(String.valueOf(KIND_SAMPLE))) {
+                final int s1 = decoded.indexOf(SEP, pos);
+                if (s1 < 0) {
+                    throw new PageTokenException("malformed sample token (no seconds separator)");
+                }
+                final long seconds = Long.parseLong(decoded.substring(pos, s1));
+                final long nanos = Long.parseLong(decoded.substring(s1 + 1));
+                return KeysetPosition.ofSample(seconds, nanos);
+
+            } else {
+                throw new PageTokenException("unknown page token kind: " + kind);
+            }
+
+        } catch (NumberFormatException ex) {
+            throw new PageTokenException("malformed page token (non-numeric field)", ex);
+        } catch (IndexOutOfBoundsException ex) {
+            throw new PageTokenException("malformed page token (truncated)", ex);
+        }
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/paging/PageTokenException.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/paging/PageTokenException.java
@@ -1,0 +1,16 @@
+package com.ospreydcs.dp.service.query.handler.paging;
+
+/**
+ * Thrown when an inbound page token cannot be decoded. The resolver translates this into an
+ * {@code ExceptionalResult} reject rather than silently treating a malformed token as "first page"
+ * (Q1/Q2/Q3: malformed inbound token → reject).
+ */
+public class PageTokenException extends Exception {
+    public PageTokenException(String message) {
+        super(message);
+    }
+
+    public PageTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/service/QueryServiceImpl.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/service/QueryServiceImpl.java
@@ -184,6 +184,76 @@ public class QueryServiceImpl extends DpQueryServiceGrpc.DpQueryServiceImplBase 
         handler.handleQueryBucketsStream(request, responseObserver);
     }
 
+    // ---- Query API V2: querySamples response helpers ----
+
+    private static QuerySamplesResponse querySamplesResponseExceptionalResult(
+            String msg, ExceptionalResult.ExceptionalResultStatus status
+    ) {
+        final ExceptionalResult exceptionalResult = ExceptionalResult.newBuilder()
+                .setExceptionalResultStatus(status)
+                .setMessage(msg)
+                .build();
+
+        return QuerySamplesResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setExceptionalResult(exceptionalResult)
+                .build();
+    }
+
+    public static QuerySamplesResponse querySamplesResponseReject(String msg) {
+        return querySamplesResponseExceptionalResult(
+                msg, ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT);
+    }
+
+    public static QuerySamplesResponse querySamplesResponseError(String msg) {
+        return querySamplesResponseExceptionalResult(
+                msg, ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR);
+    }
+
+    public static QuerySamplesResponse querySamplesResponse(
+            QuerySamplesResponse.SampleQueryResult sampleQueryResult
+    ) {
+        return QuerySamplesResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setSampleQueryResult(sampleQueryResult)
+                .build();
+    }
+
+    public static void sendQuerySamplesResponseReject(
+            String msg, StreamObserver<QuerySamplesResponse> responseObserver) {
+        responseObserver.onNext(querySamplesResponseReject(msg));
+        responseObserver.onCompleted();
+    }
+
+    public static void sendQuerySamplesResponseError(
+            String msg, StreamObserver<QuerySamplesResponse> responseObserver) {
+        responseObserver.onNext(querySamplesResponseError(msg));
+        responseObserver.onCompleted();
+    }
+
+    public static void sendQuerySamplesResponse(
+            QuerySamplesResponse.SampleQueryResult sampleQueryResult,
+            StreamObserver<QuerySamplesResponse> responseObserver
+    ) {
+        responseObserver.onNext(querySamplesResponse(sampleQueryResult));
+        responseObserver.onCompleted();
+    }
+
+    /** Empty result is a normal (empty) ColumnTable payload, NOT an ExceptionalResult. */
+    public static void sendQuerySamplesResponseEmpty(
+            StreamObserver<QuerySamplesResponse> responseObserver) {
+        responseObserver.onNext(querySamplesResponse(
+                QuerySamplesResponse.SampleQueryResult.getDefaultInstance()));
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void querySamples(QuerySamplesRequest request, StreamObserver<QuerySamplesResponse> responseObserver) {
+        logger.debug("querySamples request received id: {}", responseObserver.hashCode());
+        // validation + resolution happens in the handler (it owns the resolver and mongo client).
+        handler.handleQuerySamples(request, responseObserver);
+    }
+
     private static QueryTableResponse queryTableResponseExceptionalResult(
             String msg, ExceptionalResult.ExceptionalResultStatus status
     ) {

--- a/src/main/java/com/ospreydcs/dp/service/query/service/QueryServiceImpl.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/service/QueryServiceImpl.java
@@ -104,6 +104,77 @@ public class QueryServiceImpl extends DpQueryServiceGrpc.DpQueryServiceImplBase 
         responseObserver.onNext(response);
     }
 
+    // ---- Query API V2: queryBuckets response helpers ----
+
+    private static QueryBucketsResponse queryBucketsResponseExceptionalResult(
+            String msg, ExceptionalResult.ExceptionalResultStatus status
+    ) {
+        final ExceptionalResult exceptionalResult = ExceptionalResult.newBuilder()
+                .setExceptionalResultStatus(status)
+                .setMessage(msg)
+                .build();
+
+        return QueryBucketsResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setExceptionalResult(exceptionalResult)
+                .build();
+    }
+
+    public static QueryBucketsResponse queryBucketsResponseReject(String msg) {
+        return queryBucketsResponseExceptionalResult(
+                msg, ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT);
+    }
+
+    public static QueryBucketsResponse queryBucketsResponseError(String msg) {
+        return queryBucketsResponseExceptionalResult(
+                msg, ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR);
+    }
+
+    public static QueryBucketsResponse queryBucketsResponse(
+            QueryBucketsResponse.BucketQueryResult bucketQueryResult
+    ) {
+        return QueryBucketsResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setBucketQueryResult(bucketQueryResult)
+                .build();
+    }
+
+    public static void sendQueryBucketsResponseReject(
+            String msg, StreamObserver<QueryBucketsResponse> responseObserver) {
+        responseObserver.onNext(queryBucketsResponseReject(msg));
+        responseObserver.onCompleted();
+    }
+
+    public static void sendQueryBucketsResponseError(
+            String msg, StreamObserver<QueryBucketsResponse> responseObserver) {
+        responseObserver.onNext(queryBucketsResponseError(msg));
+        responseObserver.onCompleted();
+    }
+
+    public static void sendQueryBucketsResponse(
+            QueryBucketsResponse.BucketQueryResult bucketQueryResult,
+            StreamObserver<QueryBucketsResponse> responseObserver
+    ) {
+        responseObserver.onNext(queryBucketsResponse(bucketQueryResult));
+        responseObserver.onCompleted();
+    }
+
+    /** Empty result is a normal (empty) payload, NOT an ExceptionalResult. */
+    public static void sendQueryBucketsResponseEmpty(
+            StreamObserver<QueryBucketsResponse> responseObserver) {
+        responseObserver.onNext(queryBucketsResponse(
+                QueryBucketsResponse.BucketQueryResult.getDefaultInstance()));
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void queryBuckets(QueryBucketsRequest request, StreamObserver<QueryBucketsResponse> responseObserver) {
+        logger.debug("queryBuckets request received id: {}", responseObserver.hashCode());
+        // validation + resolution happens in the handler (it owns the resolver and mongo client);
+        // an invalid request is answered there with an ExceptionalResult reject.
+        handler.handleQueryBuckets(request, responseObserver);
+    }
+
     private static QueryTableResponse queryTableResponseExceptionalResult(
             String msg, ExceptionalResult.ExceptionalResultStatus status
     ) {

--- a/src/main/java/com/ospreydcs/dp/service/query/service/QueryServiceImpl.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/service/QueryServiceImpl.java
@@ -254,6 +254,15 @@ public class QueryServiceImpl extends DpQueryServiceGrpc.DpQueryServiceImplBase 
         handler.handleQuerySamples(request, responseObserver);
     }
 
+    @Override
+    public void querySamplesStream(
+            QuerySamplesRequest request, StreamObserver<QuerySamplesResponse> responseObserver) {
+        logger.debug("querySamplesStream request received id: {}", responseObserver.hashCode());
+        // server-streaming (single request → response stream); validation/resolution in the handler.
+        // a non-empty pageToken on a streaming call is rejected there (Q7/§6).
+        handler.handleQuerySamplesStream(request, responseObserver);
+    }
+
     private static QueryTableResponse queryTableResponseExceptionalResult(
             String msg, ExceptionalResult.ExceptionalResultStatus status
     ) {

--- a/src/main/java/com/ospreydcs/dp/service/query/service/QueryServiceImpl.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/service/QueryServiceImpl.java
@@ -175,6 +175,15 @@ public class QueryServiceImpl extends DpQueryServiceGrpc.DpQueryServiceImplBase 
         handler.handleQueryBuckets(request, responseObserver);
     }
 
+    @Override
+    public void queryBucketsStream(
+            QueryBucketsRequest request, StreamObserver<QueryBucketsResponse> responseObserver) {
+        logger.debug("queryBucketsStream request received id: {}", responseObserver.hashCode());
+        // server-streaming (single request → response stream); validation/resolution in the handler.
+        // a non-empty pageToken on a streaming call is rejected there (Q7/§6).
+        handler.handleQueryBucketsStream(request, responseObserver);
+    }
+
     private static QueryTableResponse queryTableResponseExceptionalResult(
             String msg, ExceptionalResult.ExceptionalResultStatus status
     ) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,6 +103,18 @@ QueryHandler:
   # control the size of messages for query responses.
   outgoingMessageSizeLimitBytes: ${DP_QUERY_HANDLER_OUTGOING_MESSAGE_SIZE_LIMIT_BYTES:4096000}
 
+  # QueryHandler.queryV2DefaultPageSize: Default page size (result objects per page) for Query API V2
+  # unary methods when the request's ExecutionOptions.limit is 0/unset.
+  queryV2DefaultPageSize: ${DP_QUERY_HANDLER_QUERY_V2_DEFAULT_PAGE_SIZE:10000}
+
+  # QueryHandler.queryV2MaxPageSize: Maximum page size for Query API V2 unary methods. A larger
+  # requested limit is silently clamped to this value to keep page sizes predictable.
+  queryV2MaxPageSize: ${DP_QUERY_HANDLER_QUERY_V2_MAX_PAGE_SIZE:100000}
+
+  # QueryHandler.queryV2MaxResolvedPvCount: Maximum number of PVs a Query API V2 selector may resolve
+  # to. A selector resolving to more PVs is rejected, directing the caller to narrow the selector.
+  queryV2MaxResolvedPvCount: ${DP_QUERY_HANDLER_QUERY_V2_MAX_RESOLVED_PV_COUNT:10000}
+
 # QueryBenchmark: Settings for the Query Service performance benchmark applications.
 QueryBenchmark:
 

--- a/src/test/integration/java/com/ospreydcs/dp/service/integration/query/GrpcIntegrationQueryServiceWrapper.java
+++ b/src/test/integration/java/com/ospreydcs/dp/service/integration/query/GrpcIntegrationQueryServiceWrapper.java
@@ -869,6 +869,102 @@ public class GrpcIntegrationQueryServiceWrapper extends GrpcIntegrationServiceWr
         return responseObserver.getProviderStatsList();
     }
 
+    // ---- Query API V2: queryBuckets / queryBucketsStream ----
+
+    /** Sends a single queryBuckets (unary) request through the gRPC channel and returns the response. */
+    public QueryBucketsResponse sendQueryBuckets(QueryBucketsRequest request) {
+        final DpQueryServiceGrpc.DpQueryServiceStub asyncStub = DpQueryServiceGrpc.newStub(channel);
+        final QueryTestBase.QueryBucketsResponseObserver responseObserver =
+                new QueryTestBase.QueryBucketsResponseObserver(
+                        QueryTestBase.QueryBucketsResponseObserver.Mode.UNARY);
+        new Thread(() -> asyncStub.queryBuckets(request, responseObserver)).start();
+        responseObserver.await();
+        assertEquals(1, responseObserver.getResponseList().size());
+        return responseObserver.getResponseList().get(0);
+    }
+
+    /** Sends a queryBucketsStream request and returns all streamed responses (in order). */
+    public List<QueryBucketsResponse> sendQueryBucketsStream(QueryBucketsRequest request) {
+        final DpQueryServiceGrpc.DpQueryServiceStub asyncStub = DpQueryServiceGrpc.newStub(channel);
+        final QueryTestBase.QueryBucketsResponseObserver responseObserver =
+                new QueryTestBase.QueryBucketsResponseObserver(
+                        QueryTestBase.QueryBucketsResponseObserver.Mode.STREAM);
+        new Thread(() -> asyncStub.queryBucketsStream(request, responseObserver)).start();
+        responseObserver.await();
+        return responseObserver.getResponseList();
+    }
+
+    /**
+     * Pages through queryBuckets to exhaustion via the gRPC channel, returning all buckets across all
+     * pages. Asserts each non-final page's token is non-empty and the last page's token is empty.
+     */
+    public List<DataBucket> queryBucketsAllPages(QuerySpec querySpec, int limit) {
+        final List<DataBucket> all = new ArrayList<>();
+        String token = null;
+        int pages = 0;
+        while (true) {
+            final QueryBucketsRequest request =
+                    QueryTestBase.buildQueryBucketsRequest(querySpec, limit, token, false, false);
+            final QueryBucketsResponse response = sendQueryBuckets(request);
+            assertTrue("unexpected exceptional result: "
+                    + response.getExceptionalResult().getMessage(), response.hasBucketQueryResult());
+            all.addAll(response.getBucketQueryResult().getDataBucketsList());
+            token = response.getBucketQueryResult().getNextPageToken();
+            pages++;
+            if (token.isEmpty() || pages >= 1000) {
+                break;
+            }
+        }
+        return all;
+    }
+
+    // ---- Query API V2: querySamples / querySamplesStream ----
+
+    public QuerySamplesResponse sendQuerySamples(QuerySamplesRequest request) {
+        final DpQueryServiceGrpc.DpQueryServiceStub asyncStub = DpQueryServiceGrpc.newStub(channel);
+        final QueryTestBase.QuerySamplesResponseObserver responseObserver =
+                new QueryTestBase.QuerySamplesResponseObserver(
+                        QueryTestBase.QuerySamplesResponseObserver.Mode.UNARY);
+        new Thread(() -> asyncStub.querySamples(request, responseObserver)).start();
+        responseObserver.await();
+        assertEquals(1, responseObserver.getResponseList().size());
+        return responseObserver.getResponseList().get(0);
+    }
+
+    public List<QuerySamplesResponse> sendQuerySamplesStream(QuerySamplesRequest request) {
+        final DpQueryServiceGrpc.DpQueryServiceStub asyncStub = DpQueryServiceGrpc.newStub(channel);
+        final QueryTestBase.QuerySamplesResponseObserver responseObserver =
+                new QueryTestBase.QuerySamplesResponseObserver(
+                        QueryTestBase.QuerySamplesResponseObserver.Mode.STREAM);
+        new Thread(() -> asyncStub.querySamplesStream(request, responseObserver)).start();
+        responseObserver.await();
+        return responseObserver.getResponseList();
+    }
+
+    /**
+     * Pages through querySamples to exhaustion via the gRPC channel, returning the concatenated
+     * timestamp list across all pages (for seam verification).
+     */
+    public List<Timestamp> querySamplesAllPageTimestamps(QuerySpec querySpec, int limit) {
+        final List<Timestamp> all = new ArrayList<>();
+        String token = null;
+        int pages = 0;
+        while (true) {
+            final QuerySamplesRequest request =
+                    QueryTestBase.buildQuerySamplesRequest(querySpec, limit, token, false);
+            final QuerySamplesResponse response = sendQuerySamples(request);
+            assertTrue("unexpected exceptional result: "
+                    + response.getExceptionalResult().getMessage(), response.hasSampleQueryResult());
+            all.addAll(response.getSampleQueryResult().getColumnTable().getTimestampList().getTimestampsList());
+            token = response.getSampleQueryResult().getNextPageToken();
+            pages++;
+            if (token.isEmpty() || pages >= 1000) {
+                break;
+            }
+        }
+        return all;
+    }
+
     protected void sendAndVerifyQueryProviderStats(
             String providerId,
             GrpcIntegrationIngestionServiceWrapper.IngestionProviderInfo providerInfo,

--- a/src/test/integration/java/com/ospreydcs/dp/service/integration/query/QueryV2GrpcIT.java
+++ b/src/test/integration/java/com/ospreydcs/dp/service/integration/query/QueryV2GrpcIT.java
@@ -1,0 +1,169 @@
+package com.ospreydcs.dp.service.integration.query;
+
+import com.ospreydcs.dp.grpc.v1.common.DataBucket;
+import com.ospreydcs.dp.grpc.v1.common.ExceptionalResult;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.grpc.v1.query.ColumnTable;
+import com.ospreydcs.dp.grpc.v1.query.QueryBucketsRequest;
+import com.ospreydcs.dp.grpc.v1.query.QueryBucketsResponse;
+import com.ospreydcs.dp.grpc.v1.query.QuerySamplesRequest;
+import com.ospreydcs.dp.grpc.v1.query.QuerySamplesResponse;
+import com.ospreydcs.dp.grpc.v1.query.QuerySpec;
+import com.ospreydcs.dp.service.integration.GrpcIntegrationTestBase;
+import com.ospreydcs.dp.service.integration.ingest.GrpcIntegrationIngestionServiceWrapper;
+import com.ospreydcs.dp.service.query.QueryTestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Full gRPC-channel end-to-end integration test for all four Query API V2 RPCs
+ * (queryBuckets / queryBucketsStream / querySamples / querySamplesStream). Data is ingested through
+ * the real ingestion service, then queried through the in-process gRPC channel so the complete path
+ * is exercised: client stub → QueryServiceImpl override → MongoQueryHandler resolver + worker queue →
+ * dispatcher → response stream. The dispatcher-level tests
+ * (MongoSyncQueryBucketsV2Test / MongoSyncQuerySamplesV2Test) cover the assembly/paging logic in
+ * detail; this test confirms the wiring and stub contracts hold over the wire.
+ *
+ * <p>Seeded scenario ({@code simpleIngestionScenario}): PVs {@code S01-GCC01..S10-BPM03}, each with 10
+ * one-second buckets (10 samples/bucket) over {@code [startSeconds, startSeconds+10)}.
+ */
+@RunWith(JUnit4.class)
+public class QueryV2GrpcIT extends GrpcIntegrationTestBase {
+
+    private static final String PV_1 = "S01-GCC01";
+    private static final String PV_2 = "S01-BPM01";
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        super.tearDown();
+    }
+
+    @Test
+    public void testQueryV2EndToEnd() {
+
+        final long startSeconds = Instant.now().getEpochSecond();
+        final GrpcIntegrationIngestionServiceWrapper.IngestionScenarioResult ingestionScenarioResult =
+                ingestionServiceWrapper.simpleIngestionScenario(startSeconds, false);
+        assertNotNull(ingestionScenarioResult);
+
+        final long begin = startSeconds;
+        final long end = startSeconds + 10; // whole 10-bucket window
+
+        // ---- queryBuckets (unary), single page ----
+        {
+            final QuerySpec spec = QueryTestBase.buildV2QuerySpecPvNameList(List.of(PV_1), begin, 0, end, 0);
+            final QueryBucketsRequest request = QueryTestBase.buildQueryBucketsRequest(spec, 0, null, false, false);
+            final QueryBucketsResponse response = queryServiceWrapper.sendQueryBuckets(request);
+            assertTrue(response.hasBucketQueryResult());
+            assertEquals(10, response.getBucketQueryResult().getDataBucketsCount());
+            assertTrue(response.getBucketQueryResult().getNextPageToken().isEmpty());
+            for (DataBucket b : response.getBucketQueryResult().getDataBucketsList()) {
+                assertEquals(PV_1, b.getPvName());
+            }
+        }
+
+        // ---- queryBuckets (unary), multi-page keyset continuation over 2 PVs ----
+        {
+            final QuerySpec spec = QueryTestBase.buildV2QuerySpecPvNameList(List.of(PV_1, PV_2), begin, 0, end, 0);
+            final List<DataBucket> all = queryServiceWrapper.queryBucketsAllPages(spec, 7); // 20 buckets, pages of 7
+            assertEquals(20, all.size());
+            // sorted by pvName then firstTime: 10 of PV_2 (BPM sorts before GCC? no: BPM < GCC) ...
+            // assert each PV contributes 10 buckets regardless of order
+            long pv1 = all.stream().filter(b -> b.getPvName().equals(PV_1)).count();
+            long pv2 = all.stream().filter(b -> b.getPvName().equals(PV_2)).count();
+            assertEquals(10, pv1);
+            assertEquals(10, pv2);
+        }
+
+        // ---- queryBucketsStream ----
+        {
+            final QuerySpec spec = QueryTestBase.buildV2QuerySpecPvNameList(List.of(PV_1), begin, 0, end, 0);
+            final QueryBucketsRequest request = QueryTestBase.buildQueryBucketsRequest(spec, 4, null, false, false);
+            final List<QueryBucketsResponse> messages = queryServiceWrapper.sendQueryBucketsStream(request);
+            int total = 0;
+            for (QueryBucketsResponse r : messages) {
+                assertTrue(r.hasBucketQueryResult());
+                assertTrue(r.getBucketQueryResult().getNextPageToken().isEmpty()); // empty on every stream msg
+                assertTrue(r.getBucketQueryResult().getDataBucketsCount() <= 4);
+                total += r.getBucketQueryResult().getDataBucketsCount();
+            }
+            assertEquals(10, total);
+            assertTrue("chunking should produce multiple messages", messages.size() >= 3);
+        }
+
+        // ---- queryBucketsStream rejects a non-empty pageToken ----
+        {
+            final QuerySpec spec = QueryTestBase.buildV2QuerySpecPvNameList(List.of(PV_1), begin, 0, end, 0);
+            final QueryBucketsRequest request =
+                    QueryTestBase.buildQueryBucketsRequest(spec, 4, "some-token", false, false);
+            final List<QueryBucketsResponse> messages = queryServiceWrapper.sendQueryBucketsStream(request);
+            assertFalse(messages.isEmpty());
+            final QueryBucketsResponse last = messages.get(messages.size() - 1);
+            assertTrue(last.hasExceptionalResult());
+            assertEquals(ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
+                    last.getExceptionalResult().getExceptionalResultStatus());
+        }
+
+        // ---- querySamples (unary), single page ----
+        {
+            final QuerySpec spec = QueryTestBase.buildV2QuerySpecPvNameList(List.of(PV_1, PV_2), begin, 0, end, 0);
+            final QuerySamplesRequest request = QueryTestBase.buildQuerySamplesRequest(spec, 0, null, false);
+            final QuerySamplesResponse response = queryServiceWrapper.sendQuerySamples(request);
+            assertTrue(response.hasSampleQueryResult());
+            final ColumnTable table = response.getSampleQueryResult().getColumnTable();
+            // 10 buckets x 10 samples over the 10-second window = 100 timestamps, same grid for both PVs
+            assertEquals(100, table.getTimestampList().getTimestampsCount());
+            assertEquals(2, table.getDataColumnsCount());
+            for (var col : table.getDataColumnsList()) {
+                assertEquals(100, col.getDataValuesCount());
+            }
+            assertTrue(response.getSampleQueryResult().getNextPageToken().isEmpty());
+        }
+
+        // ---- querySamples (unary), multi-page timestamp continuation seam ----
+        {
+            final QuerySpec spec = QueryTestBase.buildV2QuerySpecPvNameList(List.of(PV_1), begin, 0, end, 0);
+            final List<Timestamp> timestamps = queryServiceWrapper.querySamplesAllPageTimestamps(spec, 30);
+            assertEquals(100, timestamps.size());
+            // regular 100ms grid: consecutive timestamps exactly one step apart across page seams
+            for (int i = 1; i < timestamps.size(); i++) {
+                final long prev = timestamps.get(i - 1).getEpochSeconds() * 1_000_000_000L + timestamps.get(i - 1).getNanoseconds();
+                final long cur = timestamps.get(i).getEpochSeconds() * 1_000_000_000L + timestamps.get(i).getNanoseconds();
+                assertEquals(100_000_000L, cur - prev);
+            }
+        }
+
+        // ---- querySamplesStream ----
+        {
+            final QuerySpec spec = QueryTestBase.buildV2QuerySpecPvNameList(List.of(PV_1, PV_2), begin, 0, end, 0);
+            final QuerySamplesRequest request = QueryTestBase.buildQuerySamplesRequest(spec, 25, null, false);
+            final List<QuerySamplesResponse> messages = queryServiceWrapper.sendQuerySamplesStream(request);
+            int totalRows = 0;
+            for (QuerySamplesResponse r : messages) {
+                assertTrue(r.hasSampleQueryResult());
+                assertTrue(r.getSampleQueryResult().getNextPageToken().isEmpty());
+                final ColumnTable table = r.getSampleQueryResult().getColumnTable();
+                assertEquals(2, table.getDataColumnsCount()); // stable column set across chunks
+                final int rows = table.getTimestampList().getTimestampsCount();
+                assertTrue(rows <= 25);
+                assertEquals(rows, table.getDataColumns(0).getDataValuesCount());
+                totalRows += rows;
+            }
+            assertEquals(100, totalRows);
+            assertTrue("chunking should produce multiple messages", messages.size() >= 4);
+        }
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/common/mongo/MongoQueryFilterBuilderTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/mongo/MongoQueryFilterBuilderTest.java
@@ -1,0 +1,171 @@
+package com.ospreydcs.dp.service.common.mongo;
+
+import com.mongodb.client.model.Filters;
+import com.ospreydcs.dp.service.common.bson.BsonConstants;
+import org.bson.BsonDocument;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static com.mongodb.MongoClientSettings.getDefaultCodecRegistry;
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link MongoQueryFilterBuilder}. The primary goal is to prove the extracted
+ * helpers emit BSON that is byte-identical to the previously inline logic in
+ * {@code MongoSyncAnnotationClient} (the Q6 behavior-preserving acceptance bar), plus edge cases.
+ */
+public class MongoQueryFilterBuilderTest {
+
+    private static final CodecRegistry REGISTRY = getDefaultCodecRegistry();
+
+    /** Render a Bson filter to a canonical BsonDocument for equality comparison. */
+    private static BsonDocument render(Bson filter) {
+        return filter.toBsonDocument(BsonDocument.class, REGISTRY);
+    }
+
+    private static void assertSameBson(Bson expected, Bson actual) {
+        assertEquals(render(expected), render(actual));
+    }
+
+    private static final String FIELD = BsonConstants.BSON_KEY_PV_METADATA_PV_NAME;
+
+    // -----------------------------------------------------------------------
+    // nameMatchFilter
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testNameMatchFilter_allEmptyReturnsNull() {
+        assertNull(MongoQueryFilterBuilder.nameMatchFilter(
+                FIELD, List.of(), List.of(), List.of()));
+    }
+
+    @Test
+    public void testNameMatchFilter_nullListsReturnNull() {
+        assertNull(MongoQueryFilterBuilder.nameMatchFilter(FIELD, null, null, null));
+    }
+
+    @Test
+    public void testNameMatchFilter_exactOnly_singleFilterNotWrappedInOr() {
+        final List<String> exact = List.of("pv1", "pv2");
+        final Bson actual = MongoQueryFilterBuilder.nameMatchFilter(
+                FIELD, exact, List.of(), List.of());
+        // single filter => returned directly, not wrapped in $or
+        assertSameBson(Filters.in(FIELD, exact), actual);
+    }
+
+    @Test
+    public void testNameMatchFilter_prefixEscapedWithPatternQuote() {
+        final String prefix = "a.b*c"; // regex-special chars must be quoted
+        final Bson actual = MongoQueryFilterBuilder.nameMatchFilter(
+                FIELD, List.of(), List.of(prefix), List.of());
+        assertSameBson(Filters.regex(FIELD, "^" + Pattern.quote(prefix)), actual);
+    }
+
+    @Test
+    public void testNameMatchFilter_containsEscapedWithPatternQuote() {
+        final String contains = "x+y(z)";
+        final Bson actual = MongoQueryFilterBuilder.nameMatchFilter(
+                FIELD, List.of(), List.of(), List.of(contains));
+        assertSameBson(Filters.regex(FIELD, ".*" + Pattern.quote(contains) + ".*"), actual);
+    }
+
+    @Test
+    public void testNameMatchFilter_combinedWrappedInOr() {
+        // exact + prefix + contains => three filters combined with $or, in this order
+        final List<String> exact = List.of("e1");
+        final String prefix = "pre";
+        final String contains = "con";
+        final Bson actual = MongoQueryFilterBuilder.nameMatchFilter(
+                FIELD, exact, List.of(prefix), List.of(contains));
+        final Bson expected = Filters.or(
+                Filters.in(FIELD, exact),
+                Filters.regex(FIELD, "^" + Pattern.quote(prefix)),
+                Filters.regex(FIELD, ".*" + Pattern.quote(contains) + ".*"));
+        assertSameBson(expected, actual);
+    }
+
+    @Test
+    public void testNameMatchFilter_respectsFieldArgument() {
+        // aliases criterion uses the same logic against a different field
+        final Bson actual = MongoQueryFilterBuilder.nameMatchFilter(
+                BsonConstants.BSON_KEY_PV_METADATA_ALIASES, List.of("alias1"), List.of(), List.of());
+        assertSameBson(Filters.in(BsonConstants.BSON_KEY_PV_METADATA_ALIASES, List.of("alias1")), actual);
+    }
+
+    // -----------------------------------------------------------------------
+    // tagsFilter
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testTagsFilter() {
+        final List<String> values = List.of("tag1", "tag2");
+        assertSameBson(Filters.in(BsonConstants.BSON_KEY_TAGS, values),
+                MongoQueryFilterBuilder.tagsFilter(values));
+    }
+
+    // -----------------------------------------------------------------------
+    // attributeFilter
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testAttributeFilter_keyOnlyUsesExists() {
+        final String key = "sector";
+        final String mapKey = BsonConstants.BSON_KEY_ATTRIBUTES + "." + key;
+        assertSameBson(Filters.exists(mapKey),
+                MongoQueryFilterBuilder.attributeFilter(key, Collections.emptyList()));
+    }
+
+    @Test
+    public void testAttributeFilter_nullValuesUsesExists() {
+        final String key = "sector";
+        final String mapKey = BsonConstants.BSON_KEY_ATTRIBUTES + "." + key;
+        assertSameBson(Filters.exists(mapKey),
+                MongoQueryFilterBuilder.attributeFilter(key, null));
+    }
+
+    @Test
+    public void testAttributeFilter_withValuesUsesIn() {
+        final String key = "sector";
+        final List<String> values = List.of("A", "B");
+        final String mapKey = BsonConstants.BSON_KEY_ATTRIBUTES + "." + key;
+        assertSameBson(Filters.in(mapKey, values),
+                MongoQueryFilterBuilder.attributeFilter(key, values));
+    }
+
+    // -----------------------------------------------------------------------
+    // activationContainsInstantFilter
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testActivationContainsInstantFilter() {
+        final Instant ts = Instant.ofEpochSecond(1_700_000_000L, 123);
+        final Bson expected = Filters.and(
+                Filters.lte(BsonConstants.BSON_KEY_ACTIVATION_START_TIME, ts),
+                Filters.or(
+                        Filters.exists(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, false),
+                        Filters.gt(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, ts)));
+        assertSameBson(expected, MongoQueryFilterBuilder.activationContainsInstantFilter(ts));
+    }
+
+    // -----------------------------------------------------------------------
+    // activationOverlapsRangeFilter
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testActivationOverlapsRangeFilter() {
+        final Instant start = Instant.ofEpochSecond(1_700_000_000L);
+        final Instant end = Instant.ofEpochSecond(1_700_000_100L);
+        final Bson expected = Filters.and(
+                Filters.lt(BsonConstants.BSON_KEY_ACTIVATION_START_TIME, end),
+                Filters.or(
+                        Filters.exists(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, false),
+                        Filters.gt(BsonConstants.BSON_KEY_ACTIVATION_END_TIME, start)));
+        assertSameBson(expected, MongoQueryFilterBuilder.activationOverlapsRangeFilter(start, end));
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/query/QueryTestBase.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/QueryTestBase.java
@@ -153,6 +153,49 @@ public class QueryTestBase {
         return requestBuilder.build();
     }
 
+    // ---- Query API V2 request builders ----
+
+    /** Builds a V2 QuerySpec with a pvNameList selector and a half-open time range. */
+    public static QuerySpec buildV2QuerySpecPvNameList(
+            List<String> pvNames, long beginSecs, long beginNanos, long endSecs, long endNanos) {
+        return QuerySpec.newBuilder()
+                .setTimeRange(com.ospreydcs.dp.grpc.v1.common.TimeRange.newBuilder()
+                        .setBeginTime(Timestamp.newBuilder().setEpochSeconds(beginSecs).setNanoseconds(beginNanos))
+                        .setEndTime(Timestamp.newBuilder().setEpochSeconds(endSecs).setNanoseconds(endNanos)))
+                .setPvSelector(PvSelector.newBuilder()
+                        .setPvNameList(PvNameList.newBuilder().addAllPvNames(pvNames)))
+                .build();
+    }
+
+    public static QueryBucketsRequest buildQueryBucketsRequest(
+            QuerySpec querySpec, int limit, String pageToken, boolean useSerialized, boolean excludeMetadata) {
+        final ExecutionOptions.Builder opts = ExecutionOptions.newBuilder().setLimit(limit);
+        if (pageToken != null) {
+            opts.setPageToken(pageToken);
+        }
+        return QueryBucketsRequest.newBuilder()
+                .setQuerySpec(querySpec)
+                .setExecutionOptions(opts)
+                .setResultRepresentation(ResultRepresentation.newBuilder()
+                        .setUseSerializedColumns(useSerialized)
+                        .setExcludeColumnMetadata(excludeMetadata))
+                .build();
+    }
+
+    public static QuerySamplesRequest buildQuerySamplesRequest(
+            QuerySpec querySpec, int limit, String pageToken, boolean useSerialized) {
+        final ExecutionOptions.Builder opts = ExecutionOptions.newBuilder().setLimit(limit);
+        if (pageToken != null) {
+            opts.setPageToken(pageToken);
+        }
+        return QuerySamplesRequest.newBuilder()
+                .setQuerySpec(querySpec)
+                .setExecutionOptions(opts)
+                .setResultRepresentation(ResultRepresentation.newBuilder()
+                        .setUseSerializedColumns(useSerialized))
+                .build();
+    }
+
     public static QueryPvStatsRequest buildQueryPvStatsRequest(String columnNamePattern) {
 
         QueryPvStatsRequest.Builder requestBuilder = QueryPvStatsRequest.newBuilder();
@@ -253,6 +296,124 @@ public class QueryTestBase {
 
         @Override
         public void onCompleted() {
+        }
+    }
+
+    /**
+     * Response observer for the Query API V2 queryBuckets / queryBucketsStream RPCs. In UNARY mode it
+     * latches after the first response; in STREAM mode it accumulates messages until onCompleted.
+     */
+    public static class QueryBucketsResponseObserver implements StreamObserver<QueryBucketsResponse> {
+
+        public enum Mode { UNARY, STREAM }
+
+        private final Mode mode;
+        private final CountDownLatch finishLatch = new CountDownLatch(1);
+        private final AtomicBoolean isError = new AtomicBoolean(false);
+        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<QueryBucketsResponse> responseList = Collections.synchronizedList(new ArrayList<>());
+
+        public QueryBucketsResponseObserver(Mode mode) {
+            this.mode = mode;
+        }
+
+        public void await() {
+            try {
+                finishLatch.await(1, TimeUnit.MINUTES);
+            } catch (InterruptedException e) {
+                isError.set(true);
+            }
+        }
+
+        public boolean isError() { return isError.get(); }
+
+        public String getErrorMessage() {
+            return errorMessageList.isEmpty() ? "" : errorMessageList.get(0);
+        }
+
+        public List<QueryBucketsResponse> getResponseList() { return responseList; }
+
+        @Override
+        public void onNext(QueryBucketsResponse response) {
+            if (response.hasExceptionalResult()) {
+                isError.set(true);
+                errorMessageList.add(response.getExceptionalResult().getMessage());
+            }
+            responseList.add(response);
+            if (mode == Mode.UNARY) {
+                finishLatch.countDown();
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            isError.set(true);
+            errorMessageList.add(Status.fromThrowable(t).getDescription());
+            finishLatch.countDown();
+        }
+
+        @Override
+        public void onCompleted() {
+            finishLatch.countDown();
+        }
+    }
+
+    /**
+     * Response observer for the Query API V2 querySamples / querySamplesStream RPCs. In UNARY mode it
+     * latches after the first response; in STREAM mode it accumulates messages until onCompleted.
+     */
+    public static class QuerySamplesResponseObserver implements StreamObserver<QuerySamplesResponse> {
+
+        public enum Mode { UNARY, STREAM }
+
+        private final Mode mode;
+        private final CountDownLatch finishLatch = new CountDownLatch(1);
+        private final AtomicBoolean isError = new AtomicBoolean(false);
+        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<QuerySamplesResponse> responseList = Collections.synchronizedList(new ArrayList<>());
+
+        public QuerySamplesResponseObserver(Mode mode) {
+            this.mode = mode;
+        }
+
+        public void await() {
+            try {
+                finishLatch.await(1, TimeUnit.MINUTES);
+            } catch (InterruptedException e) {
+                isError.set(true);
+            }
+        }
+
+        public boolean isError() { return isError.get(); }
+
+        public String getErrorMessage() {
+            return errorMessageList.isEmpty() ? "" : errorMessageList.get(0);
+        }
+
+        public List<QuerySamplesResponse> getResponseList() { return responseList; }
+
+        @Override
+        public void onNext(QuerySamplesResponse response) {
+            if (response.hasExceptionalResult()) {
+                isError.set(true);
+                errorMessageList.add(response.getExceptionalResult().getMessage());
+            }
+            responseList.add(response);
+            if (mode == Mode.UNARY) {
+                finishLatch.countDown();
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            isError.set(true);
+            errorMessageList.add(Status.fromThrowable(t).getDescription());
+            finishLatch.countDown();
+        }
+
+        @Override
+        public void onCompleted() {
+            finishLatch.countDown();
         }
     }
 

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/QueryV2ResolverTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/QueryV2ResolverTest.java
@@ -1,0 +1,247 @@
+package com.ospreydcs.dp.service.query.handler;
+
+import com.mongodb.client.MongoCursor;
+import com.ospreydcs.dp.grpc.v1.common.TimeRange;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.grpc.v1.query.ExecutionOptions;
+import com.ospreydcs.dp.grpc.v1.query.PvNameList;
+import com.ospreydcs.dp.grpc.v1.query.PvSelector;
+import com.ospreydcs.dp.grpc.v1.query.QuerySpec;
+import com.ospreydcs.dp.grpc.v1.query.ResultRepresentation;
+import com.ospreydcs.dp.service.common.bson.PvMetadataQueryResultDocument;
+import com.ospreydcs.dp.service.common.bson.ProviderDocument;
+import com.ospreydcs.dp.service.common.bson.ProviderMetadataQueryResultDocument;
+import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
+import com.ospreydcs.dp.service.common.bson.dataset.DataBlockDocument;
+import com.ospreydcs.dp.grpc.v1.query.QueryDataRequest;
+import com.ospreydcs.dp.grpc.v1.query.QueryProviderStatsRequest;
+import com.ospreydcs.dp.grpc.v1.query.QueryProvidersRequest;
+import com.ospreydcs.dp.grpc.v1.query.QueryPvStatsRequest;
+import com.ospreydcs.dp.grpc.v1.query.QueryTableRequest;
+import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
+import com.ospreydcs.dp.service.query.handler.model.ResolutionResult;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
+import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
+import com.ospreydcs.dp.service.query.handler.paging.PageToken;
+import org.bson.conversions.Bson;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link QueryV2Resolver} focused on the pure validation and paging-normalization
+ * paths (§6 invariants, Q7 clamping, token mode/kind checks). PV-list resolution needs no DB round
+ * trip, so the happy path is exercised here too via a stub client; DB-backed pattern/metadata/config
+ * resolution is integration-tested in the queryBuckets step.
+ */
+public class QueryV2ResolverTest {
+
+    private static final int DEFAULT_PAGE_SIZE = 10_000;
+    private static final int MAX_PAGE_SIZE = 100_000;
+    private static final int MAX_RESOLVED_PVS = 5;
+
+    /** Stub client: no method should be called for the pure PV-list validation paths under test. */
+    private static class StubClient implements MongoQueryClientInterface {
+        @Override public boolean init() { return true; }
+        @Override public boolean fini() { return true; }
+        @Override public MongoCursor<BucketDocument> executeDataBlockQuery(DataBlockDocument d) { return null; }
+        @Override public MongoCursor<BucketDocument> executeQueryData(QueryDataRequest.QuerySpec q) { return null; }
+        @Override public MongoCursor<BucketDocument> executeQueryTable(QueryTableRequest r) { return null; }
+        @Override public MongoCursor<PvMetadataQueryResultDocument> executeQueryPvStats(QueryPvStatsRequest r) { return null; }
+        @Override public MongoCursor<PvMetadataQueryResultDocument> executeQueryPvStats(Collection<String> l) { return null; }
+        @Override public MongoCursor<PvMetadataQueryResultDocument> executeQueryPvStats(String p) { return null; }
+        @Override public Collection<String> executeQueryPvExistence(Collection<String> l) { return null; }
+        @Override public List<String> resolvePvNamesByPattern(String p) { return List.of(); }
+        @Override public List<String> resolvePvNamesByMetadata(List<Bson> f) { return List.of(); }
+        @Override public List<TimeInterval> resolveConfigurationIntervals(List<Bson> f) { return List.of(); }
+        @Override public MongoCursor<ProviderDocument> executeQueryProviders(QueryProvidersRequest r) { return null; }
+        @Override public MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(QueryProviderStatsRequest r) { return null; }
+        @Override public MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(String id) { return null; }
+    }
+
+    private QueryV2Resolver resolver() {
+        return new QueryV2Resolver(new StubClient(), DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_RESOLVED_PVS);
+    }
+
+    private static Timestamp ts(long secs, long nanos) {
+        return Timestamp.newBuilder().setEpochSeconds(secs).setNanoseconds(nanos).build();
+    }
+
+    private static QuerySpec.Builder specWithTimeRange(long beginSecs, long endSecs) {
+        return QuerySpec.newBuilder().setTimeRange(TimeRange.newBuilder()
+                .setBeginTime(ts(beginSecs, 0))
+                .setEndTime(ts(endSecs, 0)));
+    }
+
+    private static PvSelector pvList(String... names) {
+        return PvSelector.newBuilder()
+                .setPvNameList(PvNameList.newBuilder().addAllPvNames(List.of(names)))
+                .build();
+    }
+
+    private ResolutionResult resolve(QuerySpec spec, ExecutionOptions opts, boolean streaming) {
+        return resolver().resolve(
+                spec, opts, ResultRepresentation.getDefaultInstance(),
+                ResolvedQuery.ResultMode.BUCKET, streaming);
+    }
+
+    // -----------------------------------------------------------------------
+    // TimeRange validation
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testMissingTimeRangeRejected() {
+        final QuerySpec spec = QuerySpec.newBuilder().setPvSelector(pvList("pv1")).build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.getDefaultInstance(), false);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("timeRange"));
+    }
+
+    @Test
+    public void testEndBeforeBeginRejected() {
+        final QuerySpec spec = specWithTimeRange(100, 50).setPvSelector(pvList("pv1")).build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.getDefaultInstance(), false);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("endTime must be > beginTime"));
+    }
+
+    @Test
+    public void testEqualBeginEndRejected() {
+        final QuerySpec spec = specWithTimeRange(100, 100).setPvSelector(pvList("pv1")).build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.getDefaultInstance(), false);
+        assertTrue(r.isError());
+    }
+
+    // -----------------------------------------------------------------------
+    // PvSelector validation
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testMissingPvSelectorRejected() {
+        final QuerySpec spec = specWithTimeRange(0, 100).build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.getDefaultInstance(), false);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("pvSelector"));
+    }
+
+    @Test
+    public void testEmptyPvNameListRejected() {
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(PvSelector.newBuilder()
+                        .setPvNameList(PvNameList.getDefaultInstance()))
+                .build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.getDefaultInstance(), false);
+        assertTrue(r.isError());
+    }
+
+    // -----------------------------------------------------------------------
+    // Happy path + interval defaulting
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testHappyPathPvListSortedAndWholeRangeInterval() {
+        final QuerySpec spec = specWithTimeRange(10, 20).setPvSelector(pvList("pvC", "pvA", "pvB")).build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.getDefaultInstance(), false);
+        assertFalse(r.isError());
+        final ResolvedQuery rq = r.getResolvedQuery();
+        assertEquals(List.of("pvA", "pvB", "pvC"), rq.getPvNames()); // sorted
+        assertEquals(1, rq.getRetrievalIntervals().size());
+        assertEquals(new TimeInterval(10, 0, 20, 0), rq.getRetrievalIntervals().get(0));
+        assertEquals(DEFAULT_PAGE_SIZE, rq.getPageSize());
+        assertNull(rq.getPageStart());
+        assertFalse(rq.isEmptyResult());
+    }
+
+    @Test
+    public void testDuplicatePvNamesDeduped() {
+        final QuerySpec spec = specWithTimeRange(0, 100).setPvSelector(pvList("pv1", "pv1", "pv2")).build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.getDefaultInstance(), false);
+        assertFalse(r.isError());
+        assertEquals(List.of("pv1", "pv2"), r.getResolvedQuery().getPvNames());
+    }
+
+    @Test
+    public void testResolvedPvCountCapExceededRejected() {
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(pvList("a", "b", "c", "d", "e", "f")) // 6 > MAX_RESOLVED_PVS (5)
+                .build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.getDefaultInstance(), false);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("exceeding the maximum"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Paging normalization (Q7)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testLimitZeroUsesDefault() {
+        final QuerySpec spec = specWithTimeRange(0, 100).setPvSelector(pvList("pv1")).build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.newBuilder().setLimit(0).build(), false);
+        assertEquals(DEFAULT_PAGE_SIZE, r.getResolvedQuery().getPageSize());
+    }
+
+    @Test
+    public void testLimitAboveMaxSilentlyClamped() {
+        final QuerySpec spec = specWithTimeRange(0, 100).setPvSelector(pvList("pv1")).build();
+        final ResolutionResult r = resolve(
+                spec, ExecutionOptions.newBuilder().setLimit(MAX_PAGE_SIZE + 5_000).build(), false);
+        assertFalse(r.isError()); // clamp, not reject
+        assertEquals(MAX_PAGE_SIZE, r.getResolvedQuery().getPageSize());
+    }
+
+    @Test
+    public void testLimitWithinRangeHonored() {
+        final QuerySpec spec = specWithTimeRange(0, 100).setPvSelector(pvList("pv1")).build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.newBuilder().setLimit(500).build(), false);
+        assertEquals(500, r.getResolvedQuery().getPageSize());
+    }
+
+    // -----------------------------------------------------------------------
+    // Page token handling
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testStreamingWithTokenRejected() {
+        final String token = PageToken.encode(KeysetPosition.ofBucket("pv1", 1, 2));
+        final QuerySpec spec = specWithTimeRange(0, 100).setPvSelector(pvList("pv1")).build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.newBuilder().setPageToken(token).build(), true);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("streaming"));
+    }
+
+    @Test
+    public void testMalformedTokenRejected() {
+        final QuerySpec spec = specWithTimeRange(0, 100).setPvSelector(pvList("pv1")).build();
+        final ResolutionResult r = resolve(
+                spec, ExecutionOptions.newBuilder().setPageToken("!!!bad!!!").build(), false);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("invalid pageToken"));
+    }
+
+    @Test
+    public void testWrongKindTokenRejected() {
+        // a SAMPLE token supplied to a BUCKET-mode query
+        final String sampleToken = PageToken.encode(KeysetPosition.ofSample(1, 2));
+        final QuerySpec spec = specWithTimeRange(0, 100).setPvSelector(pvList("pv1")).build();
+        final ResolutionResult r = resolve(
+                spec, ExecutionOptions.newBuilder().setPageToken(sampleToken).build(), false);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("not valid for this query type"));
+    }
+
+    @Test
+    public void testValidBucketTokenDecoded() {
+        final KeysetPosition pos = KeysetPosition.ofBucket("pvX", 42, 7);
+        final String token = PageToken.encode(pos);
+        final QuerySpec spec = specWithTimeRange(0, 100).setPvSelector(pvList("pv1")).build();
+        final ResolutionResult r = resolve(
+                spec, ExecutionOptions.newBuilder().setPageToken(token).build(), false);
+        assertFalse(r.isError());
+        assertEquals(pos, r.getResolvedQuery().getPageStart());
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/QueryV2ResolverTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/QueryV2ResolverTest.java
@@ -59,6 +59,7 @@ public class QueryV2ResolverTest {
         @Override public List<String> resolvePvNamesByMetadata(List<Bson> f) { return List.of(); }
         @Override public List<TimeInterval> resolveConfigurationIntervals(List<Bson> f) { return List.of(); }
         @Override public MongoCursor<BucketDocument> executeQueryBucketsV2(ResolvedQuery q) { return null; }
+        @Override public MongoCursor<BucketDocument> executeQueryBucketsV2Stream(ResolvedQuery q) { return null; }
         @Override public MongoCursor<ProviderDocument> executeQueryProviders(QueryProvidersRequest r) { return null; }
         @Override public MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(QueryProviderStatsRequest r) { return null; }
         @Override public MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(String id) { return null; }

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/QueryV2ResolverTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/QueryV2ResolverTest.java
@@ -60,6 +60,7 @@ public class QueryV2ResolverTest {
         @Override public List<TimeInterval> resolveConfigurationIntervals(List<Bson> f) { return List.of(); }
         @Override public MongoCursor<BucketDocument> executeQueryBucketsV2(ResolvedQuery q) { return null; }
         @Override public MongoCursor<BucketDocument> executeQueryBucketsV2Stream(ResolvedQuery q) { return null; }
+        @Override public MongoCursor<BucketDocument> executeQuerySamplesV2(ResolvedQuery q, long bs, long bn) { return null; }
         @Override public MongoCursor<ProviderDocument> executeQueryProviders(QueryProvidersRequest r) { return null; }
         @Override public MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(QueryProviderStatsRequest r) { return null; }
         @Override public MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(String id) { return null; }

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/QueryV2ResolverTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/QueryV2ResolverTest.java
@@ -58,6 +58,7 @@ public class QueryV2ResolverTest {
         @Override public List<String> resolvePvNamesByPattern(String p) { return List.of(); }
         @Override public List<String> resolvePvNamesByMetadata(List<Bson> f) { return List.of(); }
         @Override public List<TimeInterval> resolveConfigurationIntervals(List<Bson> f) { return List.of(); }
+        @Override public MongoCursor<BucketDocument> executeQueryBucketsV2(ResolvedQuery q) { return null; }
         @Override public MongoCursor<ProviderDocument> executeQueryProviders(QueryProvidersRequest r) { return null; }
         @Override public MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(QueryProviderStatsRequest r) { return null; }
         @Override public MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(String id) { return null; }

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/QueryV2ResolverTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/QueryV2ResolverTest.java
@@ -3,6 +3,7 @@ package com.ospreydcs.dp.service.query.handler;
 import com.mongodb.client.MongoCursor;
 import com.ospreydcs.dp.grpc.v1.common.TimeRange;
 import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.grpc.v1.query.ConfigurationSelector;
 import com.ospreydcs.dp.grpc.v1.query.ExecutionOptions;
 import com.ospreydcs.dp.grpc.v1.query.PvNameList;
 import com.ospreydcs.dp.grpc.v1.query.PvSelector;
@@ -68,6 +69,24 @@ public class QueryV2ResolverTest {
 
     private QueryV2Resolver resolver() {
         return new QueryV2Resolver(new StubClient(), DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_RESOLVED_PVS);
+    }
+
+    private QueryV2Resolver resolver(MongoQueryClientInterface client) {
+        return new QueryV2Resolver(client, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_RESOLVED_PVS);
+    }
+
+    /** Stub variant returning a fixed set of activation intervals for configuration resolution. */
+    private static class IntervalStubClient extends StubClient {
+        private final List<TimeInterval> intervals;
+        IntervalStubClient(List<TimeInterval> intervals) { this.intervals = intervals; }
+        @Override public List<TimeInterval> resolveConfigurationIntervals(List<Bson> f) { return intervals; }
+    }
+
+    private static ConfigurationSelector.Criterion configNameCriterion(String... names) {
+        return ConfigurationSelector.Criterion.newBuilder()
+                .setConfigurationNameCriterion(ConfigurationSelector.Criterion.ConfigurationNameCriterion
+                        .newBuilder().addAllValues(List.of(names)))
+                .build();
     }
 
     private static Timestamp ts(long secs, long nanos) {
@@ -246,5 +265,74 @@ public class QueryV2ResolverTest {
                 spec, ExecutionOptions.newBuilder().setPageToken(token).build(), false);
         assertFalse(r.isError());
         assertEquals(pos, r.getResolvedQuery().getPageStart());
+    }
+
+    // -----------------------------------------------------------------------
+    // ConfigurationSelector resolution (Q3): malformed rejects; well-formed
+    // matching nothing is an empty result, not an error
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testConfigSelectorEmptyCriteriaListRejected() {
+        // a present ConfigurationSelector with no criteria is a malformed request (mirrors
+        // queryProviders "criteria list must not be empty"), NOT a silent "match nothing"
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(pvList("pv1"))
+                .setConfigurationSelector(ConfigurationSelector.getDefaultInstance())
+                .build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.getDefaultInstance(), false);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("criteria list must not be empty"));
+    }
+
+    @Test
+    public void testConfigSelectorUnsetCriterionArmRejected() {
+        // a criterion with no arm set violates exactly-one-criterion → reject (client build error),
+        // rather than being silently skipped and collapsing to an empty result
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(pvList("pv1"))
+                .setConfigurationSelector(ConfigurationSelector.newBuilder()
+                        .addCriteria(ConfigurationSelector.Criterion.getDefaultInstance()))
+                .build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.getDefaultInstance(), false);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("must set exactly one arm"));
+    }
+
+    @Test
+    public void testConfigSelectorWellFormedMatchingNothingIsEmptyNotError() {
+        // a well-formed selector that matches no activations in range → empty result, NOT a reject
+        // (distinct from the malformed cases above). Stub returns no intervals.
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(pvList("pv1"))
+                .setConfigurationSelector(ConfigurationSelector.newBuilder()
+                        .addCriteria(configNameCriterion("no-such-config")))
+                .build();
+        final ResolutionResult r = resolver(new IntervalStubClient(List.of())).resolve(
+                spec, ExecutionOptions.getDefaultInstance(), ResultRepresentation.getDefaultInstance(),
+                ResolvedQuery.ResultMode.BUCKET, false);
+        assertFalse("well-formed selector matching nothing must not be an error", r.isError());
+        final ResolvedQuery rq = r.getResolvedQuery();
+        assertTrue(rq.getRetrievalIntervals().isEmpty());
+        assertTrue(rq.isEmptyResult()); // no intervals → empty (empty payload, not exceptional)
+    }
+
+    @Test
+    public void testConfigSelectorWellFormedMatchingIntervalsResolves() {
+        // a well-formed selector matching activations → intervals intersected with the query range
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(pvList("pv1"))
+                .setConfigurationSelector(ConfigurationSelector.newBuilder()
+                        .addCriteria(configNameCriterion("cfgA")))
+                .build();
+        // activation [10,50) lies within the query range [0,100) → the effective interval
+        final ResolutionResult r = resolver(new IntervalStubClient(List.of(new TimeInterval(10, 0, 50, 0))))
+                .resolve(spec, ExecutionOptions.getDefaultInstance(), ResultRepresentation.getDefaultInstance(),
+                        ResolvedQuery.ResultMode.BUCKET, false);
+        assertFalse(r.isError());
+        final ResolvedQuery rq = r.getResolvedQuery();
+        assertEquals(1, rq.getRetrievalIntervals().size());
+        assertEquals(new TimeInterval(10, 0, 50, 0), rq.getRetrievalIntervals().get(0));
+        assertFalse(rq.isEmptyResult());
     }
 }

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/model/TimeIntervalTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/model/TimeIntervalTest.java
@@ -1,0 +1,122 @@
+package com.ospreydcs.dp.service.query.handler.model;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link TimeInterval} interval math (union, intersect) — the pure Java that backs
+ * Query API V2 configuration-fragment resolution (Q3). Instants are written as {@code (seconds,
+ * nanos)}; nanos are used in a few cases to exercise the lexicographic endpoint comparison.
+ */
+public class TimeIntervalTest {
+
+    private static TimeInterval iv(long bs, long es) {
+        return new TimeInterval(bs, 0, es, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // isEmpty / compareInstant
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testIsEmpty() {
+        assertFalse(iv(10, 20).isEmpty());
+        assertTrue(iv(20, 20).isEmpty());   // end == begin
+        assertTrue(iv(30, 20).isEmpty());   // end < begin
+        assertTrue(new TimeInterval(10, 500, 10, 500).isEmpty());
+        assertFalse(new TimeInterval(10, 100, 10, 200).isEmpty()); // same secs, nanos differ
+    }
+
+    @Test
+    public void testCompareInstant() {
+        assertTrue(TimeInterval.compareInstant(1, 0, 2, 0) < 0);
+        assertTrue(TimeInterval.compareInstant(2, 0, 1, 0) > 0);
+        assertEquals(0, TimeInterval.compareInstant(1, 5, 1, 5));
+        assertTrue(TimeInterval.compareInstant(1, 5, 1, 6) < 0); // nanos tiebreak
+    }
+
+    // -----------------------------------------------------------------------
+    // intersect
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testIntersect_overlap() {
+        assertEquals(iv(15, 20), iv(10, 20).intersect(15, 0, 25, 0));
+    }
+
+    @Test
+    public void testIntersect_containedReturnsInner() {
+        assertEquals(iv(12, 18), iv(10, 20).intersect(12, 0, 18, 0));
+    }
+
+    @Test
+    public void testIntersect_noOverlapReturnsNull() {
+        assertNull(iv(10, 20).intersect(20, 0, 30, 0)); // touching at 20, half-open → empty
+        assertNull(iv(10, 20).intersect(30, 0, 40, 0)); // disjoint
+    }
+
+    // -----------------------------------------------------------------------
+    // union
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testUnion_mergesOverlapping() {
+        final List<TimeInterval> result = TimeInterval.union(List.of(iv(10, 20), iv(15, 25)));
+        assertEquals(List.of(iv(10, 25)), result);
+    }
+
+    @Test
+    public void testUnion_mergesAdjacent() {
+        // half-open [10,20) and [20,30) abut with no gap → merge
+        final List<TimeInterval> result = TimeInterval.union(List.of(iv(10, 20), iv(20, 30)));
+        assertEquals(List.of(iv(10, 30)), result);
+    }
+
+    @Test
+    public void testUnion_keepsDisjoint() {
+        final List<TimeInterval> result = TimeInterval.union(List.of(iv(30, 40), iv(10, 20)));
+        assertEquals(List.of(iv(10, 20), iv(30, 40)), result); // sorted
+    }
+
+    @Test
+    public void testUnion_dropsEmptyAndContained() {
+        final List<TimeInterval> result = TimeInterval.union(
+                List.of(iv(10, 30), iv(15, 20), iv(25, 25) /* empty */));
+        assertEquals(List.of(iv(10, 30)), result);
+    }
+
+    @Test
+    public void testUnion_emptyInput() {
+        assertTrue(TimeInterval.union(List.of()).isEmpty());
+    }
+
+    // -----------------------------------------------------------------------
+    // intersectAll
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testIntersectAll_clipsToBound() {
+        final List<TimeInterval> intervals = List.of(iv(0, 15), iv(25, 100));
+        final TimeInterval bound = iv(10, 40);
+        // union = [0,15),[25,100); clipped to [10,40) => [10,15),[25,40)
+        assertEquals(List.of(iv(10, 15), iv(25, 40)),
+                TimeInterval.intersectAll(intervals, bound));
+    }
+
+    @Test
+    public void testIntersectAll_noOverlapYieldsEmpty() {
+        assertTrue(TimeInterval.intersectAll(List.of(iv(0, 5)), iv(10, 20)).isEmpty());
+    }
+
+    @Test
+    public void testIntersectAll_openEndedSentinelClampedToBound() {
+        // open-ended activation modeled as end = Long.MAX_VALUE; clamps to the bound end
+        final TimeInterval openEnded = new TimeInterval(50, 0, Long.MAX_VALUE, 0);
+        final TimeInterval bound = iv(10, 100);
+        assertEquals(List.of(iv(50, 100)),
+                TimeInterval.intersectAll(List.of(openEnded), bound));
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQueryBucketsV2Test.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQueryBucketsV2Test.java
@@ -198,6 +198,48 @@ public class MongoSyncQueryBucketsV2Test extends MongoQueryHandlerTestBase {
     }
 
     // -----------------------------------------------------------------------
+    // streaming helpers
+    // -----------------------------------------------------------------------
+
+    /** Collected outcome of a streaming run: all messages plus completion/error flags. */
+    private static final class StreamOutcome {
+        final List<QueryBucketsResponse> messages = new ArrayList<>();
+        boolean completed = false;
+        boolean errored = false;
+    }
+
+    private StreamOutcome runStream(QueryBucketsRequest request, long byteBudget) {
+        final ResolutionResult resolution = resolver().resolve(
+                request.getQuerySpec(), request.getExecutionOptions(), request.getResultRepresentation(),
+                ResolvedQuery.ResultMode.BUCKET, true /* streaming */);
+        assertFalse("unexpected streaming resolution error: "
+                + (resolution.isError() ? resolution.getErrorStatus().msg : ""), resolution.isError());
+
+        final StreamOutcome outcome = new StreamOutcome();
+        final StreamObserver<QueryBucketsResponse> observer = new StreamObserver<>() {
+            @Override public void onNext(QueryBucketsResponse r) { outcome.messages.add(r); }
+            @Override public void onError(Throwable t) { outcome.errored = true; }
+            @Override public void onCompleted() { outcome.completed = true; }
+        };
+        final com.ospreydcs.dp.service.query.handler.mongo.dispatch.QueryBucketsStreamDispatcher dispatcher =
+                new com.ospreydcs.dp.service.query.handler.mongo.dispatch.QueryBucketsStreamDispatcher(
+                        observer, byteBudget);
+        new QueryV2Job(resolution.getResolvedQuery(), dispatcher, clientTestInterface).execute();
+        return outcome;
+    }
+
+    private static List<DataBucket> allStreamedBuckets(StreamOutcome outcome) {
+        final List<DataBucket> all = new ArrayList<>();
+        for (QueryBucketsResponse r : outcome.messages) {
+            assertTrue("streamed message must be a BucketQueryResult", r.hasBucketQueryResult());
+            assertTrue("streamed message nextPageToken must be empty",
+                    r.getBucketQueryResult().getNextPageToken().isEmpty());
+            all.addAll(r.getBucketQueryResult().getDataBucketsList());
+        }
+        return all;
+    }
+
+    // -----------------------------------------------------------------------
     // happy path
     // -----------------------------------------------------------------------
 
@@ -433,6 +475,104 @@ public class MongoSyncQueryBucketsV2Test extends MongoQueryHandlerTestBase {
         final ResolvedQuery resolved = resolvedForPv(pvName, 100, null);
         final QueryBucketsResponse response = runResolvedWithBudget(resolved, Long.MAX_VALUE);
         return response.getBucketQueryResult().getDataBuckets(0).getSerializedSize();
+    }
+
+    // -----------------------------------------------------------------------
+    // streaming (step 4) — queryBucketsStream
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testStreamChunkingByLimit() {
+        // 2 PVs x 10 buckets = 20; chunk size (limit) 6 => messages of 6,6,6,2
+        final StreamOutcome outcome = runStream(
+                bucketsRequest(List.of(COL_1_NAME, COL_2_NAME), startSeconds, startSeconds + 10, 6, null, false),
+                Long.MAX_VALUE);
+
+        assertTrue("stream must complete", outcome.completed);
+        assertFalse(outcome.errored);
+        assertEquals(4, outcome.messages.size());
+        // each message respects the count limit
+        for (QueryBucketsResponse r : outcome.messages) {
+            assertTrue(r.getBucketQueryResult().getDataBucketsCount() <= 6);
+        }
+        final List<DataBucket> all = allStreamedBuckets(outcome);
+        assertEquals(20, all.size());
+        // ordering preserved across chunks: 10 testpv_1 then 10 testpv_2
+        for (int i = 0; i < 10; i++) {
+            assertEquals(COL_1_NAME, all.get(i).getPvName());
+        }
+        for (int i = 10; i < 20; i++) {
+            assertEquals(COL_2_NAME, all.get(i).getPvName());
+        }
+    }
+
+    @Test
+    public void testStreamSingleFullChunk() {
+        // limit larger than result => a single message with all buckets, then complete
+        final StreamOutcome outcome = runStream(
+                bucketsRequest(List.of(COL_1_NAME), startSeconds, startSeconds + 10, 1000, null, false),
+                Long.MAX_VALUE);
+        assertTrue(outcome.completed);
+        assertEquals(1, outcome.messages.size());
+        assertEquals(10, outcome.messages.get(0).getBucketQueryResult().getDataBucketsCount());
+    }
+
+    @Test
+    public void testStreamEmptyResultSingleEmptyMessage() {
+        final StreamOutcome outcome = runStream(
+                bucketsRequest(List.of(COL_1_NAME), startSeconds - 1000, startSeconds - 900, 10, null, false),
+                Long.MAX_VALUE);
+        assertTrue(outcome.completed);
+        assertEquals("empty streaming result => one empty message", 1, outcome.messages.size());
+        assertFalse(outcome.messages.get(0).hasExceptionalResult());
+        assertEquals(0, outcome.messages.get(0).getBucketQueryResult().getDataBucketsCount());
+    }
+
+    @Test
+    public void testStreamRejectsNonEmptyPageToken() {
+        // a non-empty pageToken on a streaming call must be rejected (Q7/§6) — enforced in the resolver
+        final String token = com.ospreydcs.dp.service.query.handler.paging.PageToken.encode(
+                com.ospreydcs.dp.service.query.handler.model.KeysetPosition.ofBucket(COL_1_NAME, startSeconds, 0));
+        final QueryBucketsRequest request =
+                bucketsRequest(List.of(COL_1_NAME), startSeconds, startSeconds + 10, 5, token, false);
+        final ResolutionResult resolution = resolver().resolve(
+                request.getQuerySpec(), request.getExecutionOptions(), request.getResultRepresentation(),
+                ResolvedQuery.ResultMode.BUCKET, true /* streaming */);
+        assertTrue(resolution.isError());
+        assertTrue(resolution.getErrorStatus().msg.contains("streaming"));
+    }
+
+    @Test
+    public void testStreamByteBudgetFlush() {
+        // budget fits ~1 bucket => each message carries one bucket, count limit high so byte guard drives
+        final long oneBucketBytes = firstBucketSerializedSize(COL_1_NAME);
+        final long budget = oneBucketBytes + (oneBucketBytes / 2);
+
+        final StreamOutcome outcome = runStream(
+                bucketsRequest(List.of(COL_1_NAME), startSeconds, startSeconds + 10, 100, null, false),
+                budget);
+        assertTrue(outcome.completed);
+        assertEquals("byte budget => 10 one-bucket messages", 10, outcome.messages.size());
+        for (QueryBucketsResponse r : outcome.messages) {
+            assertEquals(1, r.getBucketQueryResult().getDataBucketsCount());
+        }
+        assertEquals(10, allStreamedBuckets(outcome).size());
+    }
+
+    @Test
+    public void testStreamIndivisibleOversizedErrors() {
+        final long oneBucketBytes = firstBucketSerializedSize(COL_1_NAME);
+        final long tinyBudget = Math.max(1, oneBucketBytes - 1);
+
+        final StreamOutcome outcome = runStream(
+                bucketsRequest(List.of(COL_1_NAME), startSeconds, startSeconds + 10, 100, null, false),
+                tinyBudget);
+        // the dispatcher sends an ExceptionalResult (does not call onCompleted after the error)
+        assertFalse(outcome.messages.isEmpty());
+        final QueryBucketsResponse last = outcome.messages.get(outcome.messages.size() - 1);
+        assertTrue("oversized bucket must yield an ExceptionalResult", last.hasExceptionalResult());
+        assertEquals(com.ospreydcs.dp.grpc.v1.common.ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR,
+                last.getExceptionalResult().getExceptionalResultStatus());
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQueryBucketsV2Test.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQueryBucketsV2Test.java
@@ -1,0 +1,465 @@
+package com.ospreydcs.dp.service.query.handler.mongo;
+
+import com.mongodb.client.result.InsertManyResult;
+import com.ospreydcs.dp.grpc.v1.common.ColumnMetadata;
+import com.ospreydcs.dp.grpc.v1.common.DataBucket;
+import com.ospreydcs.dp.grpc.v1.common.DataColumn;
+import com.ospreydcs.dp.grpc.v1.common.DataValue;
+import com.ospreydcs.dp.grpc.v1.common.SamplingClock;
+import com.ospreydcs.dp.grpc.v1.common.TimeRange;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.grpc.v1.query.ExecutionOptions;
+import com.ospreydcs.dp.grpc.v1.query.PvNameList;
+import com.ospreydcs.dp.grpc.v1.query.PvSelector;
+import com.ospreydcs.dp.grpc.v1.query.QueryBucketsRequest;
+import com.ospreydcs.dp.grpc.v1.query.QueryBucketsResponse;
+import com.ospreydcs.dp.grpc.v1.query.QuerySpec;
+import com.ospreydcs.dp.grpc.v1.query.ResultRepresentation;
+import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
+import com.ospreydcs.dp.service.common.bson.bucket.BucketUtility;
+import com.ospreydcs.dp.service.common.bson.DataTimestampsDocument;
+import com.ospreydcs.dp.service.common.bson.column.DataColumnDocument;
+import com.ospreydcs.dp.service.common.mongo.MongoTestClient;
+import com.ospreydcs.dp.service.common.protobuf.TimestampUtility;
+import com.ospreydcs.dp.service.query.handler.QueryV2Resolver;
+import com.ospreydcs.dp.service.query.handler.model.ResolutionResult;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.mongo.client.MongoSyncQueryClient;
+import com.ospreydcs.dp.service.query.handler.mongo.dispatch.QueryBucketsUnaryDispatcher;
+import com.ospreydcs.dp.service.query.handler.mongo.job.QueryV2Job;
+import io.grpc.stub.StreamObserver;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * End-to-end tests for Query API V2 {@code queryBuckets} unary against real MongoDB: resolution
+ * (step 2) + keyset paging (Q2) + {@code $or} fragmentation (Q3) + representation flags (Q5/Q8),
+ * driven through the shared {@link QueryV2Job} and {@link QueryBucketsUnaryDispatcher}.
+ *
+ * <p>Seeded data (from {@link MongoQueryHandlerTestBase}): 5 PVs {@code testpv_1..5}, each with 10
+ * one-second buckets at seconds {@code [startSeconds .. startSeconds+9]}, 10 samples/bucket.
+ */
+public class MongoSyncQueryBucketsV2Test extends MongoQueryHandlerTestBase {
+
+    private static final int DEFAULT_PAGE_SIZE = 10_000;
+    private static final int MAX_PAGE_SIZE = 100_000;
+    private static final int MAX_RESOLVED_PVS = 10_000;
+
+    // a PV carrying column metadata, seeded separately to exercise excludeColumnMetadata
+    private static final String META_PV_NAME = "metapv_1";
+
+    protected static class TestSyncClient extends MongoSyncQueryClient implements TestClientInterface {
+        @Override
+        protected String getCollectionNameBuckets() {
+            return getTestCollectionNameBuckets();
+        }
+
+        @Override
+        protected String getCollectionNameRequestStatus() {
+            return getTestCollectionNameRequestStatus();
+        }
+
+        public int insertBucketDocuments(List<BucketDocument> documentList) {
+            InsertManyResult result = mongoCollectionBuckets.insertMany(documentList);
+            return result.getInsertedIds().size();
+        }
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        MongoTestClient.prepareTestDatabase();
+        TestSyncClient testClient = new TestSyncClient();
+        MongoQueryHandler handler = new MongoQueryHandler(testClient);
+        setUp(handler, testClient);
+
+        // seed one extra bucket for META_PV_NAME carrying ColumnMetadata (the base's buckets have none)
+        final List<BucketDocument> metaBuckets = new ArrayList<>();
+        metaBuckets.add(buildMetadataBucket(startSeconds));
+        assertEquals(metaBuckets.size(),
+                ((TestClientInterface) clientTestInterface).insertBucketDocuments(metaBuckets));
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        MongoQueryHandlerTestBase.tearDown();
+    }
+
+    // -----------------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------------
+
+    private static BucketDocument buildMetadataBucket(long firstSeconds) {
+        final BucketDocument bucket = new BucketDocument();
+        bucket.setId(META_PV_NAME + "-" + firstSeconds + "-0");
+        bucket.setPvName(META_PV_NAME);
+
+        // attach column metadata IN the DataColumn so it is embedded in the stored bytes — the legacy
+        // toDataColumn() path (used by addColumnToBucket) emits exactly what is in the bytes.
+        final ColumnMetadata columnMetadata = ColumnMetadata.newBuilder()
+                .addTags("beamline")
+                .build();
+        final DataColumn.Builder dataColumnBuilder = DataColumn.newBuilder()
+                .setName(META_PV_NAME)
+                .setMetadata(columnMetadata);
+        for (int i = 0; i < 10; i++) {
+            dataColumnBuilder.addDataValues(DataValue.newBuilder().setDoubleValue(i).build());
+        }
+        final DataColumnDocument columnDocument = DataColumnDocument.fromDataColumn(dataColumnBuilder.build());
+        bucket.setDataColumn(columnDocument);
+
+        final Timestamp startTime = TimestampUtility.timestampFromSeconds(firstSeconds, 0);
+        final SamplingClock samplingClock = SamplingClock.newBuilder()
+                .setStartTime(startTime).setPeriodNanos(100_000_000L).setCount(10).build();
+        bucket.setDataTimestamps(DataTimestampsDocument.fromDataTimestamps(
+                com.ospreydcs.dp.grpc.v1.common.DataTimestamps.newBuilder()
+                        .setSamplingClock(samplingClock).build()));
+        return bucket;
+    }
+
+    private QueryV2Resolver resolver() {
+        return new QueryV2Resolver(
+                clientTestInterface, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_RESOLVED_PVS);
+    }
+
+    private static Timestamp ts(long secs, long nanos) {
+        return Timestamp.newBuilder().setEpochSeconds(secs).setNanoseconds(nanos).build();
+    }
+
+    private static QueryBucketsRequest bucketsRequest(
+            List<String> pvNames, long beginSecs, long endSecs,
+            int limit, String pageToken, boolean excludeMetadata) {
+
+        final QuerySpec.Builder spec = QuerySpec.newBuilder()
+                .setTimeRange(TimeRange.newBuilder().setBeginTime(ts(beginSecs, 0)).setEndTime(ts(endSecs, 0)))
+                .setPvSelector(PvSelector.newBuilder()
+                        .setPvNameList(PvNameList.newBuilder().addAllPvNames(pvNames)));
+
+        final ExecutionOptions.Builder opts = ExecutionOptions.newBuilder().setLimit(limit);
+        if (pageToken != null) {
+            opts.setPageToken(pageToken);
+        }
+
+        return QueryBucketsRequest.newBuilder()
+                .setQuerySpec(spec)
+                .setExecutionOptions(opts)
+                .setResultRepresentation(ResultRepresentation.newBuilder()
+                        .setExcludeColumnMetadata(excludeMetadata))
+                .build();
+    }
+
+    /** Resolve + run the job synchronously; return the single collected response. */
+    private QueryBucketsResponse runQueryBuckets(QueryBucketsRequest request) {
+        final ResolutionResult resolution = resolver().resolve(
+                request.getQuerySpec(), request.getExecutionOptions(), request.getResultRepresentation(),
+                ResolvedQuery.ResultMode.BUCKET, false);
+        assertFalse("unexpected resolution error: "
+                + (resolution.isError() ? resolution.getErrorStatus().msg : ""), resolution.isError());
+        return runResolved(resolution.getResolvedQuery());
+    }
+
+    private QueryBucketsResponse runResolved(ResolvedQuery resolvedQuery) {
+        return runResolvedWithBudget(resolvedQuery, Long.MAX_VALUE);
+    }
+
+    private QueryBucketsResponse runResolvedWithBudget(ResolvedQuery resolvedQuery, long byteBudget) {
+        final List<QueryBucketsResponse> responses = new ArrayList<>();
+        final StreamObserver<QueryBucketsResponse> observer = new StreamObserver<>() {
+            @Override public void onNext(QueryBucketsResponse r) { responses.add(r); }
+            @Override public void onError(Throwable t) { }
+            @Override public void onCompleted() { }
+        };
+        final QueryBucketsUnaryDispatcher dispatcher =
+                new QueryBucketsUnaryDispatcher(observer, byteBudget);
+        new QueryV2Job(resolvedQuery, dispatcher, clientTestInterface).execute();
+        assertEquals("expected exactly one unary response", 1, responses.size());
+        return responses.get(0);
+    }
+
+    private ResolvedQuery resolvedForPv(String pvName, int limit, String pageToken) {
+        final QueryBucketsRequest request =
+                bucketsRequest(List.of(pvName), startSeconds, startSeconds + 10, limit, pageToken, false);
+        final ResolutionResult resolution = resolve(request);
+        assertFalse(resolution.isError());
+        return resolution.getResolvedQuery();
+    }
+
+    /** Resolve, returning the ResolutionResult (for error-path assertions). */
+    private ResolutionResult resolve(QueryBucketsRequest request) {
+        return resolver().resolve(
+                request.getQuerySpec(), request.getExecutionOptions(), request.getResultRepresentation(),
+                ResolvedQuery.ResultMode.BUCKET, false);
+    }
+
+    // -----------------------------------------------------------------------
+    // happy path
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSinglePvWholeRange() {
+        // testpv_1 has 10 buckets across [startSeconds, startSeconds+10)
+        final QueryBucketsResponse response = runQueryBuckets(
+                bucketsRequest(List.of(COL_1_NAME), startSeconds, startSeconds + 10, 0, null, false));
+
+        assertTrue(response.hasBucketQueryResult());
+        final QueryBucketsResponse.BucketQueryResult result = response.getBucketQueryResult();
+        assertEquals(10, result.getDataBucketsCount());
+        assertTrue("single full page => empty nextPageToken", result.getNextPageToken().isEmpty());
+        // all buckets belong to testpv_1, sorted by firstTime
+        long expectedSecond = startSeconds;
+        for (DataBucket b : result.getDataBucketsList()) {
+            assertEquals(COL_1_NAME, b.getPvName());
+            assertEquals(expectedSecond, b.getDataTimestamps().getSamplingClock().getStartTime().getEpochSeconds());
+            expectedSecond++;
+        }
+    }
+
+    @Test
+    public void testWholeBoundaryBucketsNotTrimmed() {
+        // a narrow window inside one bucket still returns that WHOLE bucket (10 samples), no trimming
+        final QueryBucketsResponse response = runQueryBuckets(
+                bucketsRequest(List.of(COL_1_NAME), startSeconds, startSeconds + 1, 0, null, false));
+        final QueryBucketsResponse.BucketQueryResult result = response.getBucketQueryResult();
+        assertEquals(1, result.getDataBucketsCount());
+        assertEquals(10, result.getDataBuckets(0).getDataValues().getDataColumn().getDataValuesCount());
+    }
+
+    @Test
+    public void testMultiplePvsSortedByPvThenTime() {
+        final QueryBucketsResponse response = runQueryBuckets(
+                bucketsRequest(List.of(COL_1_NAME, COL_2_NAME), startSeconds, startSeconds + 10, 0, null, false));
+        final QueryBucketsResponse.BucketQueryResult result = response.getBucketQueryResult();
+        assertEquals(20, result.getDataBucketsCount());
+        // first 10 are testpv_1, next 10 testpv_2 (sort is pvName, then firstTime)
+        for (int i = 0; i < 10; i++) {
+            assertEquals(COL_1_NAME, result.getDataBuckets(i).getPvName());
+        }
+        for (int i = 10; i < 20; i++) {
+            assertEquals(COL_2_NAME, result.getDataBuckets(i).getPvName());
+        }
+    }
+
+    @Test
+    public void testEmptyResultIsEmptyPayloadNotExceptional() {
+        // query a time window with no data (well before seeded data)
+        final QueryBucketsResponse response = runQueryBuckets(
+                bucketsRequest(List.of(COL_1_NAME), startSeconds - 1000, startSeconds - 900, 0, null, false));
+        assertFalse("empty result must NOT be an ExceptionalResult", response.hasExceptionalResult());
+        assertTrue(response.hasBucketQueryResult());
+        assertEquals(0, response.getBucketQueryResult().getDataBucketsCount());
+        assertTrue(response.getBucketQueryResult().getNextPageToken().isEmpty());
+    }
+
+    // -----------------------------------------------------------------------
+    // keyset paging (Q2)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testKeysetPagingAcrossMultiplePages() {
+        // page through testpv_1's 10 buckets, 4 per page => pages of 4,4,2
+        final List<DataBucket> collected = new ArrayList<>();
+        String token = null;
+        int pages = 0;
+        while (true) {
+            final QueryBucketsResponse response = runQueryBuckets(
+                    bucketsRequest(List.of(COL_1_NAME), startSeconds, startSeconds + 10, 4, token, false));
+            final QueryBucketsResponse.BucketQueryResult result = response.getBucketQueryResult();
+            collected.addAll(result.getDataBucketsList());
+            pages++;
+            token = result.getNextPageToken();
+            if (token.isEmpty()) {
+                break;
+            }
+            assertTrue("page must not exceed limit", result.getDataBucketsCount() <= 4);
+            assertTrue("safety: too many pages", pages < 10);
+        }
+        assertEquals(3, pages);
+        assertEquals(10, collected.size());
+        // no duplicates / no gaps: firstTime seconds strictly increasing across the full sequence
+        long expectedSecond = startSeconds;
+        for (DataBucket b : collected) {
+            assertEquals(expectedSecond, b.getDataTimestamps().getSamplingClock().getStartTime().getEpochSeconds());
+            expectedSecond++;
+        }
+    }
+
+    @Test
+    public void testLastPageHasEmptyToken() {
+        // exactly 10 buckets with limit 10 => one full page, no following page
+        final QueryBucketsResponse response = runQueryBuckets(
+                bucketsRequest(List.of(COL_1_NAME), startSeconds, startSeconds + 10, 10, null, false));
+        final QueryBucketsResponse.BucketQueryResult result = response.getBucketQueryResult();
+        assertEquals(10, result.getDataBucketsCount());
+        assertTrue(result.getNextPageToken().isEmpty());
+    }
+
+    @Test
+    public void testKeysetPagingSpansPvBoundary() {
+        // 2 PVs x 10 buckets = 20; page size 7 => 7,7,6 crossing the pv boundary at index 10
+        final List<DataBucket> collected = new ArrayList<>();
+        String token = null;
+        int pages = 0;
+        while (true) {
+            final QueryBucketsResponse response = runQueryBuckets(
+                    bucketsRequest(List.of(COL_1_NAME, COL_2_NAME), startSeconds, startSeconds + 10, 7, token, false));
+            final QueryBucketsResponse.BucketQueryResult result = response.getBucketQueryResult();
+            collected.addAll(result.getDataBucketsList());
+            pages++;
+            token = result.getNextPageToken();
+            if (token.isEmpty() || pages >= 10) {
+                break;
+            }
+        }
+        assertEquals(3, pages);
+        assertEquals(20, collected.size());
+        for (int i = 0; i < 10; i++) {
+            assertEquals(COL_1_NAME, collected.get(i).getPvName());
+        }
+        for (int i = 10; i < 20; i++) {
+            assertEquals(COL_2_NAME, collected.get(i).getPvName());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // $or fragmentation (Q3) — exercised via multiple resolved intervals
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testFragmentedIntervalsOrFilter() {
+        // build a ResolvedQuery directly with two disjoint intervals: [start,start+2) and [start+5,start+7)
+        // expect buckets at seconds start, start+1, start+5, start+6 (4 buckets)
+        final ResolvedQuery resolved = new ResolvedQuery(
+                List.of(COL_1_NAME),
+                List.of(
+                        new com.ospreydcs.dp.service.query.handler.model.TimeInterval(startSeconds, 0, startSeconds + 2, 0),
+                        new com.ospreydcs.dp.service.query.handler.model.TimeInterval(startSeconds + 5, 0, startSeconds + 7, 0)),
+                DEFAULT_PAGE_SIZE, null, false, false,
+                ResolvedQuery.ResultMode.BUCKET, false);
+
+        final QueryBucketsResponse response = runResolved(resolved);
+        final QueryBucketsResponse.BucketQueryResult result = response.getBucketQueryResult();
+        assertEquals(4, result.getDataBucketsCount());
+        final List<Long> seconds = new ArrayList<>();
+        for (DataBucket b : result.getDataBucketsList()) {
+            seconds.add(b.getDataTimestamps().getSamplingClock().getStartTime().getEpochSeconds());
+        }
+        assertEquals(List.of(startSeconds, startSeconds + 1, startSeconds + 5, startSeconds + 6), seconds);
+    }
+
+    // -----------------------------------------------------------------------
+    // representation flags
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testExcludeColumnMetadataDefaultIncludes() {
+        final QueryBucketsResponse response = runQueryBuckets(
+                bucketsRequest(List.of(META_PV_NAME), startSeconds, startSeconds + 1, 0, null, false));
+        final DataBucket bucket = response.getBucketQueryResult().getDataBuckets(0);
+        assertTrue("default should include column metadata",
+                bucket.getDataValues().getDataColumn().hasMetadata());
+        assertTrue(bucket.getDataValues().getDataColumn().getMetadata().getTagsList().contains("beamline"));
+    }
+
+    @Test
+    public void testExcludeColumnMetadataSuppresses() {
+        final QueryBucketsResponse response = runQueryBuckets(
+                bucketsRequest(List.of(META_PV_NAME), startSeconds, startSeconds + 1, 0, null, true));
+        final DataBucket bucket = response.getBucketQueryResult().getDataBuckets(0);
+        assertFalse("excludeColumnMetadata=true should suppress column metadata",
+                bucket.getDataValues().getDataColumn().hasMetadata());
+    }
+
+    // -----------------------------------------------------------------------
+    // byte-budget page boundary + indivisible-oversized (Q7)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testByteBudgetSplitsPageAndResumes() {
+        // Determine one bucket's serialized size, then set a budget that fits ~1 bucket per page so
+        // the byte guard (not the count limit) ends each page. Count limit is high (100) so it never
+        // fires; the split is driven purely by the byte budget.
+        final long oneBucketBytes = firstBucketSerializedSize(COL_1_NAME);
+        // budget large enough for exactly one bucket but not two
+        final long budget = oneBucketBytes + (oneBucketBytes / 2);
+
+        final List<DataBucket> collected = new ArrayList<>();
+        String token = null;
+        int pages = 0;
+        while (true) {
+            final ResolvedQuery resolved = resolvedForPv(COL_1_NAME, 100, token);
+            final QueryBucketsResponse response = runResolvedWithBudget(resolved, budget);
+            final QueryBucketsResponse.BucketQueryResult result = response.getBucketQueryResult();
+            assertFalse(response.hasExceptionalResult());
+            assertEquals("byte budget should limit each page to one bucket",
+                    1, result.getDataBucketsCount());
+            collected.add(result.getDataBuckets(0));
+            pages++;
+            token = result.getNextPageToken();
+            if (token.isEmpty() || pages >= 20) {
+                break;
+            }
+        }
+        assertEquals("10 buckets, ~1 per page", 10, pages);
+        assertEquals(10, collected.size());
+        // strictly increasing firstTime => no dup / no gap across the byte-split boundaries
+        long expectedSecond = startSeconds;
+        for (DataBucket b : collected) {
+            assertEquals(expectedSecond, b.getDataTimestamps().getSamplingClock().getStartTime().getEpochSeconds());
+            expectedSecond++;
+        }
+    }
+
+    @Test
+    public void testIndivisibleOversizedBucketErrors() {
+        // a budget smaller than a single bucket cannot page out of the first bucket => error
+        final long oneBucketBytes = firstBucketSerializedSize(COL_1_NAME);
+        final long tinyBudget = Math.max(1, oneBucketBytes - 1);
+
+        final ResolvedQuery resolved = resolvedForPv(COL_1_NAME, 100, null);
+        final QueryBucketsResponse response = runResolvedWithBudget(resolved, tinyBudget);
+        assertTrue("single oversized bucket must be an ExceptionalResult", response.hasExceptionalResult());
+        assertEquals(com.ospreydcs.dp.grpc.v1.common.ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR,
+                response.getExceptionalResult().getExceptionalResultStatus());
+    }
+
+    /** Serialized size of the first emitted bucket for a PV (matches the dispatcher's measurement). */
+    private long firstBucketSerializedSize(String pvName) {
+        final ResolvedQuery resolved = resolvedForPv(pvName, 100, null);
+        final QueryBucketsResponse response = runResolvedWithBudget(resolved, Long.MAX_VALUE);
+        return response.getBucketQueryResult().getDataBuckets(0).getSerializedSize();
+    }
+
+    // -----------------------------------------------------------------------
+    // §6 validation rejections
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testMissingTimeRangeRejected() {
+        final QueryBucketsRequest request = QueryBucketsRequest.newBuilder()
+                .setQuerySpec(QuerySpec.newBuilder()
+                        .setPvSelector(PvSelector.newBuilder()
+                                .setPvNameList(PvNameList.newBuilder().addPvNames(COL_1_NAME))))
+                .build();
+        final ResolutionResult r = resolve(request);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("timeRange"));
+    }
+
+    @Test
+    public void testMissingPvSelectorRejected() {
+        final QueryBucketsRequest request = QueryBucketsRequest.newBuilder()
+                .setQuerySpec(QuerySpec.newBuilder()
+                        .setTimeRange(TimeRange.newBuilder()
+                                .setBeginTime(ts(startSeconds, 0)).setEndTime(ts(startSeconds + 1, 0))))
+                .build();
+        final ResolutionResult r = resolve(request);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("pvSelector"));
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQuerySamplesV2Test.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQuerySamplesV2Test.java
@@ -205,6 +205,34 @@ public class MongoSyncQuerySamplesV2Test extends MongoQueryHandlerTestBase {
         return responses.get(0);
     }
 
+    // ---- streaming helpers ----
+
+    private static final class StreamOutcome {
+        final List<QuerySamplesResponse> messages = new ArrayList<>();
+        boolean completed = false;
+        boolean errored = false;
+    }
+
+    private StreamOutcome runSamplesStream(QuerySamplesRequest request, long byteBudget) {
+        final ResolutionResult resolution = resolver().resolve(
+                request.getQuerySpec(), request.getExecutionOptions(), request.getResultRepresentation(),
+                ResolvedQuery.ResultMode.SAMPLE, true /* streaming */);
+        assertFalse("unexpected streaming resolution error: "
+                + (resolution.isError() ? resolution.getErrorStatus().msg : ""), resolution.isError());
+
+        final StreamOutcome outcome = new StreamOutcome();
+        final StreamObserver<QuerySamplesResponse> observer = new StreamObserver<>() {
+            @Override public void onNext(QuerySamplesResponse r) { outcome.messages.add(r); }
+            @Override public void onError(Throwable t) { outcome.errored = true; }
+            @Override public void onCompleted() { outcome.completed = true; }
+        };
+        final com.ospreydcs.dp.service.query.handler.mongo.dispatch.QuerySamplesStreamDispatcher dispatcher =
+                new com.ospreydcs.dp.service.query.handler.mongo.dispatch.QuerySamplesStreamDispatcher(
+                        observer, byteBudget);
+        new QueryV2Job(resolution.getResolvedQuery(), dispatcher, clientTestInterface).execute();
+        return outcome;
+    }
+
     private static DataColumn columnByName(ColumnTable table, String pvName) {
         for (DataColumn c : table.getDataColumnsList()) {
             if (c.getName().equals(pvName)) {
@@ -412,5 +440,112 @@ public class MongoSyncQuerySamplesV2Test extends MongoQueryHandlerTestBase {
         assertTrue(response.hasSampleQueryResult());
         assertEquals(0, response.getSampleQueryResult().getColumnTable().getTimestampList().getTimestampsCount());
         assertTrue(response.getSampleQueryResult().getNextPageToken().isEmpty());
+    }
+
+    // -----------------------------------------------------------------------
+    // streaming (step 6) — querySamplesStream
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testStreamRowChunkingAlignedAcrossChunks() {
+        // 3-second spv_a window = 30 rows; chunk (limit) 7 => messages of 7,7,7,7,2
+        final StreamOutcome outcome = runSamplesStream(
+                samplesRequest(List.of(PV_A, PV_B), B, 0, B + NUM_SECONDS, 0, 7, null, false), Long.MAX_VALUE);
+
+        assertTrue(outcome.completed);
+        assertFalse(outcome.errored);
+        assertEquals(5, outcome.messages.size());
+
+        int totalRows = 0;
+        long prevNanoTotal = -1;
+        for (QuerySamplesResponse r : outcome.messages) {
+            assertTrue(r.hasSampleQueryResult());
+            final QuerySamplesResponse.SampleQueryResult result = r.getSampleQueryResult();
+            assertTrue("streamed token must be empty", result.getNextPageToken().isEmpty());
+            final ColumnTable table = result.getColumnTable();
+            // column set stable across chunks: both PVs, sorted, timestamp/column row counts aligned
+            assertEquals(2, table.getDataColumnsCount());
+            assertEquals(PV_A, table.getDataColumns(0).getName());
+            assertEquals(PV_B, table.getDataColumns(1).getName());
+            final int rows = table.getTimestampList().getTimestampsCount();
+            assertTrue(rows <= 7);
+            assertEquals(rows, table.getDataColumns(0).getDataValuesCount());
+            assertEquals(rows, table.getDataColumns(1).getDataValuesCount());
+            totalRows += rows;
+            // seam: timestamps strictly increasing across chunk boundaries
+            for (Timestamp t : table.getTimestampList().getTimestampsList()) {
+                final long nanoTotal = t.getEpochSeconds() * 1_000_000_000L + t.getNanoseconds();
+                assertTrue("timestamps strictly increasing across chunks", nanoTotal > prevNanoTotal);
+                prevNanoTotal = nanoTotal;
+            }
+        }
+        assertEquals(30, totalRows);
+    }
+
+    @Test
+    public void testStreamSingleFullChunk() {
+        final StreamOutcome outcome = runSamplesStream(
+                samplesRequest(List.of(PV_A), B, 0, B + 1, 0, 1000, null, false), Long.MAX_VALUE);
+        assertTrue(outcome.completed);
+        assertEquals(1, outcome.messages.size());
+        assertEquals(10, outcome.messages.get(0).getSampleQueryResult().getColumnTable()
+                .getTimestampList().getTimestampsCount());
+    }
+
+    @Test
+    public void testStreamEmptyResultSingleEmptyMessage() {
+        final StreamOutcome outcome = runSamplesStream(
+                samplesRequest(List.of(PV_A), B - 1000, 0, B - 900, 0, 10, null, false), Long.MAX_VALUE);
+        assertTrue(outcome.completed);
+        assertEquals(1, outcome.messages.size());
+        assertFalse(outcome.messages.get(0).hasExceptionalResult());
+        assertEquals(0, outcome.messages.get(0).getSampleQueryResult().getColumnTable()
+                .getTimestampList().getTimestampsCount());
+    }
+
+    @Test
+    public void testStreamRejectsNonEmptyPageToken() {
+        final String token = com.ospreydcs.dp.service.query.handler.paging.PageToken.encode(
+                com.ospreydcs.dp.service.query.handler.model.KeysetPosition.ofSample(B, 0));
+        final QuerySamplesRequest request =
+                samplesRequest(List.of(PV_A), B, 0, B + NUM_SECONDS, 0, 5, token, false);
+        final ResolutionResult resolution = resolver().resolve(
+                request.getQuerySpec(), request.getExecutionOptions(), request.getResultRepresentation(),
+                ResolvedQuery.ResultMode.SAMPLE, true);
+        assertTrue(resolution.isError());
+        assertTrue(resolution.getErrorStatus().msg.contains("streaming"));
+    }
+
+    @Test
+    public void testStreamByteBudgetChunkFlush() {
+        // tiny budget forces multiple chunks even though limit is huge; verify every row delivered once
+        final StreamOutcome outcome = runSamplesStream(
+                samplesRequest(List.of(PV_A), B, 0, B + NUM_SECONDS, 0, 10_000, null, false), 40);
+        assertTrue(outcome.completed);
+        assertTrue("byte budget should force multiple chunks", outcome.messages.size() > 1);
+        int totalRows = 0;
+        long prevNanoTotal = -1;
+        for (QuerySamplesResponse r : outcome.messages) {
+            final ColumnTable table = r.getSampleQueryResult().getColumnTable();
+            totalRows += table.getTimestampList().getTimestampsCount();
+            for (Timestamp t : table.getTimestampList().getTimestampsList()) {
+                final long nanoTotal = t.getEpochSeconds() * 1_000_000_000L + t.getNanoseconds();
+                assertTrue(nanoTotal > prevNanoTotal); // no dup / no gap-reorder across byte-flushed chunks
+                prevNanoTotal = nanoTotal;
+            }
+        }
+        assertEquals(30, totalRows);
+    }
+
+    @Test
+    public void testStreamNonScalarRejected() {
+        final StreamOutcome outcome = runSamplesStream(
+                samplesRequest(List.of(PV_ARR), B, 0, B + 1, 0, 10, null, false), Long.MAX_VALUE);
+        assertFalse(outcome.messages.isEmpty());
+        final QuerySamplesResponse last = outcome.messages.get(outcome.messages.size() - 1);
+        assertTrue(last.hasExceptionalResult());
+        assertEquals(com.ospreydcs.dp.grpc.v1.common.ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
+                last.getExceptionalResult().getExceptionalResultStatus());
+        assertTrue(last.getExceptionalResult().getMessage().contains(PV_ARR));
     }
 }

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQuerySamplesV2Test.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQuerySamplesV2Test.java
@@ -518,9 +518,11 @@ public class MongoSyncQuerySamplesV2Test extends MongoQueryHandlerTestBase {
 
     @Test
     public void testStreamByteBudgetChunkFlush() {
-        // tiny budget forces multiple chunks even though limit is huge; verify every row delivered once
+        // small budget forces multiple chunks even though limit is huge; verify every row delivered
+        // once. The budget must clear the conservative single-row estimate (timestamp + one labeled
+        // double column + framing, ~52 bytes) but not two rows, so each chunk carries ~one row.
         final StreamOutcome outcome = runSamplesStream(
-                samplesRequest(List.of(PV_A), B, 0, B + NUM_SECONDS, 0, 10_000, null, false), 40);
+                samplesRequest(List.of(PV_A), B, 0, B + NUM_SECONDS, 0, 10_000, null, false), 60);
         assertTrue(outcome.completed);
         assertTrue("byte budget should force multiple chunks", outcome.messages.size() > 1);
         int totalRows = 0;
@@ -547,5 +549,39 @@ public class MongoSyncQuerySamplesV2Test extends MongoQueryHandlerTestBase {
         assertEquals(com.ospreydcs.dp.grpc.v1.common.ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
                 last.getExceptionalResult().getExceptionalResultStatus());
         assertTrue(last.getExceptionalResult().getMessage().contains(PV_ARR));
+    }
+
+    // -----------------------------------------------------------------------
+    // indivisible-oversized single row (byte budget below one row's cost)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testUnaryOversizedSingleTimestampErrors() {
+        // When the byte-driven boundary would drop the ONLY assembled timestamp (a bucket that clips
+        // to a single distinct timestamp in the window, tripping the size limit), keepCount becomes 0.
+        // Dropping it and resuming there would re-assemble the identical row on the next page and hit
+        // the same boundary forever (zero-progress infinite loop of empty pages). The dispatcher must
+        // ERROR instead. Window [B, B+1@1ns) clips spv_a to its single first sample at B.0.
+        final QuerySamplesResponse response = runSamplesWithBudget(
+                samplesRequest(List.of(PV_A), B, 0, B, 1, 10_000, null, false), 1);
+        assertTrue(response.hasExceptionalResult());
+        assertEquals(com.ospreydcs.dp.grpc.v1.common.ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR,
+                response.getExceptionalResult().getExceptionalResultStatus());
+        assertTrue(response.getExceptionalResult().getMessage().contains("exceeds the outgoing message size limit"));
+    }
+
+    @Test
+    public void testStreamIndivisibleOversizedRowErrors() {
+        // Streaming analog: a single row larger than the whole budget cannot be chunked. Rather than
+        // emit an over-limit message that gRPC would abort the stream on, the dispatcher errors out
+        // naming the timestamp (mirrors the buckets streaming isIndivisibleOversized guard).
+        final StreamOutcome outcome = runSamplesStream(
+                samplesRequest(List.of(PV_A), B, 0, B + NUM_SECONDS, 0, 10_000, null, false), 1);
+        assertFalse(outcome.messages.isEmpty());
+        final QuerySamplesResponse last = outcome.messages.get(outcome.messages.size() - 1);
+        assertTrue(last.hasExceptionalResult());
+        assertEquals(com.ospreydcs.dp.grpc.v1.common.ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR,
+                last.getExceptionalResult().getExceptionalResultStatus());
+        assertTrue(last.getExceptionalResult().getMessage().contains("exceeds the outgoing message size limit"));
     }
 }

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQuerySamplesV2Test.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQuerySamplesV2Test.java
@@ -1,0 +1,416 @@
+package com.ospreydcs.dp.service.query.handler.mongo;
+
+import com.mongodb.client.result.InsertManyResult;
+import com.ospreydcs.dp.grpc.v1.common.ArrayDimensions;
+import com.ospreydcs.dp.grpc.v1.common.DataColumn;
+import com.ospreydcs.dp.grpc.v1.common.DataTimestamps;
+import com.ospreydcs.dp.grpc.v1.common.DataValue;
+import com.ospreydcs.dp.grpc.v1.common.DoubleArrayColumn;
+import com.ospreydcs.dp.grpc.v1.common.SamplingClock;
+import com.ospreydcs.dp.grpc.v1.common.TimeRange;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.grpc.v1.query.ColumnTable;
+import com.ospreydcs.dp.grpc.v1.query.ExecutionOptions;
+import com.ospreydcs.dp.grpc.v1.query.PvNameList;
+import com.ospreydcs.dp.grpc.v1.query.PvSelector;
+import com.ospreydcs.dp.grpc.v1.query.QuerySamplesRequest;
+import com.ospreydcs.dp.grpc.v1.query.QuerySamplesResponse;
+import com.ospreydcs.dp.grpc.v1.query.QuerySpec;
+import com.ospreydcs.dp.grpc.v1.query.ResultRepresentation;
+import com.ospreydcs.dp.service.common.bson.DataTimestampsDocument;
+import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
+import com.ospreydcs.dp.service.common.bson.column.DataColumnDocument;
+import com.ospreydcs.dp.service.common.bson.column.DoubleArrayColumnDocument;
+import com.ospreydcs.dp.service.common.exception.DpException;
+import com.ospreydcs.dp.service.common.mongo.MongoTestClient;
+import com.ospreydcs.dp.service.common.protobuf.TimestampUtility;
+import com.ospreydcs.dp.service.query.handler.QueryV2Resolver;
+import com.ospreydcs.dp.service.query.handler.model.ResolutionResult;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.mongo.client.MongoSyncQueryClient;
+import com.ospreydcs.dp.service.query.handler.mongo.dispatch.QuerySamplesUnaryDispatcher;
+import com.ospreydcs.dp.service.query.handler.mongo.job.QueryV2Job;
+import io.grpc.stub.StreamObserver;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * End-to-end tests for Query API V2 {@code querySamples} unary against real MongoDB: union-axis
+ * alignment with multi-rate PVs + missing values, half-open trimming, timestamp-advanced paging
+ * (Q1) with a seam invariant (no dropped/duplicated timestamp), column seeding (Q9), non-scalar
+ * reject (Q4), and useSerializedColumns (Q5).
+ *
+ * <p>Seeds its own PVs on a time base well after the base class's data:
+ * <ul>
+ *   <li>{@code spv_a}: 10 Hz (100ms period), seconds [B, B+3) → nanos 0,1e8..9e8 each second</li>
+ *   <li>{@code spv_b}: 5 Hz (200ms period), seconds [B, B+3) → nanos 0,2e8,4e8,6e8,8e8 each second</li>
+ *   <li>{@code sarr}: a non-scalar double-array PV at second B (for the Q4 reject)</li>
+ * </ul>
+ */
+public class MongoSyncQuerySamplesV2Test extends MongoQueryHandlerTestBase {
+
+    private static final int DEFAULT_PAGE_SIZE = 10_000;
+    private static final int MAX_PAGE_SIZE = 100_000;
+    private static final int MAX_RESOLVED_PVS = 10_000;
+
+    private static final long B = startSeconds + 100_000L; // isolated time base
+    private static final int NUM_SECONDS = 3;
+    private static final String PV_A = "spv_a"; // 10 Hz
+    private static final String PV_B = "spv_b"; // 5 Hz
+    private static final String PV_ARR = "sarr"; // non-scalar
+
+    protected static class TestSyncClient extends MongoSyncQueryClient implements TestClientInterface {
+        @Override protected String getCollectionNameBuckets() { return getTestCollectionNameBuckets(); }
+        @Override protected String getCollectionNameRequestStatus() { return getTestCollectionNameRequestStatus(); }
+        public int insertBucketDocuments(List<BucketDocument> documentList) {
+            InsertManyResult result = mongoCollectionBuckets.insertMany(documentList);
+            return result.getInsertedIds().size();
+        }
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        MongoTestClient.prepareTestDatabase();
+        TestSyncClient testClient = new TestSyncClient();
+        MongoQueryHandler handler = new MongoQueryHandler(testClient);
+        setUp(handler, testClient);
+
+        final List<BucketDocument> buckets = new ArrayList<>();
+        for (int s = 0; s < NUM_SECONDS; s++) {
+            buckets.add(scalarBucket(PV_A, B + s, 100_000_000L, 10)); // 10 Hz
+            buckets.add(scalarBucket(PV_B, B + s, 200_000_000L, 5));  // 5 Hz
+        }
+        buckets.add(arrayBucket(PV_ARR, B));
+        assertEquals(buckets.size(),
+                ((TestClientInterface) clientTestInterface).insertBucketDocuments(buckets));
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        MongoQueryHandlerTestBase.tearDown();
+    }
+
+    // -----------------------------------------------------------------------
+    // seeding helpers
+    // -----------------------------------------------------------------------
+
+    private static BucketDocument scalarBucket(String pvName, long second, long periodNanos, int count) {
+        final BucketDocument bucket = new BucketDocument();
+        bucket.setId(pvName + "-" + second + "-0");
+        bucket.setPvName(pvName);
+
+        final DataColumn.Builder columnBuilder = DataColumn.newBuilder().setName(pvName);
+        for (int i = 0; i < count; i++) {
+            columnBuilder.addDataValues(DataValue.newBuilder().setDoubleValue(second * 1000 + i).build());
+        }
+        bucket.setDataColumn(DataColumnDocument.fromDataColumn(columnBuilder.build()));
+
+        final SamplingClock clock = SamplingClock.newBuilder()
+                .setStartTime(TimestampUtility.timestampFromSeconds(second, 0))
+                .setPeriodNanos(periodNanos)
+                .setCount(count)
+                .build();
+        bucket.setDataTimestamps(DataTimestampsDocument.fromDataTimestamps(
+                DataTimestamps.newBuilder().setSamplingClock(clock).build()));
+        return bucket;
+    }
+
+    private static BucketDocument arrayBucket(String pvName, long second) throws DpException {
+        final BucketDocument bucket = new BucketDocument();
+        bucket.setId(pvName + "-" + second + "-0");
+        bucket.setPvName(pvName);
+
+        // one sample of a length-2 double array
+        final DoubleArrayColumn arrayColumn = DoubleArrayColumn.newBuilder()
+                .setName(pvName)
+                .setDimensions(ArrayDimensions.newBuilder().addDims(2))
+                .addValues(1.0).addValues(2.0)
+                .build();
+        bucket.setDataColumn(DoubleArrayColumnDocument.fromDoubleArrayColumn(arrayColumn));
+
+        final SamplingClock clock = SamplingClock.newBuilder()
+                .setStartTime(TimestampUtility.timestampFromSeconds(second, 0))
+                .setPeriodNanos(100_000_000L)
+                .setCount(1)
+                .build();
+        bucket.setDataTimestamps(DataTimestampsDocument.fromDataTimestamps(
+                DataTimestamps.newBuilder().setSamplingClock(clock).build()));
+        return bucket;
+    }
+
+    // -----------------------------------------------------------------------
+    // request + run helpers
+    // -----------------------------------------------------------------------
+
+    private QueryV2Resolver resolver() {
+        return new QueryV2Resolver(clientTestInterface, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_RESOLVED_PVS);
+    }
+
+    private static Timestamp ts(long secs, long nanos) {
+        return Timestamp.newBuilder().setEpochSeconds(secs).setNanoseconds(nanos).build();
+    }
+
+    private static QuerySamplesRequest samplesRequest(
+            List<String> pvNames, long beginSecs, long beginNanos, long endSecs, long endNanos,
+            int limit, String pageToken, boolean useSerialized) {
+
+        final QuerySpec.Builder spec = QuerySpec.newBuilder()
+                .setTimeRange(TimeRange.newBuilder()
+                        .setBeginTime(ts(beginSecs, beginNanos)).setEndTime(ts(endSecs, endNanos)))
+                .setPvSelector(PvSelector.newBuilder()
+                        .setPvNameList(PvNameList.newBuilder().addAllPvNames(pvNames)));
+
+        final ExecutionOptions.Builder opts = ExecutionOptions.newBuilder().setLimit(limit);
+        if (pageToken != null) {
+            opts.setPageToken(pageToken);
+        }
+
+        return QuerySamplesRequest.newBuilder()
+                .setQuerySpec(spec)
+                .setExecutionOptions(opts)
+                .setResultRepresentation(ResultRepresentation.newBuilder().setUseSerializedColumns(useSerialized))
+                .build();
+    }
+
+    private ResolutionResult resolve(QuerySamplesRequest request) {
+        return resolver().resolve(
+                request.getQuerySpec(), request.getExecutionOptions(), request.getResultRepresentation(),
+                ResolvedQuery.ResultMode.SAMPLE, false);
+    }
+
+    private QuerySamplesResponse runSamples(QuerySamplesRequest request) {
+        return runSamplesWithBudget(request, Long.MAX_VALUE);
+    }
+
+    private QuerySamplesResponse runSamplesWithBudget(QuerySamplesRequest request, long byteBudget) {
+        final ResolutionResult resolution = resolve(request);
+        assertFalse("unexpected resolution error: "
+                + (resolution.isError() ? resolution.getErrorStatus().msg : ""), resolution.isError());
+
+        final List<QuerySamplesResponse> responses = new ArrayList<>();
+        final StreamObserver<QuerySamplesResponse> observer = new StreamObserver<>() {
+            @Override public void onNext(QuerySamplesResponse r) { responses.add(r); }
+            @Override public void onError(Throwable t) { }
+            @Override public void onCompleted() { }
+        };
+        final QuerySamplesUnaryDispatcher dispatcher = new QuerySamplesUnaryDispatcher(observer, byteBudget);
+        new QueryV2Job(resolution.getResolvedQuery(), dispatcher, clientTestInterface).execute();
+        assertEquals("expected exactly one unary response", 1, responses.size());
+        return responses.get(0);
+    }
+
+    private static DataColumn columnByName(ColumnTable table, String pvName) {
+        for (DataColumn c : table.getDataColumnsList()) {
+            if (c.getName().equals(pvName)) {
+                return c;
+            }
+        }
+        fail("column not found: " + pvName);
+        return null;
+    }
+
+    // -----------------------------------------------------------------------
+    // union axis + missing values + column seeding
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testUnionAxisMultiRateWithMissingValues() {
+        // one second window [B, B+1): spv_a has 10 rows, spv_b has 5 (present at even nanos)
+        final QuerySamplesResponse response =
+                runSamples(samplesRequest(List.of(PV_A, PV_B), B, 0, B + 1, 0, 0, null, false));
+
+        assertTrue(response.hasSampleQueryResult());
+        final ColumnTable table = response.getSampleQueryResult().getColumnTable();
+
+        assertEquals("union axis = spv_a's 10 timestamps", 10, table.getTimestampList().getTimestampsCount());
+        // both resolved PVs get a column, sorted by name (Q9)
+        assertEquals(2, table.getDataColumnsCount());
+        assertEquals(PV_A, table.getDataColumns(0).getName());
+        assertEquals(PV_B, table.getDataColumns(1).getName());
+
+        final DataColumn colB = columnByName(table, PV_B);
+        assertEquals(10, colB.getDataValuesCount());
+        // spv_b present at even indices (0,2,4,6,8), unset at odd
+        int present = 0;
+        for (int i = 0; i < 10; i++) {
+            final boolean hasValue = colB.getDataValues(i).getValueCase() != DataValue.ValueCase.VALUE_NOT_SET;
+            if (i % 2 == 0) {
+                assertTrue("spv_b should have a value at row " + i, hasValue);
+                present++;
+            } else {
+                assertFalse("spv_b should be unset at row " + i, hasValue);
+            }
+        }
+        assertEquals(5, present);
+    }
+
+    @Test
+    public void testEveryResolvedPvGetsColumnIncludingAllUnset() {
+        // query only PV_A's rate window but include PV_B AND a resolved PV with no data in-range.
+        // Use a sub-window where spv_b HAS data but restrict... simplest: window [B,B+1) already covers
+        // both; here assert PV_B column exists even if we shrink to a nanos slice where spv_b is absent.
+        // Window [B+1e8, B+2e8): only spv_a has a sample (at B+1e8); spv_b absent entirely => all-unset.
+        final QuerySamplesResponse response = runSamples(
+                samplesRequest(List.of(PV_A, PV_B), B, 100_000_000L, B, 200_000_000L, 0, null, false));
+        final ColumnTable table = response.getSampleQueryResult().getColumnTable();
+
+        assertEquals(1, table.getTimestampList().getTimestampsCount()); // just B+1e8
+        assertEquals(2, table.getDataColumnsCount());
+        final DataColumn colB = columnByName(table, PV_B);
+        assertEquals(1, colB.getDataValuesCount());
+        assertEquals("spv_b has no sample in this slice => all-unset column",
+                DataValue.ValueCase.VALUE_NOT_SET, colB.getDataValues(0).getValueCase());
+    }
+
+    // -----------------------------------------------------------------------
+    // half-open trimming
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testHalfOpenTrimmingDropsBoundarySamples() {
+        // window [B, B+1e8) is half-open: includes B (nano 0) but excludes B+1e8. Only 1 timestamp.
+        final QuerySamplesResponse response = runSamples(
+                samplesRequest(List.of(PV_A), B, 0, B, 100_000_000L, 0, null, false));
+        final ColumnTable table = response.getSampleQueryResult().getColumnTable();
+        assertEquals(1, table.getTimestampList().getTimestampsCount());
+        assertEquals(0, table.getTimestampList().getTimestamps(0).getNanoseconds());
+    }
+
+    // -----------------------------------------------------------------------
+    // timestamp paging (Q1) — seam invariant
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testTimestampPagingSeamNoGapNoOverlap() {
+        // full 3-second window for spv_a = 30 timestamps; page by 7 => 7,7,7,7,2
+        final List<Timestamp> collected = new ArrayList<>();
+        String token = null;
+        int pages = 0;
+        while (true) {
+            final QuerySamplesResponse response = runSamples(
+                    samplesRequest(List.of(PV_A), B, 0, B + NUM_SECONDS, 0, 7, token, false));
+            final QuerySamplesResponse.SampleQueryResult result = response.getSampleQueryResult();
+            collected.addAll(result.getColumnTable().getTimestampList().getTimestampsList());
+            pages++;
+            token = result.getNextPageToken();
+            if (token.isEmpty() || pages >= 20) {
+                break;
+            }
+            assertTrue("page must not exceed limit", result.getColumnTable().getTimestampList().getTimestampsCount() <= 7);
+        }
+        assertEquals(5, pages);
+        assertEquals(30, collected.size());
+        // seam invariant: strictly increasing, no dup, no gap (spv_a is a regular 100ms grid)
+        for (int i = 1; i < collected.size(); i++) {
+            final long prev = collected.get(i - 1).getEpochSeconds() * 1_000_000_000L + collected.get(i - 1).getNanoseconds();
+            final long cur = collected.get(i).getEpochSeconds() * 1_000_000_000L + collected.get(i).getNanoseconds();
+            assertEquals("consecutive timestamps must be exactly one 100ms step apart at the seam",
+                    100_000_000L, cur - prev);
+        }
+    }
+
+    @Test
+    public void testLastPageEmptyToken() {
+        // exactly 10 timestamps in [B,B+1) with limit 10 => one page, empty token
+        final QuerySamplesResponse response = runSamples(
+                samplesRequest(List.of(PV_A), B, 0, B + 1, 0, 10, null, false));
+        final QuerySamplesResponse.SampleQueryResult result = response.getSampleQueryResult();
+        assertEquals(10, result.getColumnTable().getTimestampList().getTimestampsCount());
+        assertTrue(result.getNextPageToken().isEmpty());
+    }
+
+    @Test
+    public void testByteBudgetPagingSeamNoGapNoOverlap() {
+        // Force byte-driven page boundaries with a small budget, then page the full spv_a window and
+        // verify the seam invariant holds across byte-driven cuts (the last, possibly-incomplete
+        // timestamp of each page is dropped and re-queried, so no gap and no duplicate).
+        // Size one row: run one page unbounded, measure a single-row column table's per-row cost via
+        // the serialized size of the whole 30-row result divided out is fragile; instead pick a tiny
+        // absolute budget that admits only a few rows and rely on truncation correctness.
+        final long smallBudget = 40; // bytes — admits a couple of rows per page
+
+        final List<Timestamp> collected = new ArrayList<>();
+        String token = null;
+        int pages = 0;
+        while (true) {
+            final QuerySamplesResponse response = runSamplesWithBudget(
+                    samplesRequest(List.of(PV_A), B, 0, B + NUM_SECONDS, 0, 10_000, token, false),
+                    smallBudget);
+            final QuerySamplesResponse.SampleQueryResult result = response.getSampleQueryResult();
+            assertFalse(response.hasExceptionalResult());
+            collected.addAll(result.getColumnTable().getTimestampList().getTimestampsList());
+            pages++;
+            token = result.getNextPageToken();
+            if (token.isEmpty() || pages >= 100) {
+                break;
+            }
+            // each byte-bounded page must make progress (>= 1 row) to avoid an infinite loop
+            assertTrue("byte-bounded page must emit at least one row",
+                    result.getColumnTable().getTimestampList().getTimestampsCount() >= 1);
+        }
+        assertTrue("should terminate well within the safety cap", pages < 100);
+        assertEquals(30, collected.size());
+        for (int i = 1; i < collected.size(); i++) {
+            final long prev = collected.get(i - 1).getEpochSeconds() * 1_000_000_000L + collected.get(i - 1).getNanoseconds();
+            final long cur = collected.get(i).getEpochSeconds() * 1_000_000_000L + collected.get(i).getNanoseconds();
+            assertEquals("no gap/overlap across byte-driven seam", 100_000_000L, cur - prev);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // non-scalar reject (Q4)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testNonScalarPvRejected() {
+        final QuerySamplesResponse response = runSamples(
+                samplesRequest(List.of(PV_ARR), B, 0, B + 1, 0, 0, null, false));
+        assertTrue(response.hasExceptionalResult());
+        assertEquals(com.ospreydcs.dp.grpc.v1.common.ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
+                response.getExceptionalResult().getExceptionalResultStatus());
+        final String msg = response.getExceptionalResult().getMessage();
+        assertTrue("reject must name the PV", msg.contains(PV_ARR));
+        assertTrue("reject must point at queryBuckets", msg.contains("queryBuckets"));
+    }
+
+    // -----------------------------------------------------------------------
+    // useSerializedColumns (Q5)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testUseSerializedColumnsPopulatesSerializedListOnly() {
+        final QuerySamplesResponse response = runSamples(
+                samplesRequest(List.of(PV_A, PV_B), B, 0, B + 1, 0, 0, null, true));
+        final ColumnTable table = response.getSampleQueryResult().getColumnTable();
+        assertEquals("dataColumns must be empty when serialized requested", 0, table.getDataColumnsCount());
+        assertEquals("serializedDataColumns must carry all resolved PVs", 2, table.getSerializedDataColumnsCount());
+        // payload must parse back to a DataColumn with the expected name
+        try {
+            final DataColumn parsed = DataColumn.parseFrom(table.getSerializedDataColumns(0).getPayload());
+            assertEquals(PV_A, parsed.getName());
+            assertEquals(10, parsed.getDataValuesCount());
+        } catch (Exception e) {
+            fail("serialized payload should parse as DataColumn: " + e.getMessage());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // empty result
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testEmptyResultIsEmptyColumnTable() {
+        final QuerySamplesResponse response = runSamples(
+                samplesRequest(List.of(PV_A), B - 1000, 0, B - 900, 0, 0, null, false));
+        assertFalse(response.hasExceptionalResult());
+        assertTrue(response.hasSampleQueryResult());
+        assertEquals(0, response.getSampleQueryResult().getColumnTable().getTimestampList().getTimestampsCount());
+        assertTrue(response.getSampleQueryResult().getNextPageToken().isEmpty());
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/paging/PageTokenTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/paging/PageTokenTest.java
@@ -1,0 +1,110 @@
+package com.ospreydcs.dp.service.query.handler.paging;
+
+import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link PageToken} — the opaque, position-only page-token codec (Q1/Q2/Q3).
+ * Verifies round-trip for both bucket and sample positions (including a pvName containing the
+ * internal delimiter) and that malformed tokens are rejected rather than silently treated as page 1.
+ */
+public class PageTokenTest {
+
+    // -----------------------------------------------------------------------
+    // round-trip
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testBucketRoundTrip() throws PageTokenException {
+        final KeysetPosition original = KeysetPosition.ofBucket("S01:BPM:X", 1_700_000_000L, 123_456_789L);
+        final String token = PageToken.encode(original);
+        assertEquals(original, PageToken.decode(token));
+    }
+
+    @Test
+    public void testSampleRoundTrip() throws PageTokenException {
+        final KeysetPosition original = KeysetPosition.ofSample(1_700_000_050L, 999_999_999L);
+        final String token = PageToken.encode(original);
+        assertEquals(original, PageToken.decode(token));
+    }
+
+    @Test
+    public void testBucketPvNameWithDelimiterRoundTrips() throws PageTokenException {
+        // the internal delimiter is '|'; length-prefixing must make an embedded '|' survive
+        final KeysetPosition original = KeysetPosition.ofBucket("weird|pv|name", 5L, 6L);
+        final KeysetPosition decoded = PageToken.decode(PageToken.encode(original));
+        assertEquals(original, decoded);
+        assertEquals("weird|pv|name", decoded.getPvName());
+    }
+
+    @Test
+    public void testBucketEmptyPvNameRoundTrips() throws PageTokenException {
+        final KeysetPosition original = KeysetPosition.ofBucket("", 0L, 0L);
+        assertEquals(original, PageToken.decode(PageToken.encode(original)));
+    }
+
+    @Test
+    public void testTokenIsOpaqueUrlSafeBase64() {
+        final String token = PageToken.encode(KeysetPosition.ofSample(1L, 2L));
+        // URL-safe alphabet: no '+', '/', or '=' padding
+        assertFalse(token.contains("+"));
+        assertFalse(token.contains("/"));
+        assertFalse(token.contains("="));
+    }
+
+    // -----------------------------------------------------------------------
+    // malformed → reject
+    // -----------------------------------------------------------------------
+
+    @Test(expected = PageTokenException.class)
+    public void testDecodeNullRejected() throws PageTokenException {
+        PageToken.decode(null);
+    }
+
+    @Test(expected = PageTokenException.class)
+    public void testDecodeBlankRejected() throws PageTokenException {
+        PageToken.decode("   ");
+    }
+
+    @Test(expected = PageTokenException.class)
+    public void testDecodeNonBase64Rejected() throws PageTokenException {
+        PageToken.decode("!!! not base64 !!!");
+    }
+
+    @Test(expected = PageTokenException.class)
+    public void testDecodeWrongVersionRejected() throws PageTokenException {
+        final String payload = "9|S|1|2"; // version 9 unsupported
+        final String token = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+        PageToken.decode(token);
+    }
+
+    @Test(expected = PageTokenException.class)
+    public void testDecodeUnknownKindRejected() throws PageTokenException {
+        final String payload = "1|Z|1|2"; // kind Z unknown
+        final String token = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+        PageToken.decode(token);
+    }
+
+    @Test(expected = PageTokenException.class)
+    public void testDecodeNonNumericFieldRejected() throws PageTokenException {
+        final String payload = "1|S|abc|2"; // seconds not numeric
+        final String token = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+        PageToken.decode(token);
+    }
+
+    @Test(expected = PageTokenException.class)
+    public void testDecodeTruncatedSampleRejected() throws PageTokenException {
+        final String payload = "1|S|1"; // missing nanos
+        final String token = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+        PageToken.decode(token);
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/query/server/QueryGrpcTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/server/QueryGrpcTest.java
@@ -120,6 +120,10 @@ public class QueryGrpcTest extends QueryTestBase {
         public void handleQuerySamples(QuerySamplesRequest request, StreamObserver<QuerySamplesResponse> responseObserver) {
         }
 
+        @Override
+        public void handleQuerySamplesStream(QuerySamplesRequest request, StreamObserver<QuerySamplesResponse> responseObserver) {
+        }
+
     }
 
     protected static class TestQueryClient {

--- a/src/test/java/com/ospreydcs/dp/service/query/server/QueryGrpcTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/server/QueryGrpcTest.java
@@ -116,6 +116,10 @@ public class QueryGrpcTest extends QueryTestBase {
         public void handleQueryBucketsStream(QueryBucketsRequest request, StreamObserver<QueryBucketsResponse> responseObserver) {
         }
 
+        @Override
+        public void handleQuerySamples(QuerySamplesRequest request, StreamObserver<QuerySamplesResponse> responseObserver) {
+        }
+
     }
 
     protected static class TestQueryClient {

--- a/src/test/java/com/ospreydcs/dp/service/query/server/QueryGrpcTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/server/QueryGrpcTest.java
@@ -108,6 +108,10 @@ public class QueryGrpcTest extends QueryTestBase {
         public void handleQueryProviderStats(QueryProviderStatsRequest request, StreamObserver<QueryProviderStatsResponse> responseObserver) {
         }
 
+        @Override
+        public void handleQueryBuckets(QueryBucketsRequest request, StreamObserver<QueryBucketsResponse> responseObserver) {
+        }
+
     }
 
     protected static class TestQueryClient {

--- a/src/test/java/com/ospreydcs/dp/service/query/server/QueryGrpcTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/server/QueryGrpcTest.java
@@ -112,6 +112,10 @@ public class QueryGrpcTest extends QueryTestBase {
         public void handleQueryBuckets(QueryBucketsRequest request, StreamObserver<QueryBucketsResponse> responseObserver) {
         }
 
+        @Override
+        public void handleQueryBucketsStream(QueryBucketsRequest request, StreamObserver<QueryBucketsResponse> responseObserver) {
+        }
+
     }
 
     protected static class TestQueryClient {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,6 +9,13 @@
 MongoClient:
   testDatabaseName: ${DP_MONGO_TEST_DB_NAME:dp-test}
 
+# QueryHandler: Query Service request handler settings (Query API V2 paging/resolution limits).
+# Mirrors the main application.yml keys so tests exercise the same defaults; see that file for docs.
+QueryHandler:
+  queryV2DefaultPageSize: ${DP_QUERY_HANDLER_QUERY_V2_DEFAULT_PAGE_SIZE:10000}
+  queryV2MaxPageSize: ${DP_QUERY_HANDLER_QUERY_V2_MAX_PAGE_SIZE:100000}
+  queryV2MaxResolvedPvCount: ${DP_QUERY_HANDLER_QUERY_V2_MAX_RESOLVED_PV_COUNT:10000}
+
 Level1:
   Level2:
     intValue: 60


### PR DESCRIPTION
## Summary

Implements the **Query API V2** RPCs (issue #189) in dp-service, in a single phase, reusing and evolving the existing query subsystem rather than building a parallel package tree:

- `queryBuckets` (unary) / `queryBucketsStream` (server-streaming) — bucket-oriented, whole buckets
- `querySamples` (unary) / `querySamplesStream` (server-streaming) — sample-oriented, column table

Full `QuerySpec` surface except the reserved `SampleStatusSelector`: `timeRange`, `pvSelector` (`pvNameList` / `pvNamePattern` / `metadataQuery`), `configurationSelector`, `executionOptions` (paging), and `resultRepresentation` (`excludeColumnMetadata`, `useSerializedColumns`).

All 11 design questions from the implementation plan (Q1–Q11) are resolved and realized in code. V1 methods (`queryData*`, `queryTable`, stats, providers) are unchanged.

## Commits (each self-contained, behavior-preserving for existing paths)

| Step | Deliverable |
|---|---|
| 1 | Extract shared Mongo filter-builder helpers (Q6) — one criterion→`Bson` implementation for the annotation clients and the V2 planner |
| 2 | Resolution / planner + resolved-query model — validation (§6), PV/config resolution, keyset/timestamp paging tokens |
| 3 | `queryBuckets` unary — keyset paging (Q2), `$or` config fragmentation (Q3), representation flags (Q5/Q8) |
| 4 | `queryBucketsStream` — fire-and-consume chunking |
| 5 | `querySamples` unary — timestamp paging (Q1), column seeding (Q9), non-scalar reject (Q4) |
| 6 | `querySamplesStream` — assemble-once, row-chunk |
| 7 | Full gRPC-channel integration test + config finalization |

## Key design decisions

- **Stateless, best-effort, position-only paging tokens** across all V2 paths (opaque by contract, so a future server-side cached-cursor impl is a drop-in with no proto/client change). Bucket paging is keyset seek on `(pvName, firstTimeSecs, firstTimeNanos)`; sample paging is timestamp-advanced re-query (drain-then-truncate).
- **Byte guard becomes a page/chunk boundary** (Q7), not an error — a page ends on whichever of the count limit or the message-size budget hits first; a single indivisible oversized item still errors.
- **`querySamples` is scalar-only** (Q4) — a non-scalar PV is rejected (naming the PV, pointing at `queryBuckets`) via a shared, neutrally-worded `NonScalarColumnException` that the export framework and the query path each translate for their context.
- **Every resolved PV gets a column** (Q9), sorted by name, all-unset where it has no sample in the page — so the column set/order is stable across pages.
- **Shared bucket-overlap predicate** promoted to `MongoQueryFilterBuilder.bucketOverlapsRangeFilter`, built by both the V1 retrieval path and the V2 `$or` fragmentation (behavior-preserving refactor of V1).

Fixes a latent V1 bug in passing: invalid `pvNamePattern` regexes are now caught and rejected cleanly (Q10) rather than throwing in the handler worker thread.

## Follow-up tickets (filed, out of scope here)

- #193 — standardize MLDP paging on keyset; migrate annotation metadata queries (Q2)
- #194 — `querySamples` fail-fast non-scalar reject before retrieval (Q4)
- #195 — revisit `useSerializedColumns` on `querySamples` once real usage data exists (Q5)

## Post-review fixes

A code review of the diff surfaced five findings; all are addressed in the last four commits (no behavior change to V1):

- **Fix (correctness):** `querySamples` unary — a byte-driven page boundary that dropped the *only* assembled timestamp produced a zero-row page whose resume token pointed back at the same timestamp, looping empty pages forever (inclusive `lastTime >= begin` re-assembled the identical oversized row). Now errors (indivisible-oversized) naming the timestamp, mirroring the buckets dispatchers' `isIndivisibleOversized`.
- **Fix (correctness):** `querySamplesStream` — a single row larger than the whole budget was emitted anyway, over-limit, aborting the gRPC stream. Added the same indivisible-oversized guard; also made the per-row byte estimate a conservative *upper* bound (per-column name/framing overhead, realistic value/timestamp framing, `SerializedDataColumn` wrapper) so a chunk sized to the budget cannot exceed the wire limit.
- **Fix (consistency):** malformed `ConfigurationSelector` (empty criteria list, or a criterion with no arm set) now **rejects** instead of silently returning an empty result — a client build-error is no longer indistinguishable from "no data." Matches the sibling `PvSelector` metadata path and V1 `queryProviders`. A well-formed selector that genuinely matches no activations still returns an empty result.
- **Hardening:** `resolveConfigurationIntervals` honors its "empty criteria matches nothing" contract defensively (returns no intervals) instead of a match-all default that would scan/union every activation.
- **No fix, documented:** the `TabularDataUtility.addBucketsToTable` size limit is checked per-bucket (can overshoot by up to one bucket). Benign for the hard-ceiling V1 callers (`queryTable`, export both error-and-discard on exceed); V2's paging path owns the zero-progress guard. Comment added at the check so it doesn't read as a latent bug.

## Testing

- **Unit**: `MongoQueryFilterBuilderTest`, `TimeIntervalTest`, `PageTokenTest`, `QueryV2ResolverTest` (incl. ConfigurationSelector malformed-rejects vs. matched-nothing-is-empty).
- **Dispatcher-level (real Mongo)**: `MongoSyncQueryBucketsV2Test` (20), `MongoSyncQuerySamplesV2Test` (17) — union-axis alignment with multi-rate PVs + missing values, half-open trimming, keyset + timestamp paging seam invariants (count- and byte-driven, no gap/overlap), `$or` fragmentation, representation flags, non-scalar reject, byte-budget split, indivisible-oversized error (unary single-timestamp + stream single-row), empty-result-is-empty-payload.
- **Full gRPC channel**: `QueryV2GrpcIT` — ingests a scenario, then exercises all four RPCs over the wire through the worker-queue path (multi-page continuation, streaming chunking, streaming-token reject).
- **Regression**: V1 query tests, `ExportDataIT`, `QueryTableIT`, and the annotation ITs (`PvMetadataIT`, `ConfigurationIT`) pass **unchanged** — the shared-code extractions are byte-identical.
- **`mvn verify` (surefire + failsafe): green, 0 failures/errors.**

## Config

New `QueryHandler` keys (conservative phase-1 defaults, in both `application.yml` files): `queryV2DefaultPageSize=10000`, `queryV2MaxPageSize=100000`, `queryV2MaxResolvedPvCount=10000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

