### PR TITLE
ci: re-land docker action upgrades onto main

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Log in to GitHub Container Registry
         # Skipped on a dry run, so the registry credential never reaches the runner.
         if: success() && env.DRY_RUN != 'true'
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -161,7 +161,7 @@ jobs:
         # Always builds -- that is what exercises the Dockerfile and this action.  Only the
         # push is conditional, so a dry run still proves the image builds.
         if: success()
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Re-lands the two-line docker upgrade from #217, which merged but never reached `main`.

Cherry-pick of `b9c3d43` onto `main`. Identical content to #217; only the base differs.

## What happened

#217 was stacked on `ci/issue-215-pin-actions-by-sha` and merged 26 seconds after #216. Its
body anticipated the retarget ("Merge #216 first; this will retarget to `main` automatically"),
but GitHub's auto-retarget did not win the race — so #217 merged into the feature branch that
`main` had already absorbed at `f14c5c4`.

Its merge commit `28ea00e` has first parent `f14c5c4`, the pre-merge branch tip. GitHub marks
#217 MERGED because that commit exists; it is simply not reachable from `main`.

The same file at two refs, before this PR:

```
main     docker/login-action@465a0781…       # v2.2.0   <- old
         docker/build-push-action@ca052bb5…  # v5.4.0

28ea00e  docker/login-action@dbcb8138…       # v4.6.0   <- the upgrade
         docker/build-push-action@53b7df96…  # v7.3.0
```

## Why it matters now

`rel-1.15.0` is about to be re-cut so its artifacts come from the SHA-pinned tree. Tagging
`main` as it stands would ship the pinning work while silently dropping the docker upgrades,
and #217 would read as delivered.

The two actions left frozen are also the credentialed ones — `login-action` authenticates to
ghcr.io, `build-push-action` pushes the image — at v2.2.0 (published 2023-06-07) and v5.4.0
(2024-06-10), two majors behind each. Freezing those at pin time is exactly what #217 existed
to undo.

## Verification

Both SHAs re-resolved independently rather than trusted from the comments, and checked in the
other direction by mapping each commit back to the tags pointing at it:

| Action | SHA | Tags at that commit |
|---|---|---|
| `docker/login-action` | `dbcb813823bdd20940b903addbd779551569679f` | `v4`, `v4.6.0` |
| `docker/build-push-action` | `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` | `v7`, `v7.3.0` |

Each resolves to both its exact semver tag and its floating major, so the trailing comments are
truthful and both are current heads.

The pin gate is clean on this branch:

```
grep -rnE 'uses: *[^ ]+@' .github/workflows/ | grep -vE '@[0-9a-f]{40} # v'
```

Breaking-change review carries over from #217 unchanged. The inputs this workflow uses —
`context`, `file`, `push`, `tags`, `build-args` — are unchanged across every intervening major,
and it sets neither `DOCKER_BUILD_NO_SUMMARY` nor `DOCKER_BUILD_EXPORT_RETENTION_DAYS`, the two
things v7 removes. Confirmed against the file as it stands here, not just from the #217 writeup.

## Before merging

A `release-image.yml` dry-run dispatch against this branch exercises `build-push-action` v7.3.0
on the real Dockerfile without publishing — that is the upgrade with actual breaking-change
surface. The `dry_run` gate from #216 is on `main`, so this is testable now.

`login-action` stays unexercised: a dry run skips it by design, since it is the credential step.
Pure runtime bump with unchanged inputs, but genuinely unverified until the next tag push.

Refs #215.
