### PR TITLE
ci: upgrade docker actions to current majors

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Log in to GitHub Container Registry
         # Skipped on a dry run, so the registry credential never reaches the runner.
         if: success() && env.DRY_RUN != 'true'
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -161,7 +161,7 @@ jobs:
         # Always builds -- that is what exercises the Dockerfile and this action.  Only the
         # push is conditional, so a dry run still proves the image builds.
         if: success()
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Raises the two stalest actions in the repo to current majors.

Part of #215. **Stacked on #216** — targets that branch, so this diff is just the two lines.
Merge #216 first; this will retarget to `main` automatically.

| Action | From | To |
|---|---|---|
| `docker/login-action` | v2.2.0 — published **2023-06-07** | v4.6.0 |
| `docker/build-push-action` | v5.4.0 — published **2024-06-10** | v7.3.0 |

Both were two majors behind, and both are the credentialed steps in `release-image.yml`: one
authenticates to ghcr.io, the other pushes the image. #216 pins them at these ages, which is
correct as a behavior-neutral first move but freezes two-to-three-year-old code holding registry
access. This unfreezes it.

Kept separate from the pinning PR so that a break here is attributable to the version bump rather
than tangled with 15 pins.

## Breaking-change review

None affecting this workflow. The inputs it uses — `context`, `file`, `push`, `tags`,
`build-args` — are unchanged across every intervening major.

- **login-action v3.0.0** — Node 20 default runtime
- **login-action v4.0.0** — Node 24 default runtime, ESM internals
- **build-push-action v6.0.0** — adds build summaries as a new feature (opt out with
  `DOCKER_BUILD_SUMMARY: false`); this workflow gets them, which is an improvement
- **build-push-action v7.0.0** — Node 24, ESM, and removes `DOCKER_BUILD_NO_SUMMARY` and
  `DOCKER_BUILD_EXPORT_RETENTION_DAYS`. Neither is set here.

The Node 24 runtimes require Actions Runner ≥ 2.327.1; `ubuntu-latest` on GitHub-hosted runners
is well past that.

## Verification

The `dry_run` gate added in #216 is what makes this testable at all — before it, checking a
docker upgrade meant publishing an image. A dry-run dispatch against this branch exercises the
new `build-push-action` on the real Dockerfile without pushing. Results posted below.

`login-action` remains unexercised: a dry run skips it by design, since it is the credential
step. Its upgrade is the lower-risk of the two — a pure runtime bump with unchanged inputs — but
it is genuinely unverified until the next tag push.
