### PR TITLE
dp-service #207: trim querySamples against resolved fragments, not a collapsed window

### DIFF
--- a/src/main/java/com/ospreydcs/dp/service/common/utility/TabularDataUtility.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/utility/TabularDataUtility.java
@@ -20,6 +20,17 @@ public class TabularDataUtility {
 
     public static record TimestampDataMapSizeStats(int currentDataSize, boolean sizeLimitExceeded) {}
 
+    /**
+     * A half-open {@code [begin, end)} sample-retention window, expressed as epoch seconds + nanos.
+     *
+     * <p>Deliberately a local value type rather than the query package's {@code TimeInterval}: this
+     * utility is shared by the query service, the annotation export job, and the integration test
+     * wrapper, and must not depend on Query API V2 model classes. Callers holding a {@code TimeInterval}
+     * convert at the call site.
+     */
+    public static record RetentionInterval(
+            long beginSeconds, long beginNanos, long endSeconds, long endNanos) {}
+
     public static TimestampDataMapSizeStats addBucketsToTable(
             TimestampDataMap tableValueMap,
             MongoCursor<BucketDocument> cursor,
@@ -38,17 +49,6 @@ public class TabularDataUtility {
                 sizeLimit,
                 List.of(new RetentionInterval(beginSeconds, beginNanos, endSeconds, endNanos)));
     }
-
-    /**
-     * A half-open {@code [begin, end)} sample-retention window, expressed as epoch seconds + nanos.
-     *
-     * <p>Deliberately a local value type rather than the query package's {@code TimeInterval}: this
-     * utility is shared by the query service, the annotation export job, and the integration test
-     * wrapper, and must not depend on Query API V2 model classes. Callers holding a {@code TimeInterval}
-     * convert at the call site.
-     */
-    public static record RetentionInterval(
-            long beginSeconds, long beginNanos, long endSeconds, long endNanos) {}
 
     /**
      * Multi-interval form: a sample is retained when it falls inside <em>any</em> of the given
@@ -74,7 +74,13 @@ public class TabularDataUtility {
         while (cursor.hasNext()) {
             // add buckets to table data structure
             final BucketDocument bucket = cursor.next();
-            int columnIndex = tableValueMap.getColumnIndex(bucket.getPvName());
+            // Register the bucket's PV name. getColumnIndex() is a mutator (it appends unseen names to
+            // the map's column list) and the returned index is deliberately unused here: the call is
+            // made for the registration alone, so a PV whose buckets contribute no in-range samples
+            // still gets a column slot -- an all-empty column rather than a missing one. The column is
+            // normally also registered under the same name inside addColumnsToTable below; this keeps
+            // the slot even if a bucket's PV name and its column name ever diverge.
+            tableValueMap.getColumnIndex(bucket.getPvName());
             int bucketDataSize = addBucketToTable(bucket, tableValueMap, retentionIntervals);
             currentDataSize = currentDataSize + bucketDataSize;
             // Size accounting is per-BUCKET, not per-timestamp: a whole bucket is added to the table

--- a/src/main/java/com/ospreydcs/dp/service/common/utility/TabularDataUtility.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/utility/TabularDataUtility.java
@@ -31,13 +31,51 @@ public class TabularDataUtility {
             long endNanos
     ) throws DpException {
 
+        return addBucketsToTable(
+                tableValueMap,
+                cursor,
+                previousDataSize,
+                sizeLimit,
+                List.of(new RetentionInterval(beginSeconds, beginNanos, endSeconds, endNanos)));
+    }
+
+    /**
+     * A half-open {@code [begin, end)} sample-retention window, expressed as epoch seconds + nanos.
+     *
+     * <p>Deliberately a local value type rather than the query package's {@code TimeInterval}: this
+     * utility is shared by the query service, the annotation export job, and the integration test
+     * wrapper, and must not depend on Query API V2 model classes. Callers holding a {@code TimeInterval}
+     * convert at the call site.
+     */
+    public static record RetentionInterval(
+            long beginSeconds, long beginNanos, long endSeconds, long endNanos) {}
+
+    /**
+     * Multi-interval form: a sample is retained when it falls inside <em>any</em> of the given
+     * half-open intervals.
+     *
+     * <p>Exists for Query API V2 {@code querySamples} with a {@code ConfigurationSelector}, which
+     * resolves to a set of <b>disjoint</b> retrieval intervals (issue #207). The MongoDB query filters
+     * those fragments only at <em>bucket</em> granularity, so a single bucket spanning the gap between
+     * two fragments passes the database filter with its in-gap samples intact. Trimming here against
+     * the full fragment list — rather than a single collapsed {@code [min begin, max end)} window — is
+     * what keeps gap samples out of the result. Single-interval callers ({@code queryTable}, the export
+     * job) are unaffected and reach this through the overload above.
+     */
+    public static TimestampDataMapSizeStats addBucketsToTable(
+            TimestampDataMap tableValueMap,
+            MongoCursor<BucketDocument> cursor,
+            int previousDataSize,
+            Integer sizeLimit, // if null, no limit is applied
+            List<RetentionInterval> retentionIntervals
+    ) throws DpException {
+
         int currentDataSize = previousDataSize;
         while (cursor.hasNext()) {
             // add buckets to table data structure
             final BucketDocument bucket = cursor.next();
             int columnIndex = tableValueMap.getColumnIndex(bucket.getPvName());
-            int bucketDataSize = addBucketToTable(
-                    bucket, tableValueMap, beginSeconds, beginNanos, endSeconds, endNanos);
+            int bucketDataSize = addBucketToTable(bucket, tableValueMap, retentionIntervals);
             currentDataSize = currentDataSize + bucketDataSize;
             // Size accounting is per-BUCKET, not per-timestamp: a whole bucket is added to the table
             // before the limit is checked, so currentDataSize can overshoot sizeLimit by up to one
@@ -63,10 +101,7 @@ public class TabularDataUtility {
     private static int addBucketToTable(
             BucketDocument bucket,
             TimestampDataMap tableValueMap,
-            long beginSeconds,
-            long beginNanos,
-            long endSeconds,
-            long endNanos
+            List<RetentionInterval> retentionIntervals
     ) throws DpException {
 
         final DataTimestamps bucketDataTimestamps = bucket.getDataTimestamps().toDataTimestamps();
@@ -92,10 +127,25 @@ public class TabularDataUtility {
                 bucketDataTimestamps,
                 List.of(bucketColumn),
                 tableValueMap,
-                beginSeconds,
-                beginNanos,
-                endSeconds,
-                endNanos);
+                retentionIntervals);
+    }
+
+    /**
+     * True when {@code (second, nano)} falls inside any half-open interval in {@code intervals}.
+     * A sample exactly at an interval's end belongs to the next interval, not this one.
+     */
+    private static boolean isRetained(long second, long nano, List<RetentionInterval> intervals) {
+        for (RetentionInterval interval : intervals) {
+            if (second < interval.beginSeconds() || second > interval.endSeconds()) {
+                continue;
+            }
+            if ((second == interval.beginSeconds() && nano < interval.beginNanos())
+                    || (second == interval.endSeconds() && nano >= interval.endNanos())) {
+                continue;
+            }
+            return true;
+        }
+        return false;
     }
 
     private static int addColumnsToTable(
@@ -108,10 +158,35 @@ public class TabularDataUtility {
             long endNanos
     ) throws DpException {
 
+        return addColumnsToTable(
+                dataTimestamps,
+                dataColumns,
+                tableValueMap,
+                List.of(new RetentionInterval(beginSeconds, beginNanos, endSeconds, endNanos)));
+    }
+
+    private static int addColumnsToTable(
+            DataTimestamps dataTimestamps,
+            List<DataColumn> dataColumns,
+            TimestampDataMap tableValueMap,
+            List<RetentionInterval> retentionIntervals
+    ) throws DpException {
+
         int dataValueSize = 0;
         final DataTimestampsUtility.DataTimestampsIterator dataTimestampsIterator =
                 DataTimestampsUtility.dataTimestampsIterator(dataTimestamps);
 
+
+        // Register every column up front. getColumnIndex() is a mutator -- it appends unseen names to
+        // the map's column name list, which is what determines the exported/emitted column set. The
+        // pre-#207 code got this incidentally, by calling it inside the per-column loop before the
+        // range test skipped a value, so a column whose samples all fall outside the range still got
+        // a slot (an all-empty column, not a missing one). Hoisting the range test above that loop
+        // would silently drop such columns, so the registration is now explicit rather than a side
+        // effect of the skipped path.
+        for (DataColumn dataColumn : dataColumns) {
+            tableValueMap.getColumnIndex(dataColumn.getName());
+        }
 
         // derserialize DataColumn content from document and the iterate DataValues in column
         int valueIndex = 0;
@@ -121,17 +196,17 @@ public class TabularDataUtility {
             final long second = timestamp.getEpochSeconds();
             final long nano = timestamp.getNanoseconds();
 
+            // skip values outside every retention interval (hoisted: the test depends only on the
+            // timestamp, so it is the same verdict for every column at this row)
+            if (!isRetained(second, nano, retentionIntervals)) {
+                valueIndex = valueIndex + 1;
+                continue;
+            }
+
             // add next value for each column to tableValueMap
             for (DataColumn dataColumn : dataColumns) {
                 final DataValue dataValue = dataColumn.getDataValues(valueIndex);
                 final int columnIndex = tableValueMap.getColumnIndex(dataColumn.getName());
-
-                // skip values outside query time range
-                if (second < beginSeconds || second > endSeconds) {
-                    continue;
-                } else if ((second == beginSeconds && nano < beginNanos) || (second == endSeconds && nano >= endNanos)) {
-                    continue;
-                }
 
                 // keep track of data size
                 dataValueSize = dataValueSize + dataValue.getSerializedSize();

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/model/TimeInterval.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/model/TimeInterval.java
@@ -142,6 +142,50 @@ public final class TimeInterval {
         return result;
     }
 
+    /**
+     * Clamps each interval's lower bound up to {@code (windowBeginSecs, windowBeginNanos)} and drops
+     * any interval left empty by the clamp (one ending at or before the window begin). The result
+     * preserves input order and is the set of fragments that can contribute to the page starting at
+     * that window begin.
+     *
+     * <p><b>Single source for the querySamples fragment clamp (issue #207).</b> The page's bucket
+     * retrieval filter and its sample-level retention trim must be derived from the <em>same</em>
+     * interval set, or the database and the assembly disagree about which samples belong to the page
+     * — the exact class of defect #207 fixed. {@code MongoSyncQueryClient.executeQuerySamplesV2}
+     * builds its per-fragment {@code $or} of bucket-overlap predicates from this, and
+     * {@code AbstractQuerySamplesDispatcher.retentionIntervals} builds its retention windows from it.
+     * Do not reimplement the clamp at either call site.
+     *
+     * <p>An empty result means nothing overlaps the page window; callers treat that as an empty page
+     * rather than an unfiltered query.
+     */
+    public static List<TimeInterval> clampToWindowBegin(
+            List<TimeInterval> intervals, long windowBeginSecs, long windowBeginNanos) {
+
+        final List<TimeInterval> clamped = new ArrayList<>();
+        for (TimeInterval iv : intervals) {
+            // begin = max(fragment.begin, windowBegin)
+            final long beginSecs;
+            final long beginNanos;
+            if (compareInstant(
+                    iv.beginSeconds, iv.beginNanos, windowBeginSecs, windowBeginNanos) >= 0) {
+                beginSecs = iv.beginSeconds;
+                beginNanos = iv.beginNanos;
+            } else {
+                beginSecs = windowBeginSecs;
+                beginNanos = windowBeginNanos;
+            }
+            final TimeInterval result =
+                    new TimeInterval(beginSecs, beginNanos, iv.endSeconds, iv.endNanos);
+            // drop fragments entirely at or before the window begin (they contribute nothing here)
+            if (result.isEmpty()) {
+                continue;
+            }
+            clamped.add(result);
+        }
+        return clamped;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
@@ -425,28 +425,13 @@ public class MongoSyncQueryClient extends MongoSyncClient implements MongoQueryC
 
         // Per-fragment overlap predicates with each fragment's lower bound clamped to the page window
         // begin (windowBegin = resume timestamp on a continuation page, or timeRange begin on page 1).
-        // Fragments that end at or before the window begin contribute nothing to this page.
+        // The clamp lives on TimeInterval so this filter and the dispatcher's sample-level retention
+        // trim are derived from the same interval set (#207) — see clampToWindowBegin.
         final List<Bson> fragmentFilters = new ArrayList<>();
-        for (TimeInterval interval : resolvedQuery.getRetrievalIntervals()) {
-            final long clampedBeginSecs;
-            final long clampedBeginNanos;
-            if (TimeInterval.compareInstant(
-                    interval.getBeginSeconds(), interval.getBeginNanos(),
-                    windowBeginSecs, windowBeginNanos) >= 0) {
-                clampedBeginSecs = interval.getBeginSeconds();
-                clampedBeginNanos = interval.getBeginNanos();
-            } else {
-                clampedBeginSecs = windowBeginSecs;
-                clampedBeginNanos = windowBeginNanos;
-            }
-            // drop fragments entirely before the window begin (clamped begin >= fragment end)
-            if (TimeInterval.compareInstant(
-                    clampedBeginSecs, clampedBeginNanos,
-                    interval.getEndSeconds(), interval.getEndNanos()) >= 0) {
-                continue;
-            }
+        for (TimeInterval interval : TimeInterval.clampToWindowBegin(
+                resolvedQuery.getRetrievalIntervals(), windowBeginSecs, windowBeginNanos)) {
             fragmentFilters.add(MongoQueryFilterBuilder.bucketOverlapsRangeFilter(
-                    clampedBeginSecs, clampedBeginNanos,
+                    interval.getBeginSeconds(), interval.getBeginNanos(),
                     interval.getEndSeconds(), interval.getEndNanos()));
         }
 

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQuerySamplesDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQuerySamplesDispatcher.java
@@ -7,6 +7,7 @@ import com.ospreydcs.dp.grpc.v1.common.Timestamp;
 import com.ospreydcs.dp.grpc.v1.common.TimestampList;
 import com.ospreydcs.dp.grpc.v1.query.ColumnTable;
 import com.ospreydcs.dp.service.common.model.TimestampDataMap;
+import com.ospreydcs.dp.service.common.utility.TabularDataUtility;
 import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
 import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
 import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
@@ -59,6 +60,44 @@ public abstract class AbstractQuerySamplesDispatcher extends QueryV2Dispatcher {
             }
         }
         return new long[]{beginSecs, beginNanos, endSecs, endNanos};
+    }
+
+    /**
+     * The sample-retention windows for the resolved query: one {@link TabularDataUtility.RetentionInterval}
+     * per resolved retrieval fragment, each clamped on the left to the page window begin (the resume
+     * timestamp on a continuation page), mirroring the clamping
+     * {@code MongoSyncQueryClient.executeQuerySamplesV2} applies to its per-fragment database filters.
+     *
+     * <p>Assembly must trim against this full list rather than the single collapsed window returned by
+     * {@link #computeWindow} (issue #207). The database filters fragments only at <em>bucket</em>
+     * granularity, so a bucket spanning the gap between two fragments is retrieved with its in-gap
+     * samples intact; trimming against the collapsed window would leave them in the result.
+     */
+    protected static List<TabularDataUtility.RetentionInterval> retentionIntervals(
+            ResolvedQuery resolvedQuery, long windowBeginSecs, long windowBeginNanos) {
+
+        final List<TabularDataUtility.RetentionInterval> intervals = new ArrayList<>();
+        for (TimeInterval fragment : resolvedQuery.getRetrievalIntervals()) {
+            final long beginSecs;
+            final long beginNanos;
+            if (TimeInterval.compareInstant(
+                    fragment.getBeginSeconds(), fragment.getBeginNanos(),
+                    windowBeginSecs, windowBeginNanos) >= 0) {
+                beginSecs = fragment.getBeginSeconds();
+                beginNanos = fragment.getBeginNanos();
+            } else {
+                beginSecs = windowBeginSecs;
+                beginNanos = windowBeginNanos;
+            }
+            // drop fragments entirely at or before the window begin (they contribute nothing here)
+            if (TimeInterval.compareInstant(
+                    beginSecs, beginNanos, fragment.getEndSeconds(), fragment.getEndNanos()) >= 0) {
+                continue;
+            }
+            intervals.add(new TabularDataUtility.RetentionInterval(
+                    beginSecs, beginNanos, fragment.getEndSeconds(), fragment.getEndNanos()));
+        }
+        return intervals;
     }
 
     /**

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQuerySamplesDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQuerySamplesDispatcher.java
@@ -33,69 +33,49 @@ public abstract class AbstractQuerySamplesDispatcher extends QueryV2Dispatcher {
     }
 
     /**
-     * Computes the page/stream window {@code [begin, end)} for the resolved query: begin = the resume
-     * timestamp (from a continuation token) or the earliest fragment begin; end = the latest fragment
-     * end. Returns {@code {beginSecs, beginNanos, endSecs, endNanos}}.
+     * The page/stream window <em>begin</em> for the resolved query: the resume timestamp (from a
+     * continuation token) or, on the first page, the earliest fragment begin. Returns
+     * {@code {beginSecs, beginNanos}}.
+     *
+     * <p>Deliberately begin-only. There is no corresponding window <em>end</em>, because there is no
+     * single upper bound that is correct to filter on: the resolved fragments may be disjoint, and a
+     * collapsed {@code [min begin, max end)} window spans the gaps between them. Filtering samples
+     * against such a window is precisely the #207 defect. The upper bound is applied per fragment, by
+     * {@link #retentionIntervals}; do not reintroduce a window end here.
      */
-    protected static long[] computeWindow(ResolvedQuery resolvedQuery) {
+    protected static long[] computeWindowBegin(ResolvedQuery resolvedQuery) {
         final List<TimeInterval> intervals = resolvedQuery.getRetrievalIntervals();
         final KeysetPosition pageStart = resolvedQuery.getPageStart();
 
-        final long beginSecs;
-        final long beginNanos;
         if (pageStart != null) {
-            beginSecs = pageStart.getSeconds();
-            beginNanos = pageStart.getNanos();
-        } else {
-            beginSecs = intervals.get(0).getBeginSeconds();
-            beginNanos = intervals.get(0).getBeginNanos();
+            return new long[]{pageStart.getSeconds(), pageStart.getNanos()};
         }
-
-        long endSecs = intervals.get(0).getEndSeconds();
-        long endNanos = intervals.get(0).getEndNanos();
-        for (TimeInterval iv : intervals) {
-            if (TimeInterval.compareInstant(iv.getEndSeconds(), iv.getEndNanos(), endSecs, endNanos) > 0) {
-                endSecs = iv.getEndSeconds();
-                endNanos = iv.getEndNanos();
-            }
-        }
-        return new long[]{beginSecs, beginNanos, endSecs, endNanos};
+        return new long[]{intervals.get(0).getBeginSeconds(), intervals.get(0).getBeginNanos()};
     }
 
     /**
      * The sample-retention windows for the resolved query: one {@link TabularDataUtility.RetentionInterval}
      * per resolved retrieval fragment, each clamped on the left to the page window begin (the resume
-     * timestamp on a continuation page), mirroring the clamping
-     * {@code MongoSyncQueryClient.executeQuerySamplesV2} applies to its per-fragment database filters.
+     * timestamp on a continuation page).
      *
-     * <p>Assembly must trim against this full list rather than the single collapsed window returned by
-     * {@link #computeWindow} (issue #207). The database filters fragments only at <em>bucket</em>
-     * granularity, so a bucket spanning the gap between two fragments is retrieved with its in-gap
-     * samples intact; trimming against the collapsed window would leave them in the result.
+     * <p>Assembly must trim against this full list rather than a single collapsed
+     * {@code [min begin, max end)} window (issue #207). The database filters fragments only at
+     * <em>bucket</em> granularity, so a bucket spanning the gap between two fragments is retrieved with
+     * its in-gap samples intact; trimming against a collapsed window would leave them in the result.
+     *
+     * <p>The clamp itself comes from {@link TimeInterval#clampToWindowBegin}, the same call
+     * {@code MongoSyncQueryClient.executeQuerySamplesV2} uses to build its per-fragment database
+     * filters — so the retrieval filter and this trim cannot drift apart.
      */
     protected static List<TabularDataUtility.RetentionInterval> retentionIntervals(
             ResolvedQuery resolvedQuery, long windowBeginSecs, long windowBeginNanos) {
 
         final List<TabularDataUtility.RetentionInterval> intervals = new ArrayList<>();
-        for (TimeInterval fragment : resolvedQuery.getRetrievalIntervals()) {
-            final long beginSecs;
-            final long beginNanos;
-            if (TimeInterval.compareInstant(
-                    fragment.getBeginSeconds(), fragment.getBeginNanos(),
-                    windowBeginSecs, windowBeginNanos) >= 0) {
-                beginSecs = fragment.getBeginSeconds();
-                beginNanos = fragment.getBeginNanos();
-            } else {
-                beginSecs = windowBeginSecs;
-                beginNanos = windowBeginNanos;
-            }
-            // drop fragments entirely at or before the window begin (they contribute nothing here)
-            if (TimeInterval.compareInstant(
-                    beginSecs, beginNanos, fragment.getEndSeconds(), fragment.getEndNanos()) >= 0) {
-                continue;
-            }
+        for (TimeInterval fragment : TimeInterval.clampToWindowBegin(
+                resolvedQuery.getRetrievalIntervals(), windowBeginSecs, windowBeginNanos)) {
             intervals.add(new TabularDataUtility.RetentionInterval(
-                    beginSecs, beginNanos, fragment.getEndSeconds(), fragment.getEndNanos()));
+                    fragment.getBeginSeconds(), fragment.getBeginNanos(),
+                    fragment.getEndSeconds(), fragment.getEndNanos()));
         }
         return intervals;
     }

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
@@ -76,8 +76,10 @@ public class QuerySamplesStreamDispatcher extends AbstractQuerySamplesDispatcher
         try (cursor) {
             // Assemble the full window once. No sizeLimit: streaming materializes the whole table
             // (memory-bounded, per the class note); the byte budget bounds each emitted chunk, below.
+            // Trimming uses every resolved fragment rather than the collapsed window (#207).
             TabularDataUtility.addBucketsToTable(
-                    tableValueMap, cursor, 0, null, window[0], window[1], window[2], window[3]);
+                    tableValueMap, cursor, 0, null,
+                    retentionIntervals(resolvedQuery, window[0], window[1]));
         } catch (NonScalarColumnException e) {
             final String msg = "querySamples supports scalar PVs only: PV '" + e.getPvName()
                     + "' has non-scalar column type " + e.getColumnType() + "; use queryBuckets";

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
@@ -61,10 +61,10 @@ public class QuerySamplesStreamDispatcher extends AbstractQuerySamplesDispatcher
             return;
         }
 
-        final long[] window = computeWindow(resolvedQuery);
+        final long[] windowBegin = computeWindowBegin(resolvedQuery);
 
         final MongoCursor<BucketDocument> cursor =
-                mongoClient.executeQuerySamplesV2(resolvedQuery, window[0], window[1]);
+                mongoClient.executeQuerySamplesV2(resolvedQuery, windowBegin[0], windowBegin[1]);
 
         if (cursor == null) {
             emitEmptyChunkAndComplete();
@@ -76,10 +76,10 @@ public class QuerySamplesStreamDispatcher extends AbstractQuerySamplesDispatcher
         try (cursor) {
             // Assemble the full window once. No sizeLimit: streaming materializes the whole table
             // (memory-bounded, per the class note); the byte budget bounds each emitted chunk, below.
-            // Trimming uses every resolved fragment rather than the collapsed window (#207).
+            // Trimming uses every resolved fragment rather than a collapsed window (#207).
             TabularDataUtility.addBucketsToTable(
                     tableValueMap, cursor, 0, null,
-                    retentionIntervals(resolvedQuery, window[0], window[1]));
+                    retentionIntervals(resolvedQuery, windowBegin[0], windowBegin[1]));
         } catch (NonScalarColumnException e) {
             final String msg = "querySamples supports scalar PVs only: PV '" + e.getPvName()
                     + "' has non-scalar column type " + e.getColumnType() + "; use queryBuckets";

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesUnaryDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesUnaryDispatcher.java
@@ -65,11 +65,11 @@ public class QuerySamplesUnaryDispatcher extends AbstractQuerySamplesDispatcher 
             return;
         }
 
-        // Only the window begin is needed here: it bounds the database retrieval (and the resume
-        // point on a continuation page). Sample trimming uses the per-fragment intervals below (#207).
-        final long[] window = computeWindow(resolvedQuery);
-        final long windowBeginSecs = window[0];
-        final long windowBeginNanos = window[1];
+        // Only the window begin exists: it bounds the database retrieval (and is the resume point on a
+        // continuation page). The upper bound is per-fragment, applied by retentionIntervals() (#207).
+        final long[] windowBegin = computeWindowBegin(resolvedQuery);
+        final long windowBeginSecs = windowBegin[0];
+        final long windowBeginNanos = windowBegin[1];
 
         final MongoCursor<BucketDocument> cursor =
                 mongoClient.executeQuerySamplesV2(resolvedQuery, windowBeginSecs, windowBeginNanos);

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesUnaryDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesUnaryDispatcher.java
@@ -65,11 +65,11 @@ public class QuerySamplesUnaryDispatcher extends AbstractQuerySamplesDispatcher 
             return;
         }
 
+        // Only the window begin is needed here: it bounds the database retrieval (and the resume
+        // point on a continuation page). Sample trimming uses the per-fragment intervals below (#207).
         final long[] window = computeWindow(resolvedQuery);
         final long windowBeginSecs = window[0];
         final long windowBeginNanos = window[1];
-        final long windowEndSecs = window[2];
-        final long windowEndNanos = window[3];
 
         final MongoCursor<BucketDocument> cursor =
                 mongoClient.executeQuerySamplesV2(resolvedQuery, windowBeginSecs, windowBeginNanos);
@@ -84,15 +84,15 @@ public class QuerySamplesUnaryDispatcher extends AbstractQuerySamplesDispatcher 
 
         final boolean byteBudgetHit;
         try (cursor) {
+            // Trim against every resolved fragment, not the collapsed window (#207): the database
+            // filters fragments only per-bucket, so a bucket spanning a gap arrives with its in-gap
+            // samples intact.
             final TabularDataUtility.TimestampDataMapSizeStats sizeStats = TabularDataUtility.addBucketsToTable(
                     tableValueMap,
                     cursor,
                     0,
                     (int) Math.min(Integer.MAX_VALUE, byteBudget),
-                    windowBeginSecs,
-                    windowBeginNanos,
-                    windowEndSecs,
-                    windowEndNanos);
+                    retentionIntervals(resolvedQuery, windowBeginSecs, windowBeginNanos));
             byteBudgetHit = sizeStats.sizeLimitExceeded();
         } catch (NonScalarColumnException e) {
             // Q4: scalar-only. Translate the neutral shared exception into querySamples guidance.

--- a/src/test/java/com/ospreydcs/dp/service/common/utility/TabularDataUtilityTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/utility/TabularDataUtilityTest.java
@@ -1,0 +1,155 @@
+package com.ospreydcs.dp.service.common.utility;
+
+import com.ospreydcs.dp.grpc.v1.common.DataColumn;
+import com.ospreydcs.dp.grpc.v1.common.DataTimestamps;
+import com.ospreydcs.dp.grpc.v1.common.DataValue;
+import com.ospreydcs.dp.grpc.v1.common.SamplingClock;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.service.common.model.TimestampDataMap;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the sample-level range trimming in {@link TabularDataUtility} — the half-open
+ * {@code [begin, end)} filter shared by {@code queryTable}, {@code querySamples}, and the annotation
+ * export job.
+ *
+ * <p>Exercises {@code addColumnsToTable} directly (via reflection — it is private, and the public
+ * entry points require a Mongo cursor), which is the single place the trim is applied.
+ */
+public class TabularDataUtilityTest {
+
+    private static final long BASE = 1_000_000L;
+
+    /** Builds a 1 Hz {@link DataTimestamps} of {@code count} samples starting at {@code startSecond}. */
+    private static DataTimestamps clock(long startSecond, int count) {
+        return DataTimestamps.newBuilder()
+                .setSamplingClock(SamplingClock.newBuilder()
+                        .setStartTime(Timestamp.newBuilder().setEpochSeconds(startSecond).setNanoseconds(0))
+                        .setPeriodNanos(1_000_000_000L)
+                        .setCount(count))
+                .build();
+    }
+
+    /** A column of {@code count} double values, value i = i. */
+    private static DataColumn column(String name, int count) {
+        final DataColumn.Builder builder = DataColumn.newBuilder().setName(name);
+        for (int i = 0; i < count; i++) {
+            builder.addDataValues(DataValue.newBuilder().setDoubleValue(i).build());
+        }
+        return builder.build();
+    }
+
+    private static void addColumns(
+            DataTimestamps dataTimestamps,
+            List<DataColumn> dataColumns,
+            TimestampDataMap tableValueMap,
+            List<TabularDataUtility.RetentionInterval> intervals) throws Exception {
+
+        final Method method = TabularDataUtility.class.getDeclaredMethod(
+                "addColumnsToTable", DataTimestamps.class, List.class, TimestampDataMap.class, List.class);
+        method.setAccessible(true);
+        try {
+            method.invoke(null, dataTimestamps, dataColumns, tableValueMap, intervals);
+        } catch (InvocationTargetException e) {
+            throw (Exception) e.getCause();
+        }
+    }
+
+    /** Offsets from {@link #BASE} of every timestamp held by the map, in order. */
+    private static List<Long> offsets(TimestampDataMap tableValueMap) {
+        final List<Long> result = new ArrayList<>();
+        final TimestampDataMap.DataRowIterator iterator = tableValueMap.new DataRowIterator();
+        while (iterator.hasNext()) {
+            result.add(iterator.next().seconds() - BASE);
+        }
+        return result;
+    }
+
+    @Test
+    public void testSingleIntervalTrimsToHalfOpenRange() throws Exception {
+        final TimestampDataMap map = new TimestampDataMap();
+        // 20 samples at BASE..BASE+19, kept range [BASE, BASE+10) -> offsets 0..9
+        addColumns(clock(BASE, 20), List.of(column("pv", 20)), map,
+                List.of(new TabularDataUtility.RetentionInterval(BASE, 0, BASE + 10, 0)));
+
+        assertEquals(List.of(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L), offsets(map));
+    }
+
+    @Test
+    public void testSampleExactlyAtEndIsExcluded() throws Exception {
+        final TimestampDataMap map = new TimestampDataMap();
+        addColumns(clock(BASE, 5), List.of(column("pv", 5)), map,
+                List.of(new TabularDataUtility.RetentionInterval(BASE, 0, BASE + 3, 0)));
+
+        // half-open: the sample at exactly BASE+3 is excluded
+        assertEquals(List.of(0L, 1L, 2L), offsets(map));
+    }
+
+    /**
+     * A bucket spanning the gap between two disjoint retention intervals must contribute only its
+     * in-interval samples (issue #207). This is the case the per-bucket database filter cannot catch.
+     */
+    @Test
+    public void testMultipleIntervalsExcludeGapSamples() throws Exception {
+        final TimestampDataMap map = new TimestampDataMap();
+        addColumns(clock(BASE, 10), List.of(column("pv", 10)), map,
+                List.of(
+                        new TabularDataUtility.RetentionInterval(BASE, 0, BASE + 2, 0),
+                        new TabularDataUtility.RetentionInterval(BASE + 8, 0, BASE + 10, 0)));
+
+        assertEquals(List.of(0L, 1L, 8L, 9L), offsets(map));
+    }
+
+    @Test
+    public void testValuesStayAlignedWithTimestampsAcrossAGap() throws Exception {
+        final TimestampDataMap map = new TimestampDataMap();
+        addColumns(clock(BASE, 10), List.of(column("pv", 10)), map,
+                List.of(
+                        new TabularDataUtility.RetentionInterval(BASE, 0, BASE + 2, 0),
+                        new TabularDataUtility.RetentionInterval(BASE + 8, 0, BASE + 10, 0)));
+
+        // value i == i, so the retained values must be exactly 0, 1, 8, 9 -- skipping a sample must
+        // advance the value index in lockstep with the timestamp iterator.
+        final List<Double> values = new ArrayList<>();
+        final TimestampDataMap.DataRowIterator iterator = map.new DataRowIterator();
+        while (iterator.hasNext()) {
+            values.add(iterator.next().dataValues().get(0).getDoubleValue());
+        }
+        assertEquals(List.of(0.0, 1.0, 8.0, 9.0), values);
+    }
+
+    /**
+     * A column whose samples all fall outside the retention range must still be registered, yielding
+     * an all-empty column rather than a missing one. The pre-#207 code got this incidentally (the
+     * range test sat inside the per-column loop, after the registering {@code getColumnIndex} call);
+     * registration is now explicit, and this pins the behavior so a future refactor cannot drop it.
+     */
+    @Test
+    public void testFullyOutOfRangeColumnIsStillRegistered() throws Exception {
+        final TimestampDataMap map = new TimestampDataMap();
+        // every sample (BASE..BASE+4) is outside the kept range [BASE+100, BASE+110)
+        addColumns(clock(BASE, 5), List.of(column("pv_absent", 5)), map,
+                List.of(new TabularDataUtility.RetentionInterval(BASE + 100, 0, BASE + 110, 0)));
+
+        assertTrue("no rows expected", offsets(map).isEmpty());
+        assertEquals("column must still be registered", List.of("pv_absent"), map.getColumnNameList());
+    }
+
+    @Test
+    public void testMultiColumnRegistrationOrderIsPreserved() throws Exception {
+        final TimestampDataMap map = new TimestampDataMap();
+        // pv_b has no in-range samples; pv_a and pv_c do. All three must keep their slots and order.
+        addColumns(clock(BASE, 4), List.of(column("pv_a", 4), column("pv_b", 4), column("pv_c", 4)), map,
+                List.of(new TabularDataUtility.RetentionInterval(BASE, 0, BASE + 2, 0)));
+
+        assertEquals(List.of("pv_a", "pv_b", "pv_c"), map.getColumnNameList());
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/model/TimeIntervalTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/model/TimeIntervalTest.java
@@ -119,4 +119,55 @@ public class TimeIntervalTest {
         assertEquals(List.of(iv(50, 100)),
                 TimeInterval.intersectAll(List.of(openEnded), bound));
     }
+
+    // -----------------------------------------------------------------------
+    // clampToWindowBegin
+    //
+    // The single source for the querySamples page clamp (#207): both the bucket
+    // retrieval filter (MongoSyncQueryClient.executeQuerySamplesV2) and the sample
+    // retention trim (AbstractQuerySamplesDispatcher.retentionIntervals) are built
+    // from this, so a divergence here is a divergence between what the database
+    // returns and what assembly keeps.
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testClampToWindowBegin_firstPageLeavesFragmentsUntouched() {
+        // window begin == earliest fragment begin (the page-1 case): nothing is clamped or dropped
+        final List<TimeInterval> fragments = List.of(iv(10, 20), iv(30, 40));
+        assertEquals(fragments, TimeInterval.clampToWindowBegin(fragments, 10, 0));
+    }
+
+    @Test
+    public void testClampToWindowBegin_clampsStraddlingFragmentAndDropsEarlierOnes() {
+        // resume at 35, mid-way through the second fragment: the first is entirely behind the
+        // window and drops; the second is clamped up to the resume point; the third is untouched.
+        final List<TimeInterval> fragments = List.of(iv(10, 20), iv(30, 40), iv(50, 60));
+        assertEquals(List.of(iv(35, 40), iv(50, 60)),
+                TimeInterval.clampToWindowBegin(fragments, 35, 0));
+    }
+
+    @Test
+    public void testClampToWindowBegin_dropsFragmentEndingExactlyAtWindowBegin() {
+        // half-open: a fragment ending exactly at the window begin contributes no samples
+        assertEquals(List.of(iv(30, 40)),
+                TimeInterval.clampToWindowBegin(List.of(iv(10, 20), iv(30, 40)), 20, 0));
+    }
+
+    @Test
+    public void testClampToWindowBegin_windowPastEverythingYieldsEmpty() {
+        // an empty result means nothing overlaps the page; callers must treat this as an empty
+        // page rather than an unfiltered query.
+        assertTrue(TimeInterval.clampToWindowBegin(List.of(iv(10, 20), iv(30, 40)), 99, 0).isEmpty());
+    }
+
+    @Test
+    public void testClampToWindowBegin_comparesNanosNotJustSeconds() {
+        // fragment begins at 10.500; a window begin of 10.250 is earlier, so no clamp applies
+        final TimeInterval fragment = new TimeInterval(10, 500, 20, 0);
+        assertEquals(List.of(fragment),
+                TimeInterval.clampToWindowBegin(List.of(fragment), 10, 250));
+        // a window begin of 10.750 is later, so the fragment is clamped up to it
+        assertEquals(List.of(new TimeInterval(10, 750, 20, 0)),
+                TimeInterval.clampToWindowBegin(List.of(fragment), 10, 750));
+    }
 }

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQuerySamplesV2Test.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQuerySamplesV2Test.java
@@ -27,6 +27,7 @@ import com.ospreydcs.dp.service.common.protobuf.TimestampUtility;
 import com.ospreydcs.dp.service.query.handler.QueryV2Resolver;
 import com.ospreydcs.dp.service.query.handler.model.ResolutionResult;
 import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
 import com.ospreydcs.dp.service.query.handler.mongo.client.MongoSyncQueryClient;
 import com.ospreydcs.dp.service.query.handler.mongo.dispatch.QuerySamplesUnaryDispatcher;
 import com.ospreydcs.dp.service.query.handler.mongo.job.QueryV2Job;
@@ -65,6 +66,11 @@ public class MongoSyncQuerySamplesV2Test extends MongoQueryHandlerTestBase {
     private static final String PV_B = "spv_b"; // 5 Hz
     private static final String PV_ARR = "sarr"; // non-scalar
 
+    // #207 fragment-gap fixture, on its own time base clear of the other PVs
+    private static final String PV_SPAN = "spanpv";
+    private static final long SPAN_B = startSeconds + 200_000L;
+    private static final int SPAN_SECONDS = 10;
+
     protected static class TestSyncClient extends MongoSyncQueryClient implements TestClientInterface {
         @Override protected String getCollectionNameBuckets() { return getTestCollectionNameBuckets(); }
         @Override protected String getCollectionNameRequestStatus() { return getTestCollectionNameRequestStatus(); }
@@ -87,6 +93,10 @@ public class MongoSyncQuerySamplesV2Test extends MongoQueryHandlerTestBase {
             buckets.add(scalarBucket(PV_B, B + s, 200_000_000L, 5));  // 5 Hz
         }
         buckets.add(arrayBucket(PV_ARR, B));
+        // #207 fixture: ONE bucket covering the whole span, at 1 Hz. Deliberately a single bucket --
+        // the same data stored as per-second buckets is filtered correctly by the database alone and
+        // would not exercise the sample-level fragment trim.
+        buckets.add(spanningBucket(PV_SPAN, SPAN_B, SPAN_SECONDS));
         assertEquals(buckets.size(),
                 ((TestClientInterface) clientTestInterface).insertBucketDocuments(buckets));
     }
@@ -138,6 +148,28 @@ public class MongoSyncQuerySamplesV2Test extends MongoQueryHandlerTestBase {
                 .setStartTime(TimestampUtility.timestampFromSeconds(second, 0))
                 .setPeriodNanos(100_000_000L)
                 .setCount(1)
+                .build();
+        bucket.setDataTimestamps(DataTimestampsDocument.fromDataTimestamps(
+                DataTimestamps.newBuilder().setSamplingClock(clock).build()));
+        return bucket;
+    }
+
+    /** A single bucket holding {@code count} 1 Hz samples starting at {@code startSecond}. */
+    private static BucketDocument spanningBucket(String pvName, long startSecond, int count) {
+        final BucketDocument bucket = new BucketDocument();
+        bucket.setId(pvName + "-span-" + startSecond);
+        bucket.setPvName(pvName);
+
+        final DataColumn.Builder columnBuilder = DataColumn.newBuilder().setName(pvName);
+        for (int i = 0; i < count; i++) {
+            columnBuilder.addDataValues(DataValue.newBuilder().setDoubleValue(i).build());
+        }
+        bucket.setDataColumn(DataColumnDocument.fromDataColumn(columnBuilder.build()));
+
+        final SamplingClock clock = SamplingClock.newBuilder()
+                .setStartTime(TimestampUtility.timestampFromSeconds(startSecond, 0))
+                .setPeriodNanos(1_000_000_000L)
+                .setCount(count)
                 .build();
         bucket.setDataTimestamps(DataTimestampsDocument.fromDataTimestamps(
                 DataTimestamps.newBuilder().setSamplingClock(clock).build()));
@@ -583,5 +615,120 @@ public class MongoSyncQuerySamplesV2Test extends MongoQueryHandlerTestBase {
         assertEquals(com.ospreydcs.dp.grpc.v1.common.ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR,
                 last.getExceptionalResult().getExceptionalResultStatus());
         assertTrue(last.getExceptionalResult().getMessage().contains("exceeds the outgoing message size limit"));
+    }
+
+    // -----------------------------------------------------------------------
+    // #207: fragmented retrieval intervals (ConfigurationSelector) must be enforced at SAMPLE
+    // granularity, not just per-bucket by the database query.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Two disjoint fragments [SPAN_B, SPAN_B+2) and [SPAN_B+8, SPAN_B+10); seconds +2..+7 are the gap.
+     * Builds the ResolvedQuery directly rather than going through the resolver, so the fragmented
+     * shape is exercised without seeding configuration activations.
+     */
+    private static ResolvedQuery fragmentedSpanQuery(boolean streaming) {
+        final List<TimeInterval> intervals = new ArrayList<>();
+        intervals.add(new TimeInterval(SPAN_B, 0, SPAN_B + 2, 0));
+        intervals.add(new TimeInterval(SPAN_B + 8, 0, SPAN_B + 10, 0));
+        return new ResolvedQuery(
+                List.of(PV_SPAN), intervals, DEFAULT_PAGE_SIZE, null, false, false,
+                ResolvedQuery.ResultMode.SAMPLE, streaming);
+    }
+
+    /** Offsets from SPAN_B of every timestamp in the table. */
+    private static List<Long> spanOffsets(ColumnTable table) {
+        final List<Long> offsets = new ArrayList<>();
+        for (Timestamp t : table.getTimestampList().getTimestampsList()) {
+            offsets.add(t.getEpochSeconds() - SPAN_B);
+        }
+        return offsets;
+    }
+
+    @Test
+    public void testFragmentGapExcludedUnary() {
+        final List<QuerySamplesResponse> responses = new ArrayList<>();
+        final StreamObserver<QuerySamplesResponse> observer = new StreamObserver<>() {
+            @Override public void onNext(QuerySamplesResponse r) { responses.add(r); }
+            @Override public void onError(Throwable t) { }
+            @Override public void onCompleted() { }
+        };
+        new QueryV2Job(
+                fragmentedSpanQuery(false),
+                new QuerySamplesUnaryDispatcher(observer, Long.MAX_VALUE),
+                clientTestInterface).execute();
+
+        assertEquals(1, responses.size());
+        final ColumnTable table = responses.get(0).getSampleQueryResult().getColumnTable();
+        assertEquals("only in-fragment samples expected", List.of(0L, 1L, 8L, 9L), spanOffsets(table));
+
+        // values must stay aligned with their timestamps after the gap is dropped
+        final DataColumn column = columnByName(table, PV_SPAN);
+        assertEquals(4, column.getDataValuesCount());
+        assertEquals(0.0, column.getDataValues(0).getDoubleValue(), 0.0);
+        assertEquals(1.0, column.getDataValues(1).getDoubleValue(), 0.0);
+        assertEquals(8.0, column.getDataValues(2).getDoubleValue(), 0.0);
+        assertEquals(9.0, column.getDataValues(3).getDoubleValue(), 0.0);
+    }
+
+    @Test
+    public void testFragmentGapExcludedStreaming() {
+        final StreamOutcome outcome = new StreamOutcome();
+        final StreamObserver<QuerySamplesResponse> observer = new StreamObserver<>() {
+            @Override public void onNext(QuerySamplesResponse r) { outcome.messages.add(r); }
+            @Override public void onError(Throwable t) { outcome.errored = true; }
+            @Override public void onCompleted() { outcome.completed = true; }
+        };
+        new QueryV2Job(
+                fragmentedSpanQuery(true),
+                new com.ospreydcs.dp.service.query.handler.mongo.dispatch.QuerySamplesStreamDispatcher(
+                        observer, Long.MAX_VALUE),
+                clientTestInterface).execute();
+
+        assertFalse(outcome.errored);
+        assertTrue(outcome.completed);
+
+        final List<Long> allOffsets = new ArrayList<>();
+        for (QuerySamplesResponse r : outcome.messages) {
+            allOffsets.addAll(spanOffsets(r.getSampleQueryResult().getColumnTable()));
+        }
+        assertEquals("only in-fragment samples expected", List.of(0L, 1L, 8L, 9L), allOffsets);
+    }
+
+    @Test
+    public void testFragmentGapExcludedAcrossPages() throws Exception {
+        // pageSize=1 forces a page boundary at every row, including across the gap seam, so the
+        // resume-clamped retention intervals are exercised on each continuation page (#207).
+        final List<Long> collected = new ArrayList<>();
+        String pageToken = null;
+        for (int page = 0; page < 20; page++) {
+            final List<TimeInterval> intervals = new ArrayList<>();
+            intervals.add(new TimeInterval(SPAN_B, 0, SPAN_B + 2, 0));
+            intervals.add(new TimeInterval(SPAN_B + 8, 0, SPAN_B + 10, 0));
+            final ResolvedQuery rq = new ResolvedQuery(
+                    List.of(PV_SPAN), intervals, 1,
+                    (pageToken == null || pageToken.isEmpty())
+                            ? null
+                            : com.ospreydcs.dp.service.query.handler.paging.PageToken.decode(pageToken),
+                    false, false, ResolvedQuery.ResultMode.SAMPLE, false);
+
+            final List<QuerySamplesResponse> responses = new ArrayList<>();
+            final StreamObserver<QuerySamplesResponse> observer = new StreamObserver<>() {
+                @Override public void onNext(QuerySamplesResponse r) { responses.add(r); }
+                @Override public void onError(Throwable t) { }
+                @Override public void onCompleted() { }
+            };
+            new QueryV2Job(rq, new QuerySamplesUnaryDispatcher(observer, Long.MAX_VALUE),
+                    clientTestInterface).execute();
+            assertEquals(1, responses.size());
+            final QuerySamplesResponse.SampleQueryResult result = responses.get(0).getSampleQueryResult();
+            collected.addAll(spanOffsets(result.getColumnTable()));
+            pageToken = result.getNextPageToken();
+            if (pageToken == null || pageToken.isEmpty()) {
+                break;
+            }
+        }
+        assertEquals("paged traversal must visit each in-fragment sample exactly once",
+                List.of(0L, 1L, 8L, 9L), collected);
     }
 }


### PR DESCRIPTION
Fixes #207.

## Problem

A `querySamples` request with a `configurationSelector` resolves to a set of **disjoint** retrieval intervals (`QueryV2Resolver.resolveIntervals()` intersects the matched activation windows with the query range). Those fragments were enforced at two different granularities:

- **Database (bucket granularity)** — `MongoSyncQueryClient.executeQuerySamplesV2()` builds a per-fragment `$or` of overlap predicates. Correct, but bucket-level.
- **Assembly (sample granularity)** — `AbstractQuerySamplesDispatcher.computeWindow()` collapsed every fragment into a single `[min begin, max end)` window, and only that was passed to `TabularDataUtility.addBucketsToTable()`.

So the sample-level trim never saw the gaps. A bucket spanning a gap legitimately overlaps the fragments on either side, passes the database filter, and then had **none** of its in-gap samples trimmed — silently returning data outside the requested intervals.

The gap was excluded only incidentally, when gap data happened to live in buckets that did not also overlap a fragment.

## Fix

Added a multi-interval form of `addBucketsToTable()` that retains a sample when it falls inside **any** of the given half-open intervals. Both dispatchers now pass the full fragment list, each fragment clamped to the page window begin the same way `executeQuerySamplesV2` clamps its database filters — so the two filters agree on the same interval set.

`queryTable` and the annotation export job always resolve to exactly one interval and are unaffected; they reach the same code through a single-interval overload that preserves the previous behavior exactly.

### Column registration

While hoisting the range test above the per-column loop, `getColumnIndex()` stopped being called for fully-out-of-range columns. It is a **mutator** — it appends unseen names to the column list that drives the emitted column set — and the previous code got that registration incidentally, by calling it inside the loop before the range test skipped a value. So a column with no in-range samples still got a slot (an all-empty column, not a missing one).

Hoisting would have silently dropped such columns from exports. Registration is now explicit rather than a side effect of the skipped path. This was caught by `AnnotationCalculationsIT` (expected 16 columns, got 14).

## Verification

| Storage layout | Offsets returned | |
|---|---|---|
| Separate 1-second buckets | `0, 1, 8, 9` | correct before and after |
| One bucket spanning `[0, 10)` | `0, 1, 2, 3, 4, 5, 6, 7, 8, 9` → `0, 1, 8, 9` | **fixed** |

Two resolved fragments `[B, B+2)` and `[B+8, B+10)`, so seconds `B+2`..`B+7` are the gap.

Tests added (each confirmed to fail without its corresponding fix):

- `MongoSyncQuerySamplesV2Test` — unary gap, streaming gap, and paging across the gap (`pageSize=1`, verifying each in-fragment sample is visited exactly once with no seam duplication or loss).
- `TabularDataUtilityTest` (new) — the utility had no unit coverage at all. Covers the half-open range, the exclusive end boundary, the multi-interval gap, value/timestamp alignment across a skipped sample, and the column-registration invariant.

Full suite green: **267 unit + 162 integration**, zero failures.

## Note for reviewers

These integration tests share the `dp-test` database and cannot run concurrently — two overlapping `mvn verify` runs produce spurious failures in `ExportDataIT` / `ExportDataBucketSpanIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ljt3T7SWxX5TpZSkCKAegF
