### PR TITLE
dp-service: support column metadata in IngestionRequestParams

### DIFF
--- a/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
@@ -187,11 +187,22 @@ public class IngestionClient extends ServiceApiClientBase {
          * Sets the column metadata applied to each column in the request, and returns this params
          * object so the call can be chained to a constructor invocation.  The supplied message is
          * used as-is with no normalization; unlike the convenience overload below, blank provenance
-         * fields are not omitted, and an empty message is not treated as "no metadata".  Pass null
-         * to clear.
+         * fields are not omitted, and an empty message is not treated as "no metadata".  Use
+         * clearColumnMetadata() rather than passing null, which is ambiguous between this method
+         * and the overload below and so requires an explicit cast at the call site.
          */
         public IngestionRequestParams setColumnMetadata(ColumnMetadata columnMetadata) {
             this.columnMetadata = columnMetadata;
+            return this;
+        }
+
+        /*
+         * Clears any column metadata previously set, so that the request's columns are built
+         * without a metadata field.  Returns this params object so the call can be chained to a
+         * constructor invocation.
+         */
+        public IngestionRequestParams clearColumnMetadata() {
+            this.columnMetadata = null;
             return this;
         }
 
@@ -319,6 +330,28 @@ public class IngestionClient extends ServiceApiClientBase {
             this.dataType = dataType;
             this.values = values;
             this.valuesStatus = valuesStatus;
+
+            // buildIngestionRequest() indexes valuesStatus by the values dimensions, so a mismatch
+            // would otherwise surface as an IndexOutOfBoundsException from inside the builder,
+            // far from the call site that supplied the mismatched lists
+            if (valuesStatus != null && values != null) {
+                if (valuesStatus.size() != values.size()) {
+                    throw new IllegalArgumentException(
+                            "valuesStatus size does not match values size: "
+                                    + "valuesStatus: " + valuesStatus.size()
+                                    + ", values: " + values.size());
+                }
+                for (int i = 0; i < values.size(); i++) {
+                    final List<DataValue.ValueStatus> columnStatus = valuesStatus.get(i);
+                    if (columnStatus == null || columnStatus.size() != values.get(i).size()) {
+                        throw new IllegalArgumentException(
+                                "valuesStatus[" + i + "] size does not match values[" + i + "] size: "
+                                        + "valuesStatus: "
+                                        + (columnStatus == null ? "null" : columnStatus.size())
+                                        + ", values: " + values.get(i).size());
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
@@ -166,9 +166,12 @@ public class IngestionClient extends ServiceApiClientBase {
         public List<List<DataValue.ValueStatus>> valuesStatus = null;
 
         /*
-         * Optional column-level metadata (provenance, tags, attributes) applied uniformly to every
-         * column in the request's DataFrame.  Left null when no metadata is supplied, in which case
-         * the columns are built without a metadata field.
+         * Optional column-level metadata (provenance, tags, attributes) applied to each DataColumn
+         * that buildIngestionRequest() adds to the request's DataFrame.  The other column types
+         * defined by DataFrame also carry a metadata field, but buildIngestionRequest() does not
+         * build them, so this field does not apply to them.  A column that already carries its own
+         * metadata keeps it; this field is only applied to columns without one.  Left null when no
+         * metadata is supplied, in which case the columns are built without a metadata field.
          */
         public ColumnMetadata columnMetadata = null;
 
@@ -182,7 +185,10 @@ public class IngestionClient extends ServiceApiClientBase {
 
         /*
          * Sets the column metadata applied to each column in the request, and returns this params
-         * object so the call can be chained to a constructor invocation.
+         * object so the call can be chained to a constructor invocation.  The supplied message is
+         * used as-is with no normalization; unlike the convenience overload below, blank provenance
+         * fields are not omitted, and an empty message is not treated as "no metadata".  Pass null
+         * to clear.
          */
         public IngestionRequestParams setColumnMetadata(ColumnMetadata columnMetadata) {
             this.columnMetadata = columnMetadata;
@@ -191,10 +197,16 @@ public class IngestionClient extends ServiceApiClientBase {
 
         /*
          * Convenience method building ColumnMetadata from its constituent parts, applied to each
-         * column in the request.  Provenance is only set if at least one of source/process is
-         * specified, and individual provenance fields are omitted rather than set to empty strings,
-         * per the ColumnProvenance contract in common.proto.  Returns this params object so the
-         * call can be chained to a constructor invocation.
+         * column in the request.  The provenance message is only set if at least one of
+         * source/process is supplied, and a blank argument is treated the same as null.  Note that
+         * ColumnProvenance.source and .process are plain proto3 strings with no field presence, so
+         * an unsupplied one is indistinguishable from an empty one on the wire and reads back as
+         * the empty string; the blank checking here determines whether the enclosing provenance
+         * message, which does have presence, is set at all.  If none of the arguments supply a
+         * value, columnMetadata is left null rather than set to an empty message, so that the
+         * columns are built without a metadata field instead of carrying an empty one.  Attribute
+         * entries with a null name or value are skipped.  Returns this params object so the call
+         * can be chained to a constructor invocation.
          */
         public IngestionRequestParams setColumnMetadata(
                 String provenanceSource,
@@ -222,10 +234,26 @@ public class IngestionClient extends ServiceApiClientBase {
             }
 
             if (attributes != null && !attributes.isEmpty()) {
-                metadataBuilder.addAllAttributes(AttributesUtility.attributeListFromMap(attributes));
+                for (Map.Entry<String, String> entry : attributes.entrySet()) {
+                    // skip incomplete entries, since the protobuf setters reject null
+                    if (entry.getKey() == null || entry.getValue() == null) {
+                        continue;
+                    }
+                    metadataBuilder.addAttributes(
+                            Attribute.newBuilder()
+                                    .setName(entry.getKey())
+                                    .setValue(entry.getValue())
+                                    .build());
+                }
             }
 
-            this.columnMetadata = metadataBuilder.build();
+            final ColumnMetadata metadata = metadataBuilder.build();
+
+            // leave columnMetadata null when nothing was actually supplied, so that the columns are
+            // built without a metadata field rather than carrying an empty one
+            this.columnMetadata =
+                    metadata.equals(ColumnMetadata.getDefaultInstance()) ? null : metadata;
+
             return this;
         }
 
@@ -554,13 +582,20 @@ public class IngestionClient extends ServiceApiClientBase {
             }
         }
 
-        // apply optional column metadata uniformly to each column in the frame, covering both the
-        // caller-supplied column list and the columns built from params above
+        // apply optional column metadata to each column in the frame, covering both the
+        // caller-supplied column list and the columns built from params above.  A column that
+        // already carries its own metadata keeps it, since per-column metadata is the more specific
+        // intent than the request-wide default in params.
         final List<DataColumn> metadataColumns;
         if (params.columnMetadata != null) {
             metadataColumns = new ArrayList<>(frameColumns.size());
             for (DataColumn frameColumn : frameColumns) {
-                metadataColumns.add(frameColumn.toBuilder().setMetadata(params.columnMetadata).build());
+                if (frameColumn.hasMetadata()) {
+                    metadataColumns.add(frameColumn);
+                } else {
+                    metadataColumns.add(
+                            frameColumn.toBuilder().setMetadata(params.columnMetadata).build());
+                }
             }
         } else {
             metadataColumns = frameColumns;

--- a/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
@@ -165,12 +165,68 @@ public class IngestionClient extends ServiceApiClientBase {
         public List<List<Object>> values = null;
         public List<List<DataValue.ValueStatus>> valuesStatus = null;
 
+        /*
+         * Optional column-level metadata (provenance, tags, attributes) applied uniformly to every
+         * column in the request's DataFrame.  Left null when no metadata is supplied, in which case
+         * the columns are built without a metadata field.
+         */
+        public ColumnMetadata columnMetadata = null;
+
         public IngestionRequestParams(
                 String providerId,
                 String requestId
         ) {
             this.providerId = providerId;
             this.requestId = requestId;
+        }
+
+        /*
+         * Sets the column metadata applied to each column in the request, and returns this params
+         * object so the call can be chained to a constructor invocation.
+         */
+        public IngestionRequestParams setColumnMetadata(ColumnMetadata columnMetadata) {
+            this.columnMetadata = columnMetadata;
+            return this;
+        }
+
+        /*
+         * Convenience method building ColumnMetadata from its constituent parts, applied to each
+         * column in the request.  Provenance is only set if at least one of source/process is
+         * specified, and individual provenance fields are omitted rather than set to empty strings,
+         * per the ColumnProvenance contract in common.proto.  Returns this params object so the
+         * call can be chained to a constructor invocation.
+         */
+        public IngestionRequestParams setColumnMetadata(
+                String provenanceSource,
+                String provenanceProcess,
+                List<String> tags,
+                Map<String, String> attributes
+        ) {
+            final ColumnMetadata.Builder metadataBuilder = ColumnMetadata.newBuilder();
+
+            final boolean hasSource = provenanceSource != null && !provenanceSource.isBlank();
+            final boolean hasProcess = provenanceProcess != null && !provenanceProcess.isBlank();
+            if (hasSource || hasProcess) {
+                final ColumnProvenance.Builder provenanceBuilder = ColumnProvenance.newBuilder();
+                if (hasSource) {
+                    provenanceBuilder.setSource(provenanceSource);
+                }
+                if (hasProcess) {
+                    provenanceBuilder.setProcess(provenanceProcess);
+                }
+                metadataBuilder.setProvenance(provenanceBuilder.build());
+            }
+
+            if (tags != null && !tags.isEmpty()) {
+                metadataBuilder.addAllTags(tags);
+            }
+
+            if (attributes != null && !attributes.isEmpty()) {
+                metadataBuilder.addAllAttributes(AttributesUtility.attributeListFromMap(attributes));
+            }
+
+            this.columnMetadata = metadataBuilder.build();
+            return this;
         }
 
         public IngestionRequestParams(
@@ -187,6 +243,39 @@ public class IngestionClient extends ServiceApiClientBase {
                 List<String> columnNames,
                 IngestionDataType dataType,
                 List<List<Object>> values
+        ) {
+            this(
+                    providerId,
+                    requestId,
+                    snapshotStartTimestampSeconds,
+                    snapshotStartTimestampNanos,
+                    timestampsSecondsList,
+                    timestampNanosList,
+                    samplingClockStartSeconds,
+                    samplingClockStartNanos,
+                    samplingClockPeriodNanos,
+                    samplingClockCount,
+                    columnNames,
+                    dataType,
+                    values,
+                    null);
+        }
+
+        public IngestionRequestParams(
+                String providerId,
+                String requestId,
+                Long snapshotStartTimestampSeconds,
+                Long snapshotStartTimestampNanos,
+                List<Long> timestampsSecondsList,
+                List<Long> timestampNanosList,
+                Long samplingClockStartSeconds,
+                Long samplingClockStartNanos,
+                Long samplingClockPeriodNanos,
+                Integer samplingClockCount,
+                List<String> columnNames,
+                IngestionDataType dataType,
+                List<List<Object>> values,
+                List<List<DataValue.ValueStatus>> valuesStatus
         ) {
             this(providerId, requestId);
 
@@ -464,8 +553,21 @@ public class IngestionClient extends ServiceApiClientBase {
                 frameColumns.add(dataColumnBuilder.build());
             }
         }
+
+        // apply optional column metadata uniformly to each column in the frame, covering both the
+        // caller-supplied column list and the columns built from params above
+        final List<DataColumn> metadataColumns;
+        if (params.columnMetadata != null) {
+            metadataColumns = new ArrayList<>(frameColumns.size());
+            for (DataColumn frameColumn : frameColumns) {
+                metadataColumns.add(frameColumn.toBuilder().setMetadata(params.columnMetadata).build());
+            }
+        } else {
+            metadataColumns = frameColumns;
+        }
+
         // add regular DataColumns
-        dataFrameBuilder.addAllDataColumns(frameColumns);
+        dataFrameBuilder.addAllDataColumns(metadataColumns);
 
         dataFrameBuilder.build();
         requestBuilder.setIngestionDataFrame(dataFrameBuilder);

--- a/src/test/java/com/ospreydcs/dp/client/IngestionClientTest.java
+++ b/src/test/java/com/ospreydcs/dp/client/IngestionClientTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -311,8 +312,42 @@ public class IngestionClientTest {
     }
 
     /**
+     * Verifies that a valuesStatus whose dimensions do not match values is rejected at construction
+     * with a clear message, rather than surfacing later as an IndexOutOfBoundsException from inside
+     * buildIngestionRequest().
+     */
+    @Test
+    public void testMismatchedValuesStatusDimensionsRejected() {
+
+        final DataValue.ValueStatus status = DataValue.ValueStatus.newBuilder()
+                .setMessage("status")
+                .build();
+
+        // outer dimension too short: one status column for two value columns
+        final IllegalArgumentException outerException = assertThrows(
+                IllegalArgumentException.class,
+                () -> buildParams(List.of(List.of(status, status))));
+        assertTrue(
+                outerException.getMessage(),
+                outerException.getMessage().contains("valuesStatus size does not match values size"));
+
+        // inner dimension too short: one status for a column with two values
+        final IllegalArgumentException innerException = assertThrows(
+                IllegalArgumentException.class,
+                () -> buildParams(List.of(List.of(status), List.of(status, status))));
+        assertTrue(
+                innerException.getMessage(),
+                innerException.getMessage().contains("valuesStatus[0] size does not match values[0] size"));
+
+        // matching dimensions are accepted
+        buildParams(Arrays.asList(
+                Arrays.asList(status, status),
+                Arrays.asList(status, status)));
+    }
+
+    /**
      * Verifies that the raw setter overload applies the supplied message as is, with no
-     * normalization, and that passing null clears any metadata previously set.
+     * normalization, and that clearColumnMetadata() removes any metadata previously set.
      */
     @Test
     public void testRawSetterAppliesMessageAsIs() {
@@ -327,8 +362,9 @@ public class IngestionClientTest {
             assertTrue(column.hasMetadata());
         }
 
-        // passing null clears it
-        params.setColumnMetadata((ColumnMetadata) null);
+        // clearColumnMetadata() removes it, avoiding the ambiguity of passing null to the
+        // overloaded setColumnMetadata()
+        params.clearColumnMetadata();
         assertNull(params.columnMetadata);
         for (DataColumn column : buildRequestColumns(params)) {
             assertFalse(column.hasMetadata());

--- a/src/test/java/com/ospreydcs/dp/client/IngestionClientTest.java
+++ b/src/test/java/com/ospreydcs/dp/client/IngestionClientTest.java
@@ -1,0 +1,351 @@
+package com.ospreydcs.dp.client;
+
+import com.ospreydcs.dp.client.IngestionClient.IngestionDataType;
+import com.ospreydcs.dp.client.IngestionClient.IngestionRequestParams;
+import com.ospreydcs.dp.grpc.v1.common.Attribute;
+import com.ospreydcs.dp.grpc.v1.common.ColumnMetadata;
+import com.ospreydcs.dp.grpc.v1.common.ColumnProvenance;
+import com.ospreydcs.dp.grpc.v1.common.DataColumn;
+import com.ospreydcs.dp.grpc.v1.common.DataValue;
+import com.ospreydcs.dp.grpc.v1.ingestion.IngestDataRequest;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Provides test coverage for IngestionClient.IngestionRequestParams and the column metadata and
+ * valuesStatus handling in IngestionClient.buildIngestionRequest().
+ */
+public class IngestionClientTest {
+
+    private static final String PROVIDER_ID = "1";
+    private static final String REQUEST_ID = "request-1";
+    private static final List<String> COLUMN_NAMES = Arrays.asList("pv_01", "pv_02");
+    private static final List<List<Object>> VALUES =
+            Arrays.asList(Arrays.asList(12.34, 42.00), Arrays.asList(56.78, 90.12));
+
+    /*
+     * Builds params using the 13 argument constructor, which does not accept valuesStatus.
+     */
+    private static IngestionRequestParams buildParams() {
+        return buildParams(null);
+    }
+
+    /*
+     * Builds params using the 14 argument constructor, which accepts valuesStatus explicitly.
+     */
+    private static IngestionRequestParams buildParams(
+            List<List<DataValue.ValueStatus>> valuesStatus
+    ) {
+        final Instant instantNow = Instant.now();
+        return new IngestionRequestParams(
+                PROVIDER_ID,
+                REQUEST_ID,
+                null,
+                null,
+                null,
+                null,
+                instantNow.getEpochSecond(),
+                0L,
+                1_000_000L,
+                2,
+                COLUMN_NAMES,
+                IngestionDataType.DOUBLE,
+                VALUES,
+                valuesStatus);
+    }
+
+    private static List<DataColumn> buildRequestColumns(IngestionRequestParams params) {
+        final IngestDataRequest request = IngestionClient.buildIngestionRequest(params, null, null);
+        return request.getIngestionDataFrame().getDataColumnsList();
+    }
+
+    /**
+     * Verifies that valuesStatus supplied to the 14 argument constructor reaches the built request.
+     * Regression coverage for the self assignment in the 13 argument constructor, which left the
+     * field permanently null and made the valuesStatus handling in buildIngestionRequest()
+     * unreachable.
+     */
+    @Test
+    public void testValuesStatusReachesBuiltRequest() {
+
+        final DataValue.ValueStatus statusOne = DataValue.ValueStatus.newBuilder()
+                .setMessage("status-one")
+                .build();
+        final DataValue.ValueStatus statusTwo = DataValue.ValueStatus.newBuilder()
+                .setMessage("status-two")
+                .build();
+
+        final List<List<DataValue.ValueStatus>> valuesStatus = Arrays.asList(
+                Arrays.asList(statusOne, statusTwo),
+                Arrays.asList(statusTwo, statusOne));
+
+        final IngestionRequestParams params = buildParams(valuesStatus);
+        assertEquals(valuesStatus, params.valuesStatus);
+
+        final List<DataColumn> columns = buildRequestColumns(params);
+        assertEquals(COLUMN_NAMES.size(), columns.size());
+
+        // each value carries the status supplied for its column and row position
+        for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+            final List<DataValue> dataValues = columns.get(columnIndex).getDataValuesList();
+            assertEquals(VALUES.get(columnIndex).size(), dataValues.size());
+            for (int valueIndex = 0; valueIndex < dataValues.size(); valueIndex++) {
+                assertEquals(
+                        valuesStatus.get(columnIndex).get(valueIndex),
+                        dataValues.get(valueIndex).getValueStatus());
+            }
+        }
+    }
+
+    /**
+     * Verifies that the 13 argument constructor still builds a request, leaving valuesStatus unset.
+     */
+    @Test
+    public void testThirteenArgumentConstructorLeavesValuesStatusUnset() {
+
+        final IngestionRequestParams params = buildParams();
+        assertNull(params.valuesStatus);
+
+        final List<DataColumn> columns = buildRequestColumns(params);
+        assertEquals(COLUMN_NAMES.size(), columns.size());
+
+        for (DataColumn column : columns) {
+            for (DataValue dataValue : column.getDataValuesList()) {
+                assertFalse(dataValue.hasValueStatus());
+            }
+        }
+    }
+
+    /**
+     * Verifies that column metadata is applied to columns built from the params columnNames and
+     * values, and that it coexists with valuesStatus.
+     */
+    @Test
+    public void testColumnMetadataAppliedToGeneratedColumns() {
+
+        final DataValue.ValueStatus status = DataValue.ValueStatus.newBuilder()
+                .setMessage("status")
+                .build();
+        final List<List<DataValue.ValueStatus>> valuesStatus = Arrays.asList(
+                Arrays.asList(status, status),
+                Arrays.asList(status, status));
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("attribute-name", "attribute-value");
+
+        final IngestionRequestParams params = buildParams(valuesStatus)
+                .setColumnMetadata(
+                        "test-source",
+                        "test-process",
+                        List.of("tag-one", "tag-two"),
+                        attributes);
+
+        final List<DataColumn> columns = buildRequestColumns(params);
+        assertEquals(COLUMN_NAMES.size(), columns.size());
+
+        // metadata is applied uniformly to every generated column
+        for (DataColumn column : columns) {
+            assertTrue(column.hasMetadata());
+            final ColumnMetadata metadata = column.getMetadata();
+            assertEquals("test-source", metadata.getProvenance().getSource());
+            assertEquals("test-process", metadata.getProvenance().getProcess());
+            assertEquals(List.of("tag-one", "tag-two"), metadata.getTagsList());
+            assertEquals(1, metadata.getAttributesCount());
+            assertEquals("attribute-name", metadata.getAttributes(0).getName());
+            assertEquals("attribute-value", metadata.getAttributes(0).getValue());
+
+            // metadata application preserves the per value status set on the generated values
+            for (DataValue dataValue : column.getDataValuesList()) {
+                assertEquals(status, dataValue.getValueStatus());
+            }
+        }
+    }
+
+    /**
+     * Verifies that column metadata is applied to a caller supplied column list, the path used by
+     * the desktop app's Excel import.
+     */
+    @Test
+    public void testColumnMetadataAppliedToCallerSuppliedColumns() {
+
+        final DataColumn callerColumn = DataColumn.newBuilder()
+                .setName("pv_caller")
+                .addDataValues(DataValue.newBuilder().setDoubleValue(1.0).build())
+                .build();
+
+        final IngestionRequestParams params = buildParams()
+                .setColumnMetadata("caller-source", null, null, null);
+
+        final IngestDataRequest request =
+                IngestionClient.buildIngestionRequest(params, null, List.of(callerColumn));
+        final List<DataColumn> columns = request.getIngestionDataFrame().getDataColumnsList();
+
+        // the caller supplied column replaces the columns that would be generated from params
+        assertEquals(1, columns.size());
+        assertEquals("pv_caller", columns.get(0).getName());
+        assertTrue(columns.get(0).hasMetadata());
+        assertEquals("caller-source", columns.get(0).getMetadata().getProvenance().getSource());
+
+        // source and process are plain proto3 strings with no field presence, so an omitted field
+        // is indistinguishable from an empty one on the wire and reads back as the empty string
+        assertEquals("", columns.get(0).getMetadata().getProvenance().getProcess());
+    }
+
+    /**
+     * Verifies that a column already carrying its own metadata keeps it, since per column metadata
+     * is more specific than the request wide default in params.
+     */
+    @Test
+    public void testExistingColumnMetadataIsPreserved() {
+
+        final ColumnMetadata columnOwnMetadata = ColumnMetadata.newBuilder()
+                .setProvenance(ColumnProvenance.newBuilder().setSource("column-source").build())
+                .build();
+
+        final DataColumn withMetadata = DataColumn.newBuilder()
+                .setName("pv_with_metadata")
+                .addDataValues(DataValue.newBuilder().setDoubleValue(1.0).build())
+                .setMetadata(columnOwnMetadata)
+                .build();
+
+        final DataColumn withoutMetadata = DataColumn.newBuilder()
+                .setName("pv_without_metadata")
+                .addDataValues(DataValue.newBuilder().setDoubleValue(2.0).build())
+                .build();
+
+        final IngestionRequestParams params = buildParams()
+                .setColumnMetadata("params-source", null, null, null);
+
+        final IngestDataRequest request = IngestionClient.buildIngestionRequest(
+                params, null, List.of(withMetadata, withoutMetadata));
+        final List<DataColumn> columns = request.getIngestionDataFrame().getDataColumnsList();
+
+        assertEquals(2, columns.size());
+
+        // the column with its own metadata keeps it
+        assertEquals("column-source", columns.get(0).getMetadata().getProvenance().getSource());
+
+        // the column without metadata receives the params metadata
+        assertEquals("params-source", columns.get(1).getMetadata().getProvenance().getSource());
+    }
+
+    /**
+     * Verifies handling of partially supplied provenance.  ColumnProvenance.source and .process are
+     * plain proto3 strings with no field presence, so an unsupplied one cannot be distinguished
+     * from an empty one and reads back as the empty string.  What the blank checking controls is
+     * whether the enclosing provenance message, which does have presence, is set at all.
+     */
+    @Test
+    public void testPartiallySuppliedProvenance() {
+
+        final IngestionRequestParams processOnly = buildParams()
+                .setColumnMetadata(null, "only-process", null, null);
+
+        final ColumnProvenance provenance = processOnly.columnMetadata.getProvenance();
+        assertTrue(processOnly.columnMetadata.hasProvenance());
+        assertEquals("only-process", provenance.getProcess());
+        assertEquals("", provenance.getSource());
+
+        // blank strings are treated the same as null
+        final IngestionRequestParams blankSource = buildParams()
+                .setColumnMetadata("   ", "only-process", null, null);
+        assertEquals("", blankSource.columnMetadata.getProvenance().getSource());
+
+        // provenance is left unset entirely when neither source nor process is supplied
+        final IngestionRequestParams tagsOnly = buildParams()
+                .setColumnMetadata(null, null, List.of("tag"), null);
+        assertFalse(tagsOnly.columnMetadata.hasProvenance());
+        assertEquals(List.of("tag"), tagsOnly.columnMetadata.getTagsList());
+    }
+
+    /**
+     * Verifies that the convenience overload leaves columnMetadata null when no argument supplies a
+     * value, so that the built columns carry no metadata field rather than an empty one.
+     */
+    @Test
+    public void testEmptyColumnMetadataLeavesFieldNull() {
+
+        final IngestionRequestParams allNull = buildParams()
+                .setColumnMetadata(null, null, null, null);
+        assertNull(allNull.columnMetadata);
+
+        final IngestionRequestParams allBlankOrEmpty = buildParams()
+                .setColumnMetadata("  ", "", List.of(), Map.of());
+        assertNull(allBlankOrEmpty.columnMetadata);
+
+        // the built columns carry no metadata field at all
+        for (DataColumn column : buildRequestColumns(allBlankOrEmpty)) {
+            assertFalse(column.hasMetadata());
+        }
+    }
+
+    /**
+     * Verifies that attribute entries with a null name or value are skipped rather than raising a
+     * NullPointerException from the protobuf setters.
+     */
+    @Test
+    public void testAttributeEntriesWithNullsAreSkipped() {
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("good-name", "good-value");
+        attributes.put("null-value-name", null);
+        attributes.put(null, "null-name-value");
+
+        final IngestionRequestParams params = buildParams()
+                .setColumnMetadata(null, null, null, attributes);
+
+        final List<Attribute> attributeList = params.columnMetadata.getAttributesList();
+        assertEquals(1, attributeList.size());
+        assertEquals("good-name", attributeList.get(0).getName());
+        assertEquals("good-value", attributeList.get(0).getValue());
+    }
+
+    /**
+     * Verifies that the raw setter overload applies the supplied message as is, with no
+     * normalization, and that passing null clears any metadata previously set.
+     */
+    @Test
+    public void testRawSetterAppliesMessageAsIs() {
+
+        final ColumnMetadata empty = ColumnMetadata.getDefaultInstance();
+
+        final IngestionRequestParams params = buildParams().setColumnMetadata(empty);
+        assertEquals(empty, params.columnMetadata);
+
+        // an empty message supplied directly is applied, unlike the convenience overload
+        for (DataColumn column : buildRequestColumns(params)) {
+            assertTrue(column.hasMetadata());
+        }
+
+        // passing null clears it
+        params.setColumnMetadata((ColumnMetadata) null);
+        assertNull(params.columnMetadata);
+        for (DataColumn column : buildRequestColumns(params)) {
+            assertFalse(column.hasMetadata());
+        }
+    }
+
+    /**
+     * Verifies that columns are built without a metadata field when no column metadata is supplied.
+     */
+    @Test
+    public void testNoColumnMetadataByDefault() {
+
+        final IngestionRequestParams params = buildParams();
+        assertNull(params.columnMetadata);
+
+        for (DataColumn column : buildRequestColumns(params)) {
+            assertFalse(column.hasMetadata());
+        }
+    }
+}


### PR DESCRIPTION
Supports osprey-dcs/dp-desktop-app#17, which replaces the desktop app's request-level metadata panel with column-level `ColumnMetadata`.

## Changes

**Column metadata support.** Adds an optional `ColumnMetadata` field to `IngestionClient.IngestionRequestParams`, with a fluent `setColumnMetadata()` and a convenience overload that builds the message from provenance source/process, tags, and attributes. `buildIngestionRequest()` applies it to the columns at a single point after both column branches populate, so the caller-supplied `dataColumns` path (used by the desktop app's Excel import) and the `columnNames`/`values` path (used by data generation) are both covered without the caller doing protobuf surgery.

A column that already carries its own metadata keeps it — the params field is a request-wide default, and per-column metadata is the more specific intent. The convenience overload leaves `columnMetadata` null when no argument supplies a value, so columns are built without a metadata field rather than carrying an empty one. Validation is left to the existing server-side `IngestionValidationUtility.validateColumnMetadata()`.

A separate `clearColumnMetadata()` removes metadata previously set. It exists because the two `setColumnMetadata()` overloads make `setColumnMetadata(null)` ambiguous, requiring an explicit cast at the call site.

Scope note: the metadata applies to the `DataColumn`s that `buildIngestionRequest()` builds. The other column types defined by `DataFrame` also carry a `metadata` field, but this builder does not build them.

**Provenance field presence.** `ColumnProvenance.source` and `.process` are plain proto3 strings with no field presence, so an unsupplied one is indistinguishable from an empty one on the wire and reads back as the empty string — they cannot be "omitted." What the blank checking in the convenience overload controls is whether the enclosing `provenance` message, which does have presence, is set at all. (An earlier revision of this description claimed otherwise.)

**Pre-existing `valuesStatus` bug.** The 13-argument `IngestionRequestParams` constructor ended with `this.valuesStatus = valuesStatus;` — a self-assignment of the field, since no such parameter exists — leaving `valuesStatus` permanently null and making the per-value status handling in `buildIngestionRequest()` unreachable through that constructor. The 13-argument form now delegates to a new 14-argument constructor taking `valuesStatus` explicitly, matching the shape already used by `IngestionTestBase` on the test side. Existing 13-argument callers are unaffected.

**Null-safety and argument validation.** Attribute entries with a null name or value are skipped rather than raising an NPE from the protobuf setters, which `AttributesUtility.attributeListFromMap()` does not guard against.

`buildIngestionRequest()` indexes `valuesStatus` by the `values` dimensions, so a mismatched list threw `IndexOutOfBoundsException` from inside the builder, far from the call site that supplied it. The 14-argument constructor now validates both the outer and inner dimensions and throws `IllegalArgumentException` naming the mismatched sizes.

## Verification

- `mvn clean install -DskipTests` — exit 0
- `mvn test` — 283 tests, 0 failures
- New `IngestionClientTest` (11 tests): the `valuesStatus` fix on both the 13- and 14-argument constructor paths, metadata application on both the generated and caller-supplied column paths, existing-metadata preservation, partial provenance, the empty-metadata case, null attribute entries, mismatched `valuesStatus` dimensions, and the raw setter's as-is semantics
- Tests verified against the pre-fix source — the three behavioral fixes each produce a distinct failure without them (empty metadata `expected null, but was:<>`; overwritten metadata `expected:<column-source> but was:<params-source>`; NPE at `AttributesUtility.attributeListFromMap:23`)
- Exercised end-to-end through the desktop app against a live in-process ecosystem; metadata confirmed persisted in MongoDB

## Review follow-ups

The empty-metadata case, the per-column metadata precedence, the attribute null-safety, `clearColumnMetadata()`, and the `valuesStatus` dimension guard all came out of review feedback on the initial commit, applied in 3a9933b and 92f030e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116zMbPX8JxqoWBF4b2udZc
