### PR TITLE
dp-service #205: upgrade log4j-core to 2.25.4 and poi-ooxml to 5.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,8 @@
 
         <dp-grpc.version>1.15.0</dp-grpc.version>
         <mongodb.version>5.4.0</mongodb.version>
-        <log4j-version>2.23.1</log4j-version>
+        <log4j-version>2.25.4</log4j-version>
+        <poi.version>5.4.0</poi.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <maven.plugin.shade.version>3.6.0</maven.plugin.shade.version>
 
@@ -149,7 +150,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.3.0</version>
+            <version>${poi.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Resolves the 5 open moderate Dependabot alerts on the default branch. Two version bumps in `pom.xml`, no source changes.

Closes #205

## Changes

| Package | Before | After | Alerts cleared |
|---|---|---|---|
| log4j-api / log4j-core / log4j-slf4j-impl | 2.23.1 | 2.25.4 | #2, #3, #4, #5 |
| poi-ooxml (+ poi, poi-ooxml-lite) | 5.3.0 | 5.4.0 | #1 |

Also moves the poi version into a `poi.version` property — it was the only dependency in the file with an inline hardcoded version.

## Exposure notes

**log4j (4 alerts) — not reachable in the current configuration.** All four CVEs require appenders or layouts this project does not configure: `<Ssl>`/Socket appender (CVE-2025-68161, CVE-2026-34477), `Rfc5424Layout` (CVE-2026-34478), `XmlLayout` (CVE-2026-34480). Both `src/main/resources/log4j2.xml` and `src/test/resources/log4j2.xml` declare a single `Console` appender with a `PatternLayout`, and none of the affected symbols appear anywhere in `src/`.

Upgrading regardless, because log4j2.xml is supplied at runtime via `-Dlog4j.configurationFile` — exposure is a property of the *deployed config*, not the source tree. A deployment that adds a syslog or socket appender would become vulnerable with no code change and nothing in the repo to signal it.

Note 2.25.4 rather than 2.25.3: the 2.25.3 fix for CVE-2025-68161 was incomplete, which is what CVE-2026-34477 documents.

**poi-ooxml (1 alert) — reachable, low practical risk.** CVE-2025-31672 concerns OOXML files with duplicate zip entry names, where different readers may select different entries. The live path is XLSX *parsing*: `DataImportUtility.importXlsxData()` (`DataImportUtility.java:37`) builds `new XSSFWorkbook(fileInputStream)` from a caller-supplied path. `DataExportXlsxFile` only writes workbooks and is unaffected.

Impact is bounded: CVSS 5.3, integrity-only (`C:N/I:L/A:N`), requires importing an attacker-supplied file, and `DataImportUtility` is a client-side utility — not reachable through the ingestion, query, or annotation gRPC APIs.

## Behavior change worth knowing

POI 5.4.0's fix is to **throw** when duplicate zip entry names are found. Any XLSX that previously imported with duplicate entries will now fail instead of silently reading ambiguous data.

This does not affect the test suite: both fixture builders in `DataImportUtilityTest` (`createTestXlsxFile`, `createInsufficientColumnsXlsxFile`) generate files via `XSSFWorkbook.write()`, so POI authors the zip structure itself and cannot emit duplicates. Flagging it for operational awareness — a hand-assembled or third-party-generated XLSX could hit it.

## Verification

- `mvn clean verify` — BUILD SUCCESS
- 258 unit tests, 0 failures / 0 errors
- 162 integration tests, 0 failures / 0 errors, 1 skip (`BenchmarkIntegrationIT`, pre-existing)
- `DataImportUtilityTest` (5), `ExportDataIT` (1), `ExportDataBucketSpanIT` (1) all pass — the XLSX read and write paths
- `mvn dependency:tree` confirms all six artifacts resolve at the intended versions; both are direct dependencies with no version mediation, so no `dependencyManagement` pinning needed
- No new log4j `StatusLogger` warnings or POI warnings in the build output
- POI 5.4.0 targets Java 8+; this project builds at Java 21

All 5 alerts should close automatically once this reaches the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AECwfsTCdqtUBJmDTMYea3
