### PR TITLE
dp-service: bump version to 1.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>com.ospreydcs</groupId>
     <artifactId>dp-service</artifactId>
     <packaging>jar</packaging>
-    <version>1.15.0</version>
+    <version>1.16.0</version>
 
     <properties>
 
@@ -22,7 +22,7 @@
 
         <main.basedir>${project.basedir}</main.basedir>
 
-        <dp-grpc.version>1.15.0</dp-grpc.version>
+        <dp-grpc.version>1.16.0</dp-grpc.version>
         <mongodb.version>5.4.0</mongodb.version>
         <log4j-version>2.25.4</log4j-version>
         <poi.version>5.4.0</poi.version>


### PR DESCRIPTION
Bumps `pom.xml` project version and the `dp-grpc.version` property to 1.16.0 for the coordinated platform release train.

No code changes — version bump only.

**Merge order:** depends on osprey-dcs/dp-grpc#138, which must merge (and `rel-1.16.0` be available) first so this resolves `dp-grpc:1.16.0`.

Verified with `mvn clean install -DskipTests` (exit 0) against a locally installed dp-grpc 1.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUJHS4QtFF8MwrGBresGEr