### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keeps the pinned action versions current.  Without this they drift silently until an
+  # old major stops working -- this repo accumulated seven actions between one and three
+  # majors behind before anyone noticed, which is what prompted the pinning work.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "ci"
+    groups:
+      # One PR per month for routine bumps rather than one per action.
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,19 +20,23 @@ jobs:
       DP_GRPC_REF: 'main'
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v4
+        # Actions are pinned to commit SHAs rather than floating major tags: a mutable tag
+        # can be repointed by whoever controls the action's repo, and every run would pick
+        # up the new code with no diff and no review.  Dependabot (.github/dependabot.yml)
+        # keeps the pins current.
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
           cache: 'maven'
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: docker-cache
         with:
           path: /tmp/.buildx-cache
@@ -41,7 +45,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Checkout dp-grpc dependency
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: 'osprey-dcs/dp-grpc'
           path: dp-grpc
@@ -94,7 +98,7 @@ jobs:
 
       - name: Upload logs artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docker-logs
           path: |

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -23,6 +23,11 @@ on:
         description: 'Image tag to push (defaults to the git tag or commit SHA if no tag provided)'
         required: false
         default: ''
+      dry_run:
+        description: 'Build and test only; do not log in to ghcr.io or push the image'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -42,9 +47,18 @@ jobs:
       # 3) if inputs.tag was provided (manual dispatch), use that
       # 4) fallback to commit SHA
       IMAGE_TAG: ${{ inputs.image_tag != '' && inputs.image_tag || (github.ref_type == 'tag' && github.ref_name) || (inputs.tag != '' && inputs.tag) || github.sha }}
+      # A dry run builds and tests the image but never logs in to ghcr.io or pushes it, so
+      # the workflow can be exercised without publishing.  A tag push always publishes; a
+      # manual dispatch defaults to a dry run and must opt in to pushing.  Defined once
+      # here rather than as separate step-level conditions so the two cannot drift apart.
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
     steps:
       - name: Checkout repository at tag
-        uses: actions/checkout@v4
+        # Actions are pinned to commit SHAs rather than floating major tags: this job holds
+        # ghcr.io registry credentials and publishes the public image, so a compromised
+        # upstream tag here could push an image users pull.  Dependabot
+        # (.github/dependabot.yml) keeps the pins current.
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           # On push: github.ref already points to the tag; on manual: checkout refs/tags/<input>
@@ -53,14 +67,14 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.ref != '' && inputs.ref || (inputs.tag != '' && format('refs/tags/{0}', inputs.tag))) || github.ref }}
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
           cache: 'maven'
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: docker-cache
         with:
           path: /tmp/.buildx-cache
@@ -69,7 +83,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Checkout dp-grpc dependency
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: 'osprey-dcs/dp-grpc'
           path: dp-grpc
@@ -135,23 +149,29 @@ jobs:
           DP_MONGO_DB_PASSWORD: admin
 
       - name: Log in to GitHub Container Registry
-        if: success()
-        uses: docker/login-action@v2
+        # Skipped on a dry run, so the registry credential never reaches the runner.
+        if: success() && env.DRY_RUN != 'true'
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
+        # Always builds -- that is what exercises the Dockerfile and this action.  Only the
+        # push is conditional, so a dry run still proves the image builds.
         if: success()
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          push: ${{ env.DRY_RUN != 'true' }}
+          # `latest` is published only from a real tag push.  A manual dispatch builds an
+          # arbitrary ref with an arbitrary image_tag, and moving `latest` to that would
+          # repoint the tag most consumers pull at something that was never released.
           tags: |
             ghcr.io/${{ github.repository_owner }}/dp-service:${{ env.IMAGE_TAG }}
