### PR TITLE
dp-service #199: release tabular rows as they are consumed

### DIFF
--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/export/DataExportCsvFile.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/export/DataExportCsvFile.java
@@ -92,7 +92,10 @@ public class DataExportCsvFile implements TabularDataExportFileInterface {
 
     @Override
     public void writeData(TimestampDataMap tableValueMap) {
-        final TimestampDataMap.DataRowIterator dataRowIterator = tableValueMap.dataRowIterator();
+        // Draining iteration (#199): rows are released as they are written to the file, so the map
+        // shrinks instead of being held whole until the export completes. The caller writes the
+        // header from getColumnNameList() before this and does not reuse the map afterward.
+        final TimestampDataMap.DataRowIterator dataRowIterator = tableValueMap.drainingDataRowIterator();
         while (dataRowIterator.hasNext()) {
             final TimestampDataMap.DataRow dataRow = dataRowIterator.next();
             final List<String> rowDataValues = new ArrayList<>();

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/export/DataExportXlsxFile.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/export/DataExportXlsxFile.java
@@ -111,7 +111,10 @@ public class DataExportXlsxFile implements TabularDataExportFileInterface {
             logger.warn("TimestampDataMap is null, skipping data write");
             return;
         }
-        final TimestampDataMap.DataRowIterator dataRowIterator = timestampDataMap.dataRowIterator();
+        // Draining iteration (#199): rows are released as they are added to the workbook. Note the
+        // XSSFWorkbook itself holds the whole sheet in memory, so this bounds only the source-side
+        // copy; the workbook remains the dominant cost for large exports.
+        final TimestampDataMap.DataRowIterator dataRowIterator = timestampDataMap.drainingDataRowIterator();
         while (dataRowIterator.hasNext()) {
             final TimestampDataMap.DataRow sourceDataRow = dataRowIterator.next();
             final Row fileDataRow = dataSheet.createRow(currentDataRowIndex);

--- a/src/main/java/com/ospreydcs/dp/service/common/model/TimestampDataMap.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/model/TimestampDataMap.java
@@ -18,7 +18,13 @@ public class TimestampDataMap extends TimestampMap<Map<Integer, DataValue>> {
         private Long currentSecond = null;
         private Iterator<Map.Entry<Long, Map<Integer, DataValue>>> currentNanoEntryIterator = null;
         private final boolean draining;
-        private boolean lastSecondRemoved = false;
+        /**
+         * When draining, true while the second-level entry most recently returned by
+         * {@code currentSecondEntryIterator} is still present in the backing map. Drives a single
+         * remove-once-drained rule in {@link #hasNext()} that applies uniformly to every second --
+         * the last one, and any that is empty when reached -- rather than special-casing the tail.
+         */
+        private boolean currentSecondPending = false;
 
         public DataRowIterator() {
             this(false);
@@ -42,6 +48,7 @@ public class TimestampDataMap extends TimestampMap<Map<Integer, DataValue>> {
                     this.currentSecondEntryIterator.next();
             this.currentSecond = currentSecondEntry.getKey();
             this.currentNanoEntryIterator = currentSecondEntry.getValue().entrySet().iterator();
+            this.currentSecondPending = draining;
         }
 
         @Override
@@ -49,20 +56,22 @@ public class TimestampDataMap extends TimestampMap<Map<Integer, DataValue>> {
             if (currentNanoEntryIterator == null) {
                 return false;
             }
-            while (!this.currentNanoEntryIterator.hasNext() && this.currentSecondEntryIterator.hasNext()) {
-                if (draining) {
-                    // this second is fully consumed; drop its (now empty) map before advancing
+            // Single rule when draining: a second whose nano entries are exhausted is dropped, then
+            // we advance. currentSecondPending makes the removal idempotent, so this is safe both
+            // for the final second (no advance follows, and hasNext() may be called repeatedly after
+            // exhaustion) and for a second that was already empty when reached. Removal always
+            // targets the entry currentSecondEntryIterator last returned, satisfying its contract.
+            while (!this.currentNanoEntryIterator.hasNext()) {
+                if (this.currentSecondPending) {
                     this.currentSecondEntryIterator.remove();
+                    this.currentSecondPending = false;
+                }
+                if (!this.currentSecondEntryIterator.hasNext()) {
+                    return false;
                 }
                 updateCurrentSecond();
             }
-            if (draining && !this.currentNanoEntryIterator.hasNext() && !lastSecondRemoved) {
-                // last second drained and no more seconds follow; guard against repeated hasNext()
-                // calls after exhaustion, which would fail the iterator's remove() contract
-                this.currentSecondEntryIterator.remove();
-                lastSecondRemoved = true;
-            }
-            return this.currentNanoEntryIterator.hasNext();
+            return true;
         }
 
         @Override

--- a/src/main/java/com/ospreydcs/dp/service/common/model/TimestampDataMap.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/model/TimestampDataMap.java
@@ -17,8 +17,20 @@ public class TimestampDataMap extends TimestampMap<Map<Integer, DataValue>> {
         private final Iterator<Map.Entry<Long, Map<Long, Map<Integer, DataValue>>>> currentSecondEntryIterator;
         private Long currentSecond = null;
         private Iterator<Map.Entry<Long, Map<Integer, DataValue>>> currentNanoEntryIterator = null;
+        private final boolean draining;
+        private boolean lastSecondRemoved = false;
 
         public DataRowIterator() {
+            this(false);
+        }
+
+        /**
+         * @param draining when true, each row is removed from the backing map as it is returned, so
+         *                 the map shrinks while the caller's output representation grows (#199).
+         *                 The map is unusable for anything else afterward.
+         */
+        public DataRowIterator(boolean draining) {
+            this.draining = draining;
             this.currentSecondEntryIterator = timestampMap.entrySet().iterator();
             if (this.currentSecondEntryIterator.hasNext()) {
                 updateCurrentSecond();
@@ -38,7 +50,17 @@ public class TimestampDataMap extends TimestampMap<Map<Integer, DataValue>> {
                 return false;
             }
             while (!this.currentNanoEntryIterator.hasNext() && this.currentSecondEntryIterator.hasNext()) {
+                if (draining) {
+                    // this second is fully consumed; drop its (now empty) map before advancing
+                    this.currentSecondEntryIterator.remove();
+                }
                 updateCurrentSecond();
+            }
+            if (draining && !this.currentNanoEntryIterator.hasNext() && !lastSecondRemoved) {
+                // last second drained and no more seconds follow; guard against repeated hasNext()
+                // calls after exhaustion, which would fail the iterator's remove() contract
+                this.currentSecondEntryIterator.remove();
+                lastSecondRemoved = true;
             }
             return this.currentNanoEntryIterator.hasNext();
         }
@@ -64,6 +86,13 @@ public class TimestampDataMap extends TimestampMap<Map<Integer, DataValue>> {
                 columnIndex = columnIndex + 1;
             }
 
+            if (draining) {
+                // Release this row's cell map now that its values are held by the returned DataRow.
+                // Removal goes through the iterator rather than the map so the in-progress traversal
+                // stays valid; the enclosing per-second map is dropped by hasNext() once drained.
+                this.currentNanoEntryIterator.remove();
+            }
+
             return new DataRow(rowSecond, rowNano, rowDataValues);
         }
     }
@@ -86,6 +115,15 @@ public class TimestampDataMap extends TimestampMap<Map<Integer, DataValue>> {
 
     public DataRowIterator dataRowIterator() {
         return new DataRowIterator();
+    }
+
+    /**
+     * Row iterator that removes each row from this map as it is returned (#199), so a consumer
+     * building another representation does not hold both at full size. This map is left empty and
+     * must not be used afterward.
+     */
+    public DataRowIterator drainingDataRowIterator() {
+        return new DataRowIterator(true);
     }
 
 }

--- a/src/main/java/com/ospreydcs/dp/service/common/model/TimestampMap.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/model/TimestampMap.java
@@ -28,6 +28,33 @@ public class TimestampMap<T> {
         return timestampMap.entrySet();
     }
 
+    /**
+     * Removes the value at the given timestamp, dropping the enclosing per-second map once it is
+     * empty.
+     *
+     * <p>Exists so a consumer that materializes this map into another representation can release
+     * each entry as it is consumed, rather than holding the whole map live until the second copy is
+     * complete (issue #199). Callers that need the map afterward must not use this.
+     *
+     * @return the removed value, or null if nothing was stored at that timestamp
+     */
+    public T remove(long seconds, long nanos) {
+        final Map<Long, T> secondMap = timestampMap.get(seconds);
+        if (secondMap == null) {
+            return null;
+        }
+        final T removed = secondMap.remove(nanos);
+        if (secondMap.isEmpty()) {
+            timestampMap.remove(seconds);
+        }
+        return removed;
+    }
+
+    /** True when no values remain. */
+    public boolean isEmpty() {
+        return timestampMap.isEmpty();
+    }
+
     public int size() {
         int entryCount = 0;
         for (Map.Entry<Long, Map<Long, T>> entry : timestampMap.entrySet()) {

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQuerySamplesDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQuerySamplesDispatcher.java
@@ -114,9 +114,19 @@ public abstract class AbstractQuerySamplesDispatcher extends QueryV2Dispatcher {
             // while the builders grow instead of both being held at full size. Safe because the
             // caller discards the map after this call: rows deferred to a later page are re-queried
             // from the resume token rather than read from here.
+            //
+            // A null here means this row was already drained -- the same row range was built twice,
+            // or the streaming path emitted ahead of estimating. Fail loudly: sparse-filling would
+            // emit a row of unset values that is indistinguishable from a legitimate all-missing
+            // sample row, turning a logic error into a silently wrong query result.
             final Map<Integer, DataValue> rowValues = tableValueMap.remove(second, nano);
+            if (rowValues == null) {
+                throw new IllegalStateException(
+                        "querySamples row at timestamp " + second + "." + nano
+                                + " was already drained; each row range must be built exactly once (#199)");
+            }
             for (int columnIndex = 0; columnIndex < columnBuilders.size(); columnIndex++) {
-                DataValue value = (rowValues == null) ? null : rowValues.get(columnIndex);
+                DataValue value = rowValues.get(columnIndex);
                 if (value == null) {
                     value = DataValue.newBuilder().build(); // unset => missing sample (Q9)
                 }

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQuerySamplesDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQuerySamplesDispatcher.java
@@ -110,9 +110,13 @@ public abstract class AbstractQuerySamplesDispatcher extends QueryV2Dispatcher {
             final long nano = timestamps.get(rowIndex)[1];
             timestampListBuilder.addTimestamps(
                     Timestamp.newBuilder().setEpochSeconds(second).setNanoseconds(nano).build());
-            final Map<Integer, DataValue> rowValues = tableValueMap.get(second, nano);
+            // Release each row as it is copied into the column builders (#199), so the map shrinks
+            // while the builders grow instead of both being held at full size. Safe because the
+            // caller discards the map after this call: rows deferred to a later page are re-queried
+            // from the resume token rather than read from here.
+            final Map<Integer, DataValue> rowValues = tableValueMap.remove(second, nano);
             for (int columnIndex = 0; columnIndex < columnBuilders.size(); columnIndex++) {
-                DataValue value = rowValues.get(columnIndex);
+                DataValue value = (rowValues == null) ? null : rowValues.get(columnIndex);
                 if (value == null) {
                     value = DataValue.newBuilder().build(); // unset => missing sample (Q9)
                 }

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
@@ -165,6 +165,10 @@ public class QuerySamplesStreamDispatcher extends AbstractQuerySamplesDispatcher
         final long nano = timestamps.get(rowIndex)[1];
         // Timestamp: two int64 fields (up to 10 bytes varint each) + field tags/length framing.
         long bytes = 24;
+        // ORDERING (#199): buildColumnTable drains each row it emits, so this must run before the
+        // row is emitted. The chunk loop guarantees that -- a row is always estimated at index
+        // rowIndex before any emitChunk whose range reaches it -- but a future change that emits
+        // ahead of estimating would read a drained row here.
         final Map<Integer, DataValue> rowValues = tableValueMap.get(second, nano);
         for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
             final DataValue value = rowValues.get(columnIndex);

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
@@ -168,8 +168,16 @@ public class QuerySamplesStreamDispatcher extends AbstractQuerySamplesDispatcher
         // ORDERING (#199): buildColumnTable drains each row it emits, so this must run before the
         // row is emitted. The chunk loop guarantees that -- a row is always estimated at index
         // rowIndex before any emitChunk whose range reaches it -- but a future change that emits
-        // ahead of estimating would read a drained row here.
+        // ahead of estimating would read a drained row here. Fail loudly rather than under-count:
+        // this estimate bounds the chunk against the gRPC wire limit, so silently treating a
+        // missing row as zero bytes would produce an over-limit message that aborts the stream.
         final Map<Integer, DataValue> rowValues = tableValueMap.get(second, nano);
+        if (rowValues == null) {
+            throw new IllegalStateException(
+                    "querySamples row at timestamp " + second + "." + nano
+                            + " was drained before its size was estimated; rowByteEstimate must run"
+                            + " before the emitChunk that consumes the row (#199)");
+        }
         for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
             final DataValue value = rowValues.get(columnIndex);
             // value payload + repeated DataValue tag+length framing (a few bytes); unset value is one

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QueryTableDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QueryTableDispatcher.java
@@ -58,6 +58,10 @@ public class QueryTableDispatcher extends Dispatcher {
         //
         // DataRow already sparse-fills missing cells with an unset DataValue, matching the previous
         // inline behavior here.
+        //
+        // Indexing rowDataValues by the columnBuilderMap key relies on both being dense over
+        // [0, columnNames.size()): the builder map is keyed by loop index above, and DataRow holds
+        // one entry per name in getColumnNameList(). Callers derive columnNames from that same list.
         final TimestampDataMap.DataRowIterator dataRowIterator = tableValueMap.drainingDataRowIterator();
         while (dataRowIterator.hasNext()) {
             final TimestampDataMap.DataRow dataRow = dataRowIterator.next();

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QueryTableDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QueryTableDispatcher.java
@@ -52,24 +52,23 @@ public class QueryTableDispatcher extends Dispatcher {
         }
         final TimestampList.Builder timestampListBuilder = TimestampList.newBuilder();
 
-        // add data values to column builders
-        for (var secondEntry : tableValueMap.entrySet()) {
-            final long second = secondEntry.getKey();
-            final Map<Long, Map<Integer, DataValue>> secondValueMap = secondEntry.getValue();
-            for (var nanoEntry : secondValueMap.entrySet()) {
-                final long nano = nanoEntry.getKey();
-                final Map<Integer, DataValue> nanoValueMap = nanoEntry.getValue();
-                final Timestamp timestamp = Timestamp.newBuilder().setEpochSeconds(second).setNanoseconds(nano).build();
-                timestampListBuilder.addTimestamps(timestamp);
-                for (var columnBuilderMapEntry : columnBuilderMap.entrySet()) {
-                    final int columnIndex = columnBuilderMapEntry.getKey();
-                    final DataColumn.Builder dataColumnBuilder = columnBuilderMapEntry.getValue();
-                    DataValue columnDataValue = nanoValueMap.get(columnIndex);
-                    if (columnDataValue == null) {
-                        columnDataValue = DataValue.newBuilder().build();
-                    }
-                    dataColumnBuilder.addDataValues(columnDataValue);
-                }
+        // Add data values to column builders, draining the map as we go (#199): each row is released
+        // once its values are held by the builders, so peak memory is not both representations at
+        // full size. tableValueMap is not used after this point.
+        //
+        // DataRow already sparse-fills missing cells with an unset DataValue, matching the previous
+        // inline behavior here.
+        final TimestampDataMap.DataRowIterator dataRowIterator = tableValueMap.drainingDataRowIterator();
+        while (dataRowIterator.hasNext()) {
+            final TimestampDataMap.DataRow dataRow = dataRowIterator.next();
+            timestampListBuilder.addTimestamps(Timestamp.newBuilder()
+                    .setEpochSeconds(dataRow.seconds())
+                    .setNanoseconds(dataRow.nanos())
+                    .build());
+            final List<DataValue> rowDataValues = dataRow.dataValues();
+            for (var columnBuilderMapEntry : columnBuilderMap.entrySet()) {
+                final int columnIndex = columnBuilderMapEntry.getKey();
+                columnBuilderMapEntry.getValue().addDataValues(rowDataValues.get(columnIndex));
             }
         }
 
@@ -98,7 +97,10 @@ public class QueryTableDispatcher extends Dispatcher {
         columnNamesWithTimestamp.addAll(columnNames);
         rowMapTableBuilder.addAllColumnNames(columnNamesWithTimestamp);
 
-        final TimestampDataMap.DataRowIterator dataRowIterator = tableValueMap.dataRowIterator();
+        // Draining iteration (#199): each row is released from the map as it is copied into the
+        // response builder, so peak memory is not both representations at full size. tableValueMap
+        // is not used after this point.
+        final TimestampDataMap.DataRowIterator dataRowIterator = tableValueMap.drainingDataRowIterator();
         while (dataRowIterator.hasNext()) {
 
             // read next data row

--- a/src/test/java/com/ospreydcs/dp/service/common/model/TimestampDataMapDrainMemoryTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/model/TimestampDataMapDrainMemoryTest.java
@@ -15,8 +15,9 @@ import static org.junit.Assert.assertTrue;
  *
  * <p>The acceptance criterion for #199 is a reduction in peak heap while a table result is
  * materialized into a second representation. This test approximates that by holding a consumer-side
- * copy of every row (standing in for protobuf builder state) and sampling retained heap at the
- * midpoint of iteration: without draining both copies are live, with draining only one is.
+ * copy of every row (standing in for protobuf builder state) and sampling retained heap after every
+ * row is consumed, with those copies still retained — the moment of peak footprint. At that point,
+ * without draining both representations are live; with draining only the consumer-side copies are.
  *
  * <p>Heap measurement is inherently noisy, so the assertion is deliberately loose — it checks the
  * direction and rough magnitude of the effect, not an exact figure. The precise per-row saving is

--- a/src/test/java/com/ospreydcs/dp/service/common/model/TimestampDataMapDrainMemoryTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/model/TimestampDataMapDrainMemoryTest.java
@@ -1,0 +1,118 @@
+package com.ospreydcs.dp.service.common.model;
+
+import com.ospreydcs.dp.grpc.v1.common.DataValue;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Measures the memory effect of draining iteration (#199).
+ *
+ * <p>The acceptance criterion for #199 is a reduction in peak heap while a table result is
+ * materialized into a second representation. This test approximates that by holding a consumer-side
+ * copy of every row (standing in for protobuf builder state) and sampling retained heap at the
+ * midpoint of iteration: without draining both copies are live, with draining only one is.
+ *
+ * <p>Heap measurement is inherently noisy, so the assertion is deliberately loose — it checks the
+ * direction and rough magnitude of the effect, not an exact figure. The precise per-row saving is
+ * whatever the JVM's TreeMap/boxing overhead happens to be.
+ */
+public class TimestampDataMapDrainMemoryTest {
+
+    private static final int ROW_COUNT = 20_000;
+    private static final int COLUMN_COUNT = 20;
+
+    private static TimestampDataMap buildMap() {
+        final TimestampDataMap map = new TimestampDataMap();
+        for (int c = 0; c < COLUMN_COUNT; c++) {
+            map.getColumnIndex("pv_" + c);
+        }
+        for (int r = 0; r < ROW_COUNT; r++) {
+            final Map<Integer, DataValue> row = new HashMap<>();
+            for (int c = 0; c < COLUMN_COUNT; c++) {
+                row.put(c, DataValue.newBuilder().setDoubleValue(r * 1.0 + c).build());
+            }
+            // spread across seconds so the nested per-second maps are exercised
+            map.put(1_700_000_000L + (r / 10), (r % 10) * 100_000_000L, row);
+        }
+        return map;
+    }
+
+    private static long usedHeap() {
+        final Runtime runtime = Runtime.getRuntime();
+        for (int i = 0; i < 4; i++) {
+            System.gc();
+            try {
+                Thread.sleep(30);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        return runtime.totalMemory() - runtime.freeMemory();
+    }
+
+    /**
+     * Live heap once every row has been consumed and the consumer-side copies are held — the moment
+     * of peak footprint, when a dispatcher holds fully-populated protobuf builders.
+     *
+     * <p>Measured as an absolute live-heap reading (not a delta) with both the map and the consumed
+     * rows reachable, so the map's own retention is included: that retention is precisely what
+     * draining eliminates.
+     */
+    private static long peakLiveHeap(boolean draining) {
+        final TimestampDataMap map = buildMap();
+        final List<TimestampDataMap.DataRow> consumed = new ArrayList<>(ROW_COUNT);
+
+        final TimestampDataMap.DataRowIterator it =
+                draining ? map.drainingDataRowIterator() : map.dataRowIterator();
+        while (it.hasNext()) {
+            consumed.add(it.next());
+        }
+
+        // Sample with both structures still strongly reachable. Under draining the map is empty
+        // here; without it the map still holds every cell.
+        final long live = usedHeap();
+
+        // Reachability barrier: keep both alive past the sample so neither is collected early.
+        assertTrue(consumed.size() == ROW_COUNT);
+        assertTrue(draining ? map.isEmpty() : !map.isEmpty());
+
+        return live;
+    }
+
+    @Test
+    public void testDrainingReducesPeakHeap() {
+
+        // warm up so JIT and allocation behavior are comparable between measurements
+        peakLiveHeap(false);
+        peakLiveHeap(true);
+
+        // interleave and take the best (lowest) of several runs to blunt GC timing noise
+        long nonDraining = Long.MAX_VALUE;
+        long draining = Long.MAX_VALUE;
+        for (int i = 0; i < 3; i++) {
+            nonDraining = Math.min(nonDraining, peakLiveHeap(false));
+            draining = Math.min(draining, peakLiveHeap(true));
+        }
+
+        final double reduction = 100.0 * (nonDraining - draining) / nonDraining;
+        System.out.println("peak live heap holding " + ROW_COUNT + " rows x " + COLUMN_COUNT
+                + " columns, consumer copies retained:");
+        System.out.println("  without draining: " + (nonDraining / 1024) + " KB");
+        System.out.println("  with draining:    " + (draining / 1024) + " KB");
+        System.out.println("  reduction:        " + String.format("%.1f%%", reduction));
+
+        // Direction check with a loose floor. Heap sampling is noisy, so this asserts the effect is
+        // real and substantial rather than pinning an exact figure; the printed percentage is the
+        // number to read when evaluating the #199 acceptance target.
+        assertTrue(
+                "draining should reduce peak live heap (without=" + nonDraining
+                        + " with=" + draining + ")",
+                draining < nonDraining);
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/common/model/TimestampDataMapTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/model/TimestampDataMapTest.java
@@ -1,0 +1,161 @@
+package com.ospreydcs.dp.service.common.model;
+
+import com.ospreydcs.dp.grpc.v1.common.DataValue;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers {@link TimestampDataMap} row iteration, in particular the draining mode added for #199.
+ *
+ * <p>Draining lets a consumer release each row as it is materialized into another representation,
+ * so peak memory is not the sum of both copies. The rows produced must be identical either way —
+ * the only difference is what remains in the map afterward.
+ */
+public class TimestampDataMapTest {
+
+    private static DataValue doubleValue(double v) {
+        return DataValue.newBuilder().setDoubleValue(v).build();
+    }
+
+    /** Builds a map with the given (seconds, nanos) rows, one value per column. */
+    private static TimestampDataMap mapWithRows(List<long[]> timestamps, int columnCount) {
+        final TimestampDataMap map = new TimestampDataMap();
+        for (int c = 0; c < columnCount; c++) {
+            map.getColumnIndex("pv_" + c);
+        }
+        for (int r = 0; r < timestamps.size(); r++) {
+            final Map<Integer, DataValue> row = new HashMap<>();
+            for (int c = 0; c < columnCount; c++) {
+                row.put(c, doubleValue(r * 100 + c));
+            }
+            map.put(timestamps.get(r)[0], timestamps.get(r)[1], row);
+        }
+        return map;
+    }
+
+    private static List<long[]> timestamps(long... secondsNanosPairs) {
+        final List<long[]> result = new ArrayList<>();
+        for (int i = 0; i < secondsNanosPairs.length; i += 2) {
+            result.add(new long[]{secondsNanosPairs[i], secondsNanosPairs[i + 1]});
+        }
+        return result;
+    }
+
+    private static List<TimestampDataMap.DataRow> drain(TimestampDataMap.DataRowIterator it) {
+        final List<TimestampDataMap.DataRow> rows = new ArrayList<>();
+        while (it.hasNext()) {
+            rows.add(it.next());
+        }
+        return rows;
+    }
+
+    /** Draining must produce exactly the same rows, in the same order, as non-draining. */
+    @Test
+    public void testDrainingProducesSameRowsAsNonDraining() {
+        final List<long[]> ts = timestamps(100L, 0L, 100L, 500L, 101L, 0L, 102L, 250L);
+
+        final List<TimestampDataMap.DataRow> expected =
+                drain(mapWithRows(ts, 3).new DataRowIterator(false));
+        final List<TimestampDataMap.DataRow> actual =
+                drain(mapWithRows(ts, 3).new DataRowIterator(true));
+
+        assertEquals(expected.size(), actual.size());
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals(expected.get(i).seconds(), actual.get(i).seconds());
+            assertEquals(expected.get(i).nanos(), actual.get(i).nanos());
+            assertEquals(expected.get(i).dataValues(), actual.get(i).dataValues());
+        }
+    }
+
+    /** After a full draining pass the map retains nothing, including empty per-second maps. */
+    @Test
+    public void testDrainingEmptiesTheMap() {
+        final TimestampDataMap map =
+                mapWithRows(timestamps(100L, 0L, 100L, 500L, 101L, 0L, 102L, 250L), 2);
+        assertEquals(4, map.size());
+
+        drain(map.new DataRowIterator(true));
+
+        assertEquals(0, map.size());
+        assertTrue("per-second maps must be dropped, not left empty", map.isEmpty());
+    }
+
+    /** Non-draining iteration leaves the map intact, which existing callers rely on. */
+    @Test
+    public void testNonDrainingLeavesMapIntact() {
+        final TimestampDataMap map = mapWithRows(timestamps(100L, 0L, 101L, 0L), 2);
+
+        drain(map.new DataRowIterator(false));
+
+        assertEquals(2, map.size());
+        assertFalse(map.isEmpty());
+    }
+
+    /**
+     * The map shrinks progressively during draining rather than only at the end — the property that
+     * makes peak memory lower.
+     */
+    @Test
+    public void testMapShrinksDuringDraining() {
+        final TimestampDataMap map =
+                mapWithRows(timestamps(100L, 0L, 101L, 0L, 102L, 0L, 103L, 0L), 2);
+        final TimestampDataMap.DataRowIterator it = map.new DataRowIterator(true);
+
+        int previousSize = map.size();
+        assertEquals(4, previousSize);
+        while (it.hasNext()) {
+            it.next();
+            final int currentSize = map.size();
+            assertTrue("map size must not grow while draining", currentSize < previousSize);
+            previousSize = currentSize;
+        }
+        assertEquals(0, previousSize);
+    }
+
+    /** hasNext() after exhaustion must stay safe: the final removal happens at most once. */
+    @Test
+    public void testRepeatedHasNextAfterExhaustionIsSafe() {
+        final TimestampDataMap map = mapWithRows(timestamps(100L, 0L), 1);
+        final TimestampDataMap.DataRowIterator it = map.new DataRowIterator(true);
+
+        assertTrue(it.hasNext());
+        it.next();
+        assertFalse(it.hasNext());
+        assertFalse(it.hasNext());
+        assertFalse(it.hasNext());
+        assertEquals(0, map.size());
+    }
+
+    /** An empty map iterates to nothing in both modes. */
+    @Test
+    public void testEmptyMapIterates() {
+        assertEquals(0, drain(new TimestampDataMap().new DataRowIterator(true)).size());
+        assertEquals(0, drain(new TimestampDataMap().new DataRowIterator(false)).size());
+    }
+
+    /** Missing cells are filled with an unset DataValue, in draining mode too. */
+    @Test
+    public void testSparseRowsFilledWhenDraining() {
+        final TimestampDataMap map = new TimestampDataMap();
+        map.getColumnIndex("pv_0");
+        map.getColumnIndex("pv_1");
+        final Map<Integer, DataValue> sparseRow = new HashMap<>();
+        sparseRow.put(0, doubleValue(1.0)); // column 1 absent
+        map.put(100L, 0L, sparseRow);
+
+        final List<TimestampDataMap.DataRow> rows = drain(map.new DataRowIterator(true));
+
+        assertEquals(1, rows.size());
+        assertEquals(2, rows.get(0).dataValues().size());
+        assertEquals(doubleValue(1.0), rows.get(0).dataValues().get(0));
+        assertEquals(DataValue.newBuilder().build(), rows.get(0).dataValues().get(1));
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/common/model/TimestampDataMapTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/model/TimestampDataMapTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -157,5 +158,77 @@ public class TimestampDataMapTest {
         assertEquals(2, rows.get(0).dataValues().size());
         assertEquals(doubleValue(1.0), rows.get(0).dataValues().get(0));
         assertEquals(DataValue.newBuilder().build(), rows.get(0).dataValues().get(1));
+    }
+
+    /**
+     * A second whose nano map is already empty when the iterator reaches it must be skipped and
+     * dropped, not treated as a row. Reachable because {@link TimestampMap#remove} is public, so a
+     * caller can empty a second out from under a later iteration.
+     */
+    @Test
+    public void testDrainingSkipsEmptySecondMap() {
+        final TimestampDataMap map = mapWithRows(timestamps(100L, 0L, 200L, 0L, 300L, 0L), 2);
+
+        // empty out the middle second directly, leaving its (now empty) per-second map in place
+        // only if remove() failed to drop it -- which is itself asserted below
+        map.remove(200L, 0L);
+
+        final List<TimestampDataMap.DataRow> rows = drain(map.drainingDataRowIterator());
+
+        assertEquals(2, rows.size());
+        assertEquals(100L, rows.get(0).seconds());
+        assertEquals(300L, rows.get(1).seconds());
+        assertTrue(map.isEmpty());
+    }
+
+    /** remove() returns the stored row and drops the enclosing per-second map once it is empty. */
+    @Test
+    public void testRemoveDropsEmptySecondMap() {
+        final TimestampDataMap map = mapWithRows(timestamps(100L, 0L, 100L, 500L, 200L, 0L), 1);
+        assertFalse(map.isEmpty());
+
+        // removing one of two entries in second 100 keeps that second alive
+        final Map<Integer, DataValue> removed = map.remove(100L, 0L);
+        assertEquals(doubleValue(0), removed.get(0));
+        assertEquals(2, map.size());
+        assertEquals(2, drain(map.dataRowIterator()).size());
+
+        // removing the last entry in second 100 drops the second itself
+        assertEquals(doubleValue(100), map.remove(100L, 500L).get(0));
+        assertEquals(1, map.size());
+        assertEquals(200L, drain(map.dataRowIterator()).get(0).seconds());
+
+        // removing the final entry empties the map
+        assertEquals(doubleValue(200), map.remove(200L, 0L).get(0));
+        assertEquals(0, map.size());
+        assertTrue(map.isEmpty());
+    }
+
+    /** remove() of a timestamp that was never stored returns null and changes nothing. */
+    @Test
+    public void testRemoveMissingTimestampReturnsNull() {
+        final TimestampDataMap map = mapWithRows(timestamps(100L, 0L), 1);
+
+        assertNull(map.remove(999L, 0L));      // no such second
+        assertNull(map.remove(100L, 999L));    // second exists, no such nano
+        assertEquals(1, map.size());
+        assertFalse(map.isEmpty());
+
+        // the surviving row is untouched
+        assertEquals(1, drain(map.dataRowIterator()).size());
+    }
+
+    /** isEmpty() tracks the map through a full draining pass. */
+    @Test
+    public void testIsEmptyReflectsDraining() {
+        final TimestampDataMap map = mapWithRows(timestamps(100L, 0L, 200L, 0L), 1);
+        assertFalse(map.isEmpty());
+
+        final TimestampDataMap.DataRowIterator it = map.drainingDataRowIterator();
+        it.next();
+        assertFalse(map.isEmpty()); // one row still held
+
+        drain(it);
+        assertTrue(map.isEmpty());
     }
 }


### PR DESCRIPTION
Implements option 1 (release-as-you-go) from #199.

## Problem

`queryTable()` and `querySamples()` materialized the entire result **twice**: once as a `TimestampDataMap` (nested `TreeMap`s holding a boxed `DataValue` per cell), and again as protobuf builder state — with the map retained at full size until the second copy completed.

The gRPC message-size limit bounds each individual response, but nothing bounded the transient total across concurrent queries. Heavy `queryTable` use could therefore exhaust the query service heap, which fails far worse than a slow query: a slow query inconveniences one caller, an OOM takes down the service for everyone.

## Change

`TimestampDataMap.DataRowIterator` gains a draining mode that removes each row as it is returned, so the map shrinks while the output representation grows. Removal goes through the *iterator* rather than the map so the in-progress traversal stays valid, and emptied per-second maps are dropped rather than left behind as empty shells.

Every consumer that materializes the map into another representation now drains:

| Site | Effect |
|---|---|
| `queryTable` row-map | already used `DataRowIterator`; one-line switch |
| `queryTable` column | rewrote the manual `entrySet()` walk to use the iterator, which also removed its duplicated sparse-fill logic |
| `buildColumnTable` | covers `querySamples` unary **and** streaming |
| `DataExportCsvFile` | real win — streams to disk, so the map shrinks as the file grows |
| `DataExportXlsxFile` | bounded — `XSSFWorkbook` holds the whole sheet regardless |

HDF5 export needs no change: it writes buckets directly and never builds a `TimestampDataMap`.

## Measured result: 31% peak-heap reduction

`TimestampDataMapDrainMemoryTest` samples absolute live heap with both the map and consumer-side row copies strongly reachable — the moment of peak footprint:

| | Peak live heap |
|---|---|
| without draining | 57,100 KB |
| with draining | 39,397 KB |
| **reduction** | **31.0%** |

(20,000 rows × 20 columns.)

**Option 1 goes about as far as it can on its own.** Draining eliminates one of the two copies; what remains is the per-cell `TreeMap` + boxing overhead of the intermediate structure itself, which is exactly what option 3 (flat sorted structure keyed by a packed long, pairing with #198) targets. The real-world ratio is likely better than 31% because protobuf builder state is heavier than the `DataRow`/`ArrayList` stand-in used in the test — but that is not measured here and should not be assumed.

Proposing this be accepted as-is: it removes the *unbounded* double-retention, which is the mechanism behind the concurrent-query heap risk, at low risk and with no behavior change. Further reduction is better addressed alongside #198, if measurement on real workloads shows it is needed.

## Ordering dependency this introduces

`QuerySamplesStreamDispatcher.rowByteEstimate()` reads rows via `get()` to size them, and the streaming path interleaves size estimation with emission across chunks. It is correct today — the chunk loop always estimates row *i* before any `emitChunk` whose range reaches it — but a future change that emits ahead of estimating would read an already-drained row and NPE. Commented at the call site.

## Testing

- **254 unit + 162 integration tests pass**, 0 failures.
- New `TimestampDataMapTest` (7 cases): draining produces byte-identical rows to non-draining, empties the map completely including per-second shells, leaves the map intact when not draining, shrinks progressively during iteration, survives repeated `hasNext()` after exhaustion, handles empty maps, and sparse-fills missing cells.
- New `TimestampDataMapDrainMemoryTest`: the measurement above.
- The integration suite (`QueryTableIT`, `ExportDataIT`, V2 sample tests) verifies response and file contents, so the "no behavior change" acceptance criteria are demonstrated rather than assumed across all five converted sites.

## Review follow-ups (f35e1af)

- Both dispatcher sites that read a row draining may have removed now **throw** rather than degrade. `buildColumnTable` previously sparse-filled a drained row with unset values — indistinguishable from a legitimate all-missing sample row, so a logic error would have surfaced as a silently wrong result instead of an error. `rowByteEstimate` had no guard and would have NPE'd; it also must not under-count, since it is what keeps each chunk under the gRPC wire limit.
- `DataRowIterator.hasNext()` replaces the `lastSecondRemoved` tail special-case with one uniform remove-once-drained rule, also covering a second that is already empty when reached (reachable now that `TimestampMap.remove()` is public). Non-draining behavior unchanged.
- Direct coverage added for the new public `TimestampMap.remove()` / `isEmpty()`.
- Corrected the memory test's class Javadoc, which claimed midpoint-of-iteration sampling (flagged by Copilot).

Implements option 1 of #199. Deliberately does **not** close that issue — option 3 remains open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tij5WzpebAF2fmbrDZMF1F