-            ghcr.io/${{ github.repository_owner }}/dp-service:latest
+            ${{ github.ref_type == 'tag' && format('ghcr.io/{0}/dp-service:latest', github.repository_owner) || '' }}
           build-args: |
             DP_GRPC_REPO=${{ env.DP_GRPC_REPO }}
             DP_GRPC_REF=${{ env.DP_GRPC_REF }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,11 @@ jobs:
 
     steps:
       - name: Checkout dp-service at tag
-        uses: actions/checkout@v4
+        # Actions are pinned to commit SHAs rather than floating major tags: this job runs
+        # with `contents: write` and publishes release artifacts, so a compromised upstream
+        # tag here could replace what users download.  Dependabot (.github/dependabot.yml)
+        # keeps the pins current.
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -37,14 +41,14 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
 
       - name: Checkout dp-grpc at matching tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: ${{ env.DP_GRPC_REPO }}
           path: dp-grpc
@@ -105,7 +109,7 @@ jobs:
             > release/dp-service-${VERSION}.jar.sha256
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             release/dp-service-${{ env.VERSION }}.jar


### PR DESCRIPTION
Pins all 15 GitHub Actions references to full commit SHAs, adds a Dependabot config, and makes
`release-image.yml` testable without publishing to ghcr.io.

Part of #215 and osprey-dcs/data-platform#90. Follows the format settled in
osprey-dcs/dp-python-lib#34 and osprey-dcs/dp-grpc#134.

The docker major upgrades are deliberately **not** here — see "Follow-up" below.

## Pins — 15 references, 7 distinct actions

| Action | SHA | Version | Refs |
|---|---|---|---|
| `actions/checkout` | `11d5960a326750d5838078e36cf38b85af677262` | v4.4.0 | 6 |
| `actions/setup-java` | `cf277c60eb25467037889841efdb72551f06f6c3` | v4.9.1 | 3 |
| `actions/cache` | `0057852bfaa89a56745cba8c7296529d2fc39830` | v4.3.0 | 2 |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 | 1 |
| `softprops/action-gh-release` | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | v2.6.2 | 1 |
| `docker/login-action` | `465a07811f14bebb1938fbed4728c6a1ff8901fc` | v2.2.0 | 1 |
| `docker/build-push-action` | `ca052bb54ab0790a636c9b5f226502c73d547a25` | v5.4.0 | 1 |

**No version changes.** Each floating major resolves to exactly the SHA it was replaced with
today, so nothing about what runs changes.

Each SHA was resolved from its tag ref and then checked in the other direction — mapping the
commit back to the tags pointing at it — to confirm the trailing comment is truthful. All seven
resolve to both their exact semver tag and the floating major they replace.

```
grep -rnE 'uses: *[^ ]+@' .github/workflows/ | grep -vE '@[0-9a-f]{40} # v'
```

returns clean.

## Dependabot

New `.github/dependabot.yml`: `github-actions` ecosystem, monthly, `ci` commit prefix, wildcard
group so routine bumps arrive as one PR rather than one per action.

This half matters more here than in the other repos. This is the repo that drifted to seven
actions between one and three majors behind, which is what prompted the whole effort. Pinning
without Dependabot would freeze that drift in place permanently rather than fixing it.

## `dry_run` gate on `release-image.yml`

The publish steps were ungated: dispatching the workflow logged in to ghcr.io and pushed for
real. That meant there was no way to exercise it, and therefore no way to verify the two docker
pins — the highest-risk ones in the repo — without publishing an image.

So: a `dry_run` input, defaulting to `true`. A dry run still **builds** the image, which is what
actually exercises `build-push-action` and the Dockerfile, but skips the registry login and sets
`push: false`. Dispatching with `dry_run: false` publishes as before. A tag push is unaffected.

### `latest` is now conditional

Separately, `ghcr.io/…/dp-service:latest` was an unconditional entry in the `tags:` list. Any
manual dispatch — any `image_tag`, any ref — republished the tag most consumers pull, at whatever
was built. It now only publishes from a real tag push.

This is a live footgun independent of the pinning work, and it is why a "just dispatch with a
throwaway `image_tag`" rehearsal would not have been safe: the throwaway tag avoids colliding
with a real version, but `latest` moves regardless.

Two details worth a reviewer's eye:

- The gate is one job-level `DRY_RUN` env var referenced by both steps, not two independently
  written conditions, so they cannot drift apart.
- `dry_run` defaults to **true**, so publishing requires deliberately opting in.

## What this PR proves

- **`ci.yml` runs on this PR** — exercises `checkout`, `setup-java`, `cache`, and
  `upload-artifact` against a full MongoDB-backed integration suite. 4 of 7 actions.
- **`release-image.yml` dry-run dispatch** — exercises `checkout`, `setup-java`, `cache`, and
  `build-push-action` (build path). Results posted as a comment below.
- **Not exercised:** `docker/login-action` (skipped by design on a dry run — it is the credential
  step) and `softprops/action-gh-release` in `release.yml`, which is `rel-*`-triggered only.
  Both await the next real release.

## Follow-up

Two actions here are badly stale, and they are the credentialed ones:

- `docker/login-action` v2.2.0 — published **2023-06-07**, two majors behind current (v4.6.0)
- `docker/build-push-action` v5.4.0 — published **2024-06-10**, two majors behind (v7.3.0)

Pinning them at these SHAs is the right first move — behavior-neutral, and it makes the current
state explicit rather than silently floating — but it does freeze old code holding registry
credentials, so it is not a neutral act.

A second PR against #215 raises both to current, kept separate so that if a two-major docker bump
breaks the image build the failure is attributable rather than tangled with 15 pins.
