### PR TITLE
dp-service: expose service result status on client API results

### DIFF
--- a/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class AnnotationClient extends ServiceApiClientBase {
 
@@ -55,6 +56,12 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<String> dataSetIdList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -88,6 +95,8 @@ public class AnnotationClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public String getDataSetId() {
             if (!dataSetIdList.isEmpty()) {
                 return dataSetIdList.get(0);
@@ -107,6 +116,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     finishLatch.countDown();
@@ -179,6 +190,12 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<DataSet> dataSetsList =
                 Collections.synchronizedList(new ArrayList<>());
 
@@ -213,6 +230,8 @@ public class AnnotationClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public List<DataSet> getDataSetsList() {
             return dataSetsList;
         }
@@ -228,6 +247,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     finishLatch.countDown();
@@ -300,6 +321,12 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<String> annotationIdList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -333,6 +360,8 @@ public class AnnotationClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public String getAnnotationId() {
             if (!annotationIdList.isEmpty()) {
                 return annotationIdList.get(0);
@@ -352,6 +381,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     finishLatch.countDown();
@@ -443,6 +474,12 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<QueryAnnotationsResponse.AnnotationsResult.Annotation> annotationsList =
                 Collections.synchronizedList(new ArrayList<>());
 
@@ -477,6 +514,8 @@ public class AnnotationClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public List<QueryAnnotationsResponse.AnnotationsResult.Annotation> getAnnotationsList() {
             return annotationsList;
         }
@@ -492,6 +531,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     finishLatch.countDown();
@@ -557,6 +598,12 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<ExportDataResponse.ExportDataResult> resultList =
                 Collections.synchronizedList(new ArrayList<>());
 
@@ -591,6 +638,8 @@ public class AnnotationClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public ExportDataResponse.ExportDataResult getResult() {
             if (!resultList.isEmpty()) {
                 return resultList.get(0);
@@ -610,6 +659,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     finishLatch.countDown();
@@ -720,7 +771,8 @@ public class AnnotationClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new SaveDataSetApiResult(true, responseObserver.getErrorMessage());
+            return new SaveDataSetApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new SaveDataSetApiResult(responseObserver.getDataSetId());
         }
@@ -810,7 +862,8 @@ public class AnnotationClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new QueryDataSetsApiResult(true, responseObserver.getErrorMessage());
+            return new QueryDataSetsApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new QueryDataSetsApiResult(responseObserver.getDataSetsList());
         }
@@ -873,7 +926,8 @@ public class AnnotationClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new SaveAnnotationApiResult(true, responseObserver.getErrorMessage());
+            return new SaveAnnotationApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new SaveAnnotationApiResult(responseObserver.getAnnotationId());
         }
@@ -1004,7 +1058,8 @@ public class AnnotationClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new QueryAnnotationsApiResult(true, responseObserver.getErrorMessage());
+            return new QueryAnnotationsApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new QueryAnnotationsApiResult(responseObserver.getAnnotationsList());
         }
@@ -1066,7 +1121,8 @@ public class AnnotationClient extends ServiceApiClientBase {
         System.out.println("export format " + request.getOutputFormat().name() + " elapsed seconds: " + secondsElapsed);
 
         if (responseObserver.isError()) {
-            return new ExportDataApiResult(true, responseObserver.getErrorMessage());
+            return new ExportDataApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new ExportDataApiResult(responseObserver.getResult());
         }
@@ -1104,6 +1160,12 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<String> pvNameList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -1137,6 +1199,8 @@ public class AnnotationClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public String getPvName() {
             if (!pvNameList.isEmpty()) {
                 return pvNameList.get(0);
@@ -1156,6 +1220,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     finishLatch.countDown();
@@ -1247,7 +1313,8 @@ public class AnnotationClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new SavePvMetadataApiResult(true, responseObserver.getErrorMessage());
+            return new SavePvMetadataApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new SavePvMetadataApiResult(responseObserver.getPvName());
         }
@@ -1328,6 +1395,12 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<String> configurationNameList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -1361,6 +1434,8 @@ public class AnnotationClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public String getConfigurationName() {
             if (!configurationNameList.isEmpty()) {
                 return configurationNameList.get(0);
@@ -1380,6 +1455,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     finishLatch.countDown();
@@ -1430,6 +1507,12 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<String> clientActivationIdList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -1463,6 +1546,8 @@ public class AnnotationClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public String getClientActivationId() {
             if (!clientActivationIdList.isEmpty()) {
                 return clientActivationIdList.get(0);
@@ -1482,6 +1567,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     finishLatch.countDown();
@@ -1532,6 +1619,12 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<com.ospreydcs.dp.grpc.v1.common.Configuration> configurationList =
                 Collections.synchronizedList(new ArrayList<>());
 
@@ -1566,6 +1659,8 @@ public class AnnotationClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public com.ospreydcs.dp.grpc.v1.common.Configuration getConfiguration() {
             if (!configurationList.isEmpty()) {
                 return configurationList.get(0);
@@ -1585,6 +1680,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     finishLatch.countDown();
@@ -1734,7 +1831,8 @@ public class AnnotationClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new SaveConfigurationApiResult(true, responseObserver.getErrorMessage());
+            return new SaveConfigurationApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new SaveConfigurationApiResult(responseObserver.getConfigurationName());
         }
@@ -1782,7 +1880,8 @@ public class AnnotationClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new SaveConfigurationActivationApiResult(true, responseObserver.getErrorMessage());
+            return new SaveConfigurationActivationApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new SaveConfigurationActivationApiResult(responseObserver.getClientActivationId());
         }
@@ -1834,7 +1933,8 @@ public class AnnotationClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new GetConfigurationApiResult(true, responseObserver.getErrorMessage());
+            return new GetConfigurationApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new GetConfigurationApiResult(responseObserver.getConfiguration());
         }

--- a/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
@@ -57,11 +57,13 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<String> dataSetIdList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -116,7 +118,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
@@ -191,11 +194,13 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<DataSet> dataSetsList =
                 Collections.synchronizedList(new ArrayList<>());
 
@@ -247,7 +252,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
@@ -322,11 +328,13 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<String> annotationIdList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -381,7 +389,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
@@ -475,11 +484,13 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<QueryAnnotationsResponse.AnnotationsResult.Annotation> annotationsList =
                 Collections.synchronizedList(new ArrayList<>());
 
@@ -531,7 +542,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
@@ -599,11 +611,13 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<ExportDataResponse.ExportDataResult> resultList =
                 Collections.synchronizedList(new ArrayList<>());
 
@@ -659,7 +673,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
@@ -1161,11 +1176,13 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<String> pvNameList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -1220,7 +1237,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
@@ -1396,11 +1414,13 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<String> configurationNameList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -1455,7 +1475,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
@@ -1508,11 +1529,13 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<String> clientActivationIdList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -1567,7 +1590,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
@@ -1620,11 +1644,13 @@ public class AnnotationClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<com.ospreydcs.dp.grpc.v1.common.Configuration> configurationList =
                 Collections.synchronizedList(new ArrayList<>());
 
@@ -1680,7 +1706,8 @@ public class AnnotationClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);

--- a/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
@@ -57,11 +57,13 @@ public class IngestionClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<RegisterProviderResponse> responseList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -111,7 +113,8 @@ public class IngestionClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
@@ -385,11 +388,13 @@ public class IngestionClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
 
         private final int expectedResponseCount;
 
@@ -443,7 +448,8 @@ public class IngestionClient extends ServiceApiClientBase {
                 final String errorMsg = "onNext received exceptional response: "
                         + response.getExceptionalResult().getMessage();
                 System.err.println(errorMsg);
-                apiResultStatus.set(
+                apiResultStatus.compareAndSet(
+                        ApiResultStatus.NONE,
                         ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                 isError.set(true);
                 errorMessageList.add(errorMsg);
@@ -457,9 +463,17 @@ public class IngestionClient extends ServiceApiClientBase {
 
         @Override
         public void onError(Throwable t) {
-            Status status = Status.fromThrowable(t);
-            System.err.println("IngestDataResponseObserver error: " + status);
+            final Status status = Status.fromThrowable(t);
+            final String errorMsg = "IngestDataResponseObserver error: " + status;
+            System.err.println(errorMsg);
             isError.set(true);
+            errorMessageList.add(errorMsg);
+            // this latch is initialized to expectedResponseCount, so a stream that fails after
+            // some responses have arrived still has counts outstanding.  Release all of them,
+            // otherwise await() expires and reports a timeout instead of the gRPC status.
+            while (finishLatch.getCount() > 0) {
+                finishLatch.countDown();
+            }
         }
 
         @Override

--- a/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
@@ -1,5 +1,6 @@
 package com.ospreydcs.dp.client;
 
+import com.ospreydcs.dp.client.result.ApiResultStatus;
 import com.ospreydcs.dp.client.result.IngestDataApiResult;
 import com.ospreydcs.dp.client.result.RegisterProviderApiResult;
 import com.ospreydcs.dp.grpc.v1.common.*;
@@ -18,6 +19,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class IngestionClient extends ServiceApiClientBase {
 
@@ -54,6 +56,12 @@ public class IngestionClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<RegisterProviderResponse> responseList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -86,6 +94,8 @@ public class IngestionClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public List<RegisterProviderResponse> getResponseList() {
             return responseList;
         }
@@ -101,6 +111,8 @@ public class IngestionClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     finishLatch.countDown();
@@ -372,6 +384,12 @@ public class IngestionClient extends ServiceApiClientBase {
         private final List<IngestDataResponse> responseList = Collections.synchronizedList(new ArrayList<>());
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
 
         private final int expectedResponseCount;
 
@@ -416,6 +434,8 @@ public class IngestionClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         @Override
         public void onNext(IngestDataResponse response) {
 
@@ -423,6 +443,8 @@ public class IngestionClient extends ServiceApiClientBase {
                 final String errorMsg = "onNext received exceptional response: "
                         + response.getExceptionalResult().getMessage();
                 System.err.println(errorMsg);
+                apiResultStatus.set(
+                        ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                 isError.set(true);
                 errorMessageList.add(errorMsg);
                 finishLatch.countDown();
@@ -493,7 +515,8 @@ public class IngestionClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new RegisterProviderApiResult(true, responseObserver.getErrorMessage());
+            return new RegisterProviderApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new RegisterProviderApiResult(responseObserver.getResponseList().get(0));
         }
@@ -685,7 +708,8 @@ public class IngestionClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new IngestDataApiResult(true, responseObserver.getErrorMessage());
+            return new IngestDataApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new IngestDataApiResult(responseObserver.getResponseList().get(0));
         }

--- a/src/main/java/com/ospreydcs/dp/client/IngestionStreamClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/IngestionStreamClient.java
@@ -1,5 +1,6 @@
 package com.ospreydcs.dp.client;
 
+import com.ospreydcs.dp.client.result.ApiResultStatus;
 import com.ospreydcs.dp.client.result.SubscribeDataEventApiResult;
 import com.ospreydcs.dp.grpc.v1.ingestionstream.*;
 import io.grpc.ManagedChannel;
@@ -12,6 +13,7 @@ import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class IngestionStreamClient extends ServiceApiClientBase {
 
@@ -97,6 +99,12 @@ public class IngestionStreamClient extends ServiceApiClientBase {
         CountDownLatch closeLatch = null;
         private final int eventListSizeLimit;
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<SubscribeDataEventResponse.Event> eventList = Collections.synchronizedList(new ArrayList<>());
         private final AtomicBoolean isError = new AtomicBoolean(false);
 
@@ -157,6 +165,8 @@ public class IngestionStreamClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         private void addEvent(SubscribeDataEventResponse.Event event) {
             eventList.add(event);
             while (eventList.size() > eventListSizeLimit) {
@@ -172,6 +182,8 @@ public class IngestionStreamClient extends ServiceApiClientBase {
                 case EXCEPTIONALRESULT -> {
                     final String errorMsg = response.getExceptionalResult().getMessage();
                     System.err.println("SubscribeDataEventResponseOberver received ExceptionalResult: " + errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     ackLatch.countDown();
@@ -295,7 +307,8 @@ public class IngestionStreamClient extends ServiceApiClientBase {
         responseObserver.awaitAckLatch();
 
         if (responseObserver.isError()) {
-            return new SubscribeDataEventApiResult(true, responseObserver.getErrorMessage());
+            return new SubscribeDataEventApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new SubscribeDataEventApiResult(new SubscribeDataEventCall(requestObserver, responseObserver));
         }

--- a/src/main/java/com/ospreydcs/dp/client/IngestionStreamClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/IngestionStreamClient.java
@@ -100,11 +100,13 @@ public class IngestionStreamClient extends ServiceApiClientBase {
         private final int eventListSizeLimit;
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<SubscribeDataEventResponse.Event> eventList = Collections.synchronizedList(new ArrayList<>());
         private final AtomicBoolean isError = new AtomicBoolean(false);
 
@@ -182,7 +184,8 @@ public class IngestionStreamClient extends ServiceApiClientBase {
                 case EXCEPTIONALRESULT -> {
                     final String errorMsg = response.getExceptionalResult().getMessage();
                     System.err.println("SubscribeDataEventResponseOberver received ExceptionalResult: " + errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
@@ -219,6 +222,11 @@ public class IngestionStreamClient extends ServiceApiClientBase {
             System.err.println(errorMsg);
             isError.set(true);
             errorMessageList.add(errorMsg);
+            // sendSubscribeDataEvent() blocks on awaitAckLatch() before returning, and
+            // onCompleted() releases only closeLatch, so a transport failure before the ack
+            // arrives would otherwise hang until the await expires
+            ackLatch.countDown();
+            closeLatch.countDown();
         }
 
         @Override

--- a/src/main/java/com/ospreydcs/dp/client/QueryClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/QueryClient.java
@@ -40,11 +40,13 @@ public class QueryClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<QueryTableResponse> responseList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -94,7 +96,8 @@ public class QueryClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
@@ -116,9 +119,15 @@ public class QueryClient extends ServiceApiClientBase {
             // handle response in separate thread to better simulate out of process grpc,
             // otherwise response is handled in same thread as service handler that sent it
             new Thread(() -> {
-                Status status = Status.fromThrowable(t);
-                System.err.println("QueryTableResponseObserver error: " + status);
+                final Status status = Status.fromThrowable(t);
+                final String errorMsg = "QueryTableResponseObserver error: " + status;
+                System.err.println(errorMsg);
                 isError.set(true);
+                errorMessageList.add(errorMsg);
+                // the latch must be counted down here, otherwise a transport failure leaves
+                // await() to expire and the caller sees a timeout message instead of the
+                // actual gRPC status
+                finishLatch.countDown();
             }).start();
         }
 
@@ -134,11 +143,13 @@ public class QueryClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<QueryPvStatsResponse> responseList =
                 Collections.synchronizedList(new ArrayList<>());
 
@@ -193,7 +204,8 @@ public class QueryClient extends ServiceApiClientBase {
                     final String errorMsg = "QueryResponseColumnInfoObserver onNext received exception response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
@@ -268,11 +280,13 @@ public class QueryClient extends ServiceApiClientBase {
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
         // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
-        // response -- a transport error, an await timeout, a malformed response sequence -- is
-        // reported as locally generated.
+        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+        // recorded without a status-bearing response -- a transport error, an await timeout, a
+        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+        // that the status and the message returned by getErrorMessage() describe the same failure.
         private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
+                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<QueryProvidersResponse.ProvidersResult.ProviderInfo> providerInfoList =
                 Collections.synchronizedList(new ArrayList<>());
 
@@ -323,7 +337,8 @@ public class QueryClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received ExceptionalResult: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
-                    apiResultStatus.set(
+                    apiResultStatus.compareAndSet(
+                            ApiResultStatus.NONE,
                             ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);

--- a/src/main/java/com/ospreydcs/dp/client/QueryClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/QueryClient.java
@@ -1,5 +1,6 @@
 package com.ospreydcs.dp.client;
 
+import com.ospreydcs.dp.client.result.ApiResultStatus;
 import com.ospreydcs.dp.client.result.QueryProvidersApiResult;
 import com.ospreydcs.dp.client.result.QueryPvStatsApiResult;
 import com.ospreydcs.dp.client.result.QueryTableApiResult;
@@ -18,6 +19,7 @@ import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class QueryClient extends ServiceApiClientBase {
 
@@ -37,6 +39,12 @@ public class QueryClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<QueryTableResponse> responseList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -70,6 +78,8 @@ public class QueryClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public QueryTableResponse getQueryResponse() {
             return responseList.get(0);
         }
@@ -84,6 +94,8 @@ public class QueryClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                 }
@@ -121,6 +133,12 @@ public class QueryClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<QueryPvStatsResponse> responseList =
                 Collections.synchronizedList(new ArrayList<>());
 
@@ -154,6 +172,8 @@ public class QueryClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public QueryPvStatsResponse getResponse() {
             if (responseList.isEmpty() || responseList.size() > 1) {
                 return null;
@@ -173,6 +193,8 @@ public class QueryClient extends ServiceApiClientBase {
                     final String errorMsg = "QueryResponseColumnInfoObserver onNext received exception response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     finishLatch.countDown();
@@ -245,6 +267,12 @@ public class QueryClient extends ServiceApiClientBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        // categorizes a failure so callers can distinguish a service rejection from a service
+        // error.  Defaults to LOCAL_FAILURE so that any failure recorded without a status-bearing
+        // response -- a transport error, an await timeout, a malformed response sequence -- is
+        // reported as locally generated.
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.LOCAL_FAILURE);
         private final List<QueryProvidersResponse.ProvidersResult.ProviderInfo> providerInfoList =
                 Collections.synchronizedList(new ArrayList<>());
 
@@ -278,6 +306,8 @@ public class QueryClient extends ServiceApiClientBase {
             }
         }
 
+        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+
         public List<QueryProvidersResponse.ProvidersResult.ProviderInfo> getProviderInfoList() {
             return providerInfoList;
         }
@@ -293,6 +323,8 @@ public class QueryClient extends ServiceApiClientBase {
                     final String errorMsg = "onNext received ExceptionalResult: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
+                    apiResultStatus.set(
+                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
                     isError.set(true);
                     errorMessageList.add(errorMsg);
                     finishLatch.countDown();
@@ -410,7 +442,8 @@ public class QueryClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new QueryTableApiResult(true, responseObserver.getErrorMessage());
+            return new QueryTableApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new QueryTableApiResult(responseObserver.getQueryResponse());
         }
@@ -463,7 +496,8 @@ public class QueryClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new QueryPvStatsApiResult(true, responseObserver.getErrorMessage());
+            return new QueryPvStatsApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new QueryPvStatsApiResult(responseObserver.getResponse());
         }
@@ -551,7 +585,8 @@ public class QueryClient extends ServiceApiClientBase {
         responseObserver.await();
 
         if (responseObserver.isError()) {
-            return new QueryProvidersApiResult(true, responseObserver.getErrorMessage());
+            return new QueryProvidersApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
         } else {
             return new QueryProvidersApiResult(responseObserver.getProviderInfoList());
         }

--- a/src/main/java/com/ospreydcs/dp/client/result/ApiResultBase.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/ApiResultBase.java
@@ -6,7 +6,54 @@ public abstract class ApiResultBase {
 
     public final ResultStatus resultStatus;
 
+    /**
+     * Categorizes the failure carried by {@link #resultStatus}, so callers can distinguish a
+     * rejection from a service error without matching on the message string.  This is {@link
+     * ApiResultStatus#NONE} for a successful result.
+     *
+     * <p>Held here rather than on {@link ResultStatus} because {@code ResultStatus} lives in the
+     * server package and is shared with the dispatchers, jobs and validation utilities, none of
+     * which have any use for a client-facing status.
+     */
+    public final ApiResultStatus apiResultStatus;
+
+    /**
+     * Constructs a result whose failure, if any, was generated locally rather than reported by the
+     * service.  Retained so that existing callers are unaffected.
+     */
     public ApiResultBase(boolean isError, String errorMessage) {
+        this(isError, errorMessage, isError ? ApiResultStatus.LOCAL_FAILURE : ApiResultStatus.NONE);
+    }
+
+    public ApiResultBase(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
         this.resultStatus = new ResultStatus(isError, errorMessage);
+        // a successful result is never categorized as a failure, and vice versa, regardless of what
+        // the caller passed
+        if (!isError) {
+            this.apiResultStatus = ApiResultStatus.NONE;
+        } else if (apiResultStatus == null || apiResultStatus == ApiResultStatus.NONE) {
+            this.apiResultStatus = ApiResultStatus.LOCAL_FAILURE;
+        } else {
+            this.apiResultStatus = apiResultStatus;
+        }
+    }
+
+    /**
+     * Returns true if the call failed.  Equivalent to reading {@code resultStatus.isError}.
+     */
+    public boolean isError() {
+        return resultStatus.isError;
+    }
+
+    /**
+     * Returns true if the service rejected the request.
+     *
+     * <p>A reject means the service declined the request without handling it.  This covers both a
+     * request that failed server-side validation and a well-formed request whose target record does
+     * not exist — see {@link ApiResultStatus#REJECT} for why the two cannot be told apart from the
+     * status alone.
+     */
+    public boolean isReject() {
+        return apiResultStatus == ApiResultStatus.REJECT;
     }
 }

--- a/src/main/java/com/ospreydcs/dp/client/result/ApiResultStatus.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/ApiResultStatus.java
@@ -38,8 +38,13 @@ public enum ApiResultStatus {
     ERROR,
 
     /**
-     * The service was not ready to handle the request.  Currently used only for invalid
-     * bidirectional query cursor operations.
+     * The service was not ready to handle the request.  The protobuf enum documents this as
+     * covering invalid bidirectional query cursor operations only.
+     *
+     * <p>No client API call currently wired to this enum issues a bidirectional cursor request, so
+     * this status is not reachable through any of them today.  It is mapped by {@link #fromProto}
+     * so that a caller of a future bidirectional API, or a client talking to a service that starts
+     * returning the status elsewhere, sees the real category rather than a fallback.
      */
     NOT_READY,
 
@@ -58,6 +63,16 @@ public enum ApiResultStatus {
      * <p>An unrecognized value — which a client built against an older protobuf revision can
      * receive from a newer service — maps to {@link #ERROR} rather than throwing, so that an
      * unknown failure is still reported as a failure.
+     *
+     * <p><strong>Zero-value hazard:</strong> {@code RESULT_STATUS_REJECT} is 0, the protobuf
+     * default, so a service that builds an {@code ExceptionalResult} without calling {@code
+     * setExceptionalResultStatus()} sends a value indistinguishable from a deliberate reject, and
+     * this method maps it to {@link #REJECT}.  That matters because callers branch on {@link
+     * ApiResultBase#isReject()} to read "target record does not exist" — so a server-side omission
+     * can present as a benign not-found and, for a caller deciding whether a save would overwrite,
+     * turn into a silent clobber.  Every dispatcher must therefore set the status explicitly;
+     * {@code ApiResultBaseTest.testEveryExceptionalResultSetsStatus()} guards this by scanning the
+     * service sources for a builder that omits it.
      */
     public static ApiResultStatus fromProto(ExceptionalResult.ExceptionalResultStatus protoStatus) {
 

--- a/src/main/java/com/ospreydcs/dp/client/result/ApiResultStatus.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/ApiResultStatus.java
@@ -1,0 +1,75 @@
+package com.ospreydcs.dp.client.result;
+
+import com.ospreydcs.dp.grpc.v1.common.ExceptionalResult;
+
+/**
+ * Categorizes the outcome of a client API call.
+ *
+ * <p>This is a client-side enum rather than the protobuf {@link
+ * ExceptionalResult.ExceptionalResultStatus} because a client API result has two outcomes the wire
+ * enum cannot express: a successful call ({@link #NONE}), and a failure generated locally without
+ * any response from the service ({@link #LOCAL_FAILURE}).  Wrapping the wire enum also keeps
+ * callers of the client API insulated from protobuf enum evolution.
+ */
+public enum ApiResultStatus {
+
+    /**
+     * The call succeeded.  This is the status of every result whose {@code resultStatus.isError} is
+     * false.
+     */
+    NONE,
+
+    /**
+     * The request was rejected by the service before it was handled.
+     *
+     * <p>Note that this covers <em>both</em> a request that failed server-side validation and a
+     * well-formed request whose target record does not exist: the services report both with
+     * {@code RESULT_STATUS_REJECT}, and the wire response carries nothing that distinguishes them.
+     * A caller that needs to treat "record does not exist" as a normal condition — for instance to
+     * decide whether a save would overwrite an existing record — must therefore be prepared for a
+     * malformed request to produce the same status, and should validate its request before relying
+     * on that reading.  Only the human-readable message separates the two cases.
+     */
+    REJECT,
+
+    /**
+     * The service encountered an error while handling the request.
+     */
+    ERROR,
+
+    /**
+     * The service was not ready to handle the request.  Currently used only for invalid
+     * bidirectional query cursor operations.
+     */
+    NOT_READY,
+
+    /**
+     * The call failed without a status-bearing response from the service.  This covers a transport
+     * failure delivered through {@code onError}, an await timeout, an interrupted wait, and a
+     * malformed response sequence detected client-side.  The accompanying message describes the
+     * failure.
+     */
+    LOCAL_FAILURE;
+
+    /**
+     * Maps a protobuf {@link ExceptionalResult.ExceptionalResultStatus} to its client-side
+     * counterpart.
+     *
+     * <p>An unrecognized value — which a client built against an older protobuf revision can
+     * receive from a newer service — maps to {@link #ERROR} rather than throwing, so that an
+     * unknown failure is still reported as a failure.
+     */
+    public static ApiResultStatus fromProto(ExceptionalResult.ExceptionalResultStatus protoStatus) {
+
+        if (protoStatus == null) {
+            return ERROR;
+        }
+
+        return switch (protoStatus) {
+            case RESULT_STATUS_REJECT -> REJECT;
+            case RESULT_STATUS_ERROR -> ERROR;
+            case RESULT_STATUS_NOT_READY -> NOT_READY;
+            default -> ERROR;
+        };
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/client/result/ExportDataApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/ExportDataApiResult.java
@@ -11,6 +11,11 @@ public class ExportDataApiResult extends ApiResultBase {
         this.exportDataResult = null;
     }
 
+    public ExportDataApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.exportDataResult = null;
+    }
+
     public ExportDataApiResult(ExportDataResponse.ExportDataResult exportDataResult) {
         super(false, "");
         this.exportDataResult = exportDataResult;

--- a/src/main/java/com/ospreydcs/dp/client/result/GetConfigurationApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/GetConfigurationApiResult.java
@@ -12,6 +12,11 @@ public class GetConfigurationApiResult extends ApiResultBase {
         this.configuration = null;
     }
 
+    public GetConfigurationApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.configuration = null;
+    }
+
     public GetConfigurationApiResult(Configuration configuration) {
         super(false, "");
         this.configuration = configuration;

--- a/src/main/java/com/ospreydcs/dp/client/result/IngestDataApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/IngestDataApiResult.java
@@ -12,6 +12,11 @@ public class IngestDataApiResult extends ApiResultBase {
         this.ingestDataResponse = null;
     }
 
+    public IngestDataApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.ingestDataResponse = null;
+    }
+
     public IngestDataApiResult(IngestDataResponse ingestDataResponse) {
         super(false, "");
         this.ingestDataResponse = ingestDataResponse;

--- a/src/main/java/com/ospreydcs/dp/client/result/QueryAnnotationsApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/QueryAnnotationsApiResult.java
@@ -14,6 +14,11 @@ public class QueryAnnotationsApiResult extends ApiResultBase {
         this.annotations = null;
     }
 
+    public QueryAnnotationsApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.annotations = null;
+    }
+
     public QueryAnnotationsApiResult(List<QueryAnnotationsResponse.AnnotationsResult.Annotation> annotations) {
         super(false, "");
         this.annotations = annotations;

--- a/src/main/java/com/ospreydcs/dp/client/result/QueryDataSetsApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/QueryDataSetsApiResult.java
@@ -14,6 +14,11 @@ public class QueryDataSetsApiResult extends ApiResultBase {
         this.dataSets = null;
     }
 
+    public QueryDataSetsApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.dataSets = null;
+    }
+
     public QueryDataSetsApiResult(List<DataSet> dataSets) {
         super(false, "");
         this.dataSets = dataSets;

--- a/src/main/java/com/ospreydcs/dp/client/result/QueryProvidersApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/QueryProvidersApiResult.java
@@ -14,6 +14,11 @@ public class QueryProvidersApiResult extends ApiResultBase {
         this.providerInfos = null;
     }
 
+    public QueryProvidersApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.providerInfos = null;
+    }
+
     public QueryProvidersApiResult(List<QueryProvidersResponse.ProvidersResult.ProviderInfo> providerInfos) {
         super(false, "");
         this.providerInfos = providerInfos;

--- a/src/main/java/com/ospreydcs/dp/client/result/QueryPvStatsApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/QueryPvStatsApiResult.java
@@ -12,6 +12,11 @@ public class QueryPvStatsApiResult extends ApiResultBase {
         this.queryPvStatsResponse = null;
     }
 
+    public QueryPvStatsApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.queryPvStatsResponse = null;
+    }
+
     public QueryPvStatsApiResult(QueryPvStatsResponse queryPvStatsResponse) {
         super(false, "");
         this.queryPvStatsResponse = queryPvStatsResponse;

--- a/src/main/java/com/ospreydcs/dp/client/result/QueryTableApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/QueryTableApiResult.java
@@ -12,6 +12,11 @@ public class QueryTableApiResult extends ApiResultBase {
         this.queryTableResponse = null;
     }
 
+    public QueryTableApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.queryTableResponse = null;
+    }
+
     public QueryTableApiResult(QueryTableResponse queryTableResponse) {
         super(false, "");
         this.queryTableResponse = queryTableResponse;

--- a/src/main/java/com/ospreydcs/dp/client/result/RegisterProviderApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/RegisterProviderApiResult.java
@@ -12,6 +12,11 @@ public class RegisterProviderApiResult extends ApiResultBase {
         this.registerProviderResponse = null;
     }
 
+    public RegisterProviderApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.registerProviderResponse = null;
+    }
+
     public RegisterProviderApiResult(RegisterProviderResponse registerProviderResponse) {
         super(false, "");
         this.registerProviderResponse = registerProviderResponse;

--- a/src/main/java/com/ospreydcs/dp/client/result/SaveAnnotationApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/SaveAnnotationApiResult.java
@@ -10,6 +10,11 @@ public class SaveAnnotationApiResult extends ApiResultBase {
         this.annotationId = null;
     }
 
+    public SaveAnnotationApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.annotationId = null;
+    }
+
     public SaveAnnotationApiResult(String annotationId) {
         super(false, "");
         this.annotationId = annotationId;

--- a/src/main/java/com/ospreydcs/dp/client/result/SaveConfigurationActivationApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/SaveConfigurationActivationApiResult.java
@@ -16,6 +16,11 @@ public class SaveConfigurationActivationApiResult extends ApiResultBase {
         this.clientActivationId = null;
     }
 
+    public SaveConfigurationActivationApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.clientActivationId = null;
+    }
+
     public SaveConfigurationActivationApiResult(String clientActivationId) {
         super(false, "");
         this.clientActivationId = clientActivationId;

--- a/src/main/java/com/ospreydcs/dp/client/result/SaveConfigurationApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/SaveConfigurationApiResult.java
@@ -10,6 +10,11 @@ public class SaveConfigurationApiResult extends ApiResultBase {
         this.configurationName = null;
     }
 
+    public SaveConfigurationApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.configurationName = null;
+    }
+
     public SaveConfigurationApiResult(String configurationName) {
         super(false, "");
         this.configurationName = configurationName;

--- a/src/main/java/com/ospreydcs/dp/client/result/SaveDataSetApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/SaveDataSetApiResult.java
@@ -10,6 +10,11 @@ public class SaveDataSetApiResult extends ApiResultBase {
         this.datasetId = null;
     }
 
+    public SaveDataSetApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.datasetId = null;
+    }
+
     public SaveDataSetApiResult(String datasetId) {
         super(false, "");
         this.datasetId = datasetId;

--- a/src/main/java/com/ospreydcs/dp/client/result/SavePvMetadataApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/SavePvMetadataApiResult.java
@@ -10,6 +10,11 @@ public class SavePvMetadataApiResult extends ApiResultBase {
         this.pvName = null;
     }
 
+    public SavePvMetadataApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.pvName = null;
+    }
+
     public SavePvMetadataApiResult(String pvName) {
         super(false, "");
         this.pvName = pvName;

--- a/src/main/java/com/ospreydcs/dp/client/result/SubscribeDataEventApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/SubscribeDataEventApiResult.java
@@ -12,6 +12,11 @@ public class SubscribeDataEventApiResult extends ApiResultBase {
         this.subscribeDataEventCall = null;
     }
 
+    public SubscribeDataEventApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.subscribeDataEventCall = null;
+    }
+
     public SubscribeDataEventApiResult(IngestionStreamClient.SubscribeDataEventCall subscribeDataEventCall) {
         super(false, "");
         this.subscribeDataEventCall = subscribeDataEventCall;

--- a/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/ConfigurationClientIT.java
+++ b/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/ConfigurationClientIT.java
@@ -1,6 +1,7 @@
 package com.ospreydcs.dp.service.integration.annotation;
 
 import com.ospreydcs.dp.client.AnnotationClient;
+import com.ospreydcs.dp.client.result.ApiResultStatus;
 import com.ospreydcs.dp.client.result.GetConfigurationApiResult;
 import com.ospreydcs.dp.client.result.SaveConfigurationActivationApiResult;
 import com.ospreydcs.dp.client.result.SaveConfigurationApiResult;
@@ -543,6 +544,109 @@ public class ConfigurationClientIT extends AnnotationIntegrationTestIntermediate
         assertTrue(result.resultStatus.msg,
                 result.resultStatus.msg.contains("no Configuration record found for: no-such-config"));
         assertNull(result.configuration);
+
+        // the rejection is categorized without matching on the message
+        assertEquals(ApiResultStatus.REJECT, result.apiResultStatus);
+        assertTrue(result.isReject());
+    }
+
+    // =========================================================================
+    // apiResultStatus tests
+    // =========================================================================
+
+    /**
+     * Verifies that a successful call carries ApiResultStatus.NONE and is not reported as a
+     * rejection.
+     */
+    @Test
+    public void testApiResultStatusNoneOnSuccess() {
+
+        final SaveConfigurationApiResult saveResult = annotationClient.saveConfiguration(
+                new AnnotationClient.SaveConfigurationParams(
+                        "test-config-status-001", "category-status-001", null, null, null, null, null));
+
+        assertFalse(saveResult.resultStatus.msg, saveResult.resultStatus.isError);
+        assertEquals(ApiResultStatus.NONE, saveResult.apiResultStatus);
+        assertFalse(saveResult.isReject());
+
+        final GetConfigurationApiResult getResult =
+                annotationClient.getConfiguration("test-config-status-001");
+
+        assertFalse(getResult.resultStatus.msg, getResult.resultStatus.isError);
+        assertEquals(ApiResultStatus.NONE, getResult.apiResultStatus);
+        assertFalse(getResult.isReject());
+    }
+
+    /**
+     * Verifies that a server-side validation rejection reaches the caller as REJECT, the same
+     * status as a not-found rejection.
+     *
+     * This equivalence is the reason the client exposes isReject() rather than an isNotFound()
+     * predicate: the services report a malformed request and an absent record with the same wire
+     * status, so a not-found predicate built on the status alone would report a rejected bad
+     * request as "the record does not exist".  A caller using isReject() to decide whether a save
+     * would overwrite an existing record must validate its request first, since a rejection here
+     * does not establish that the record is absent.
+     */
+    @Test
+    public void testApiResultStatusRejectOnValidationFailure() {
+
+        final SaveConfigurationApiResult result = annotationClient.saveConfiguration(
+                new AnnotationClient.SaveConfigurationParams(
+                        null, "beamline", null, null, null, null, null));
+
+        assertTrue(result.resultStatus.isError);
+        assertEquals(ApiResultStatus.REJECT, result.apiResultStatus);
+        assertTrue(result.isReject());
+
+        // a validation reject and a not-found reject are indistinguishable by status
+        final GetConfigurationApiResult notFoundResult =
+                annotationClient.getConfiguration("no-such-config-status");
+        assertEquals(notFoundResult.apiResultStatus, result.apiResultStatus);
+    }
+
+    /**
+     * Verifies that the overlap constraint failure arrives categorized as ERROR, not REJECT.
+     *
+     * The overlap check runs in MongoSyncAnnotationClient after the request has already passed
+     * validation, and reports through the MongoSaveResult error path, which the dispatcher sends as
+     * RESULT_STATUS_ERROR.  So although "an overlapping activation already exists" reads like a
+     * rejection of the request, it is categorized as a service error, and a caller branching on
+     * isReject() will not catch it.  This test pins that behavior: the constraint is a server-side
+     * concern, and whether it ought to be reported as a reject instead is a question about the
+     * service, not about this client status mapping.
+     */
+    @Test
+    public void testApiResultStatusErrorOnOverlapConstraint() {
+
+        final SaveConfigurationApiResult configResult = annotationClient.saveConfiguration(
+                new AnnotationClient.SaveConfigurationParams(
+                        "test-config-status-002", "category-status-002", null, null, null, null, null));
+        assertFalse(configResult.resultStatus.msg, configResult.resultStatus.isError);
+
+        final SaveConfigurationActivationApiResult firstResult =
+                annotationClient.saveConfigurationActivation(
+                        new AnnotationClient.SaveConfigurationActivationParams(
+                                "overlap-status-first",
+                                "test-config-status-002",
+                                timestamp(1000L),
+                                timestamp(2000L),
+                                null, null, null, null));
+        assertFalse(firstResult.resultStatus.msg, firstResult.resultStatus.isError);
+        assertEquals(ApiResultStatus.NONE, firstResult.apiResultStatus);
+
+        final SaveConfigurationActivationApiResult secondResult =
+                annotationClient.saveConfigurationActivation(
+                        new AnnotationClient.SaveConfigurationActivationParams(
+                                "overlap-status-second",
+                                "test-config-status-002",
+                                timestamp(1500L),
+                                timestamp(2500L),
+                                null, null, null, null));
+
+        assertTrue(secondResult.resultStatus.isError);
+        assertEquals(ApiResultStatus.ERROR, secondResult.apiResultStatus);
+        assertFalse(secondResult.isReject());
     }
 
 }

--- a/src/test/java/com/ospreydcs/dp/client/ResponseObserverErrorTest.java
+++ b/src/test/java/com/ospreydcs/dp/client/ResponseObserverErrorTest.java
@@ -1,0 +1,114 @@
+package com.ospreydcs.dp.client;
+
+import com.ospreydcs.dp.client.result.ApiResultStatus;
+import com.ospreydcs.dp.grpc.v1.ingestion.IngestDataResponse;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Provides test coverage for the onError() handling of the client response observers, which must
+ * release the latch their send method awaits.
+ *
+ * <p>An observer that records the failure but leaves its latch held does not fail any test that
+ * only inspects the result: await() eventually expires and the call is still reported as a
+ * failure, just a minute later and with the timeout message in place of the transport status.
+ * These tests therefore assert on <em>elapsed time</em> as well as content, since the wait is the
+ * defect.  The observers are plain StreamObservers, so no server, channel or database is involved.
+ */
+public class ResponseObserverErrorTest {
+
+    // an await that returns within this bound cannot have waited out the one minute timeout the
+    // observers use, while leaving ample headroom for a slow CI machine
+    private static final Duration AWAIT_BOUND = Duration.ofSeconds(10);
+
+    private static final StatusRuntimeException TRANSPORT_FAILURE =
+            new StatusRuntimeException(Status.UNAVAILABLE.withDescription("io exception"));
+
+    /*
+     * Asserts that the given wait returns promptly rather than expiring, and returns how long it
+     * took so the caller can report it.
+     */
+    private static Duration assertReturnsPromptly(String description, Runnable wait) {
+
+        final Instant start = Instant.now();
+        wait.run();
+        final Duration elapsed = Duration.between(start, Instant.now());
+
+        assertTrue(
+                description + " did not return promptly, took " + elapsed.toMillis()
+                        + "ms, which means onError left the latch held",
+                elapsed.compareTo(AWAIT_BOUND) < 0);
+
+        return elapsed;
+    }
+
+    /*
+     * QueryTableResponseObserver.await() must return as soon as onError fires, carrying the gRPC
+     * status rather than a timeout message.
+     */
+    @Test
+    public void testQueryTableObserverReleasesLatchOnError() {
+
+        final QueryClient.QueryTableResponseObserver observer =
+                new QueryClient.QueryTableResponseObserver();
+
+        observer.onError(TRANSPORT_FAILURE);
+        assertReturnsPromptly("QueryTableResponseObserver.await()", observer::await);
+
+        assertTrue(observer.isError());
+        assertTrue(
+                "expected the gRPC status, got: " + observer.getErrorMessage(),
+                observer.getErrorMessage().contains("UNAVAILABLE"));
+        assertEquals(ApiResultStatus.NONE, observer.getApiResultStatus());
+    }
+
+    /*
+     * IngestDataResponseObserver's latch is initialized to the expected response count, so onError
+     * must release every outstanding count, not just one.  Fail the stream after a single response
+     * of three so that two counts remain.
+     */
+    @Test
+    public void testIngestDataObserverReleasesAllOutstandingCountsOnError() {
+
+        final IngestionClient.IngestDataResponseObserver observer =
+                new IngestionClient.IngestDataResponseObserver(3);
+
+        observer.onNext(IngestDataResponse.newBuilder().build());
+        observer.onError(TRANSPORT_FAILURE);
+
+        assertReturnsPromptly("IngestDataResponseObserver.await()", observer::await);
+
+        assertTrue(observer.isError());
+        assertTrue(
+                "expected the gRPC status, got: " + observer.getErrorMessage(),
+                observer.getErrorMessage().contains("UNAVAILABLE"));
+    }
+
+    /*
+     * sendSubscribeDataEvent blocks on awaitAckLatch before returning, and onCompleted is not
+     * reached after a transport failure, so onError must release both the ack and close latches.
+     */
+    @Test
+    public void testSubscribeDataEventObserverReleasesBothLatchesOnError() {
+
+        final IngestionStreamClient.SubscribeDataEventResponseObserver observer =
+                new IngestionStreamClient.SubscribeDataEventResponseObserver(10);
+
+        observer.onError(TRANSPORT_FAILURE);
+
+        assertReturnsPromptly("awaitAckLatch()", observer::awaitAckLatch);
+        assertReturnsPromptly("awaitCloseLatch()", observer::awaitCloseLatch);
+
+        assertTrue(observer.isError());
+        assertTrue(
+                "expected the gRPC status, got: " + observer.getErrorMessage(),
+                observer.getErrorMessage().contains("UNAVAILABLE"));
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/client/result/ApiResultBaseTest.java
+++ b/src/test/java/com/ospreydcs/dp/client/result/ApiResultBaseTest.java
@@ -1,0 +1,128 @@
+package com.ospreydcs.dp.client.result;
+
+import com.ospreydcs.dp.grpc.v1.common.ExceptionalResult;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Provides test coverage for the API result status added to ApiResultBase, including the mapping
+ * from the protobuf status enum and the invariants tying apiResultStatus to isError.
+ */
+public class ApiResultBaseTest {
+
+    /*
+     * Minimal concrete subclass, since ApiResultBase is abstract.
+     */
+    private static class TestApiResult extends ApiResultBase {
+
+        public TestApiResult(boolean isError, String errorMessage) {
+            super(isError, errorMessage);
+        }
+
+        public TestApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+            super(isError, errorMessage, apiResultStatus);
+        }
+    }
+
+    @Test
+    public void testFromProtoMapsEachWireValue() {
+        assertEquals(
+                ApiResultStatus.REJECT,
+                ApiResultStatus.fromProto(ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT));
+        assertEquals(
+                ApiResultStatus.ERROR,
+                ApiResultStatus.fromProto(ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR));
+        assertEquals(
+                ApiResultStatus.NOT_READY,
+                ApiResultStatus.fromProto(ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_NOT_READY));
+    }
+
+    /*
+     * An unrecognized wire value must still be reported as a failure rather than throwing, so that
+     * a client built against an older protobuf revision degrades gracefully against a newer service.
+     */
+    @Test
+    public void testFromProtoMapsUnrecognizedValueToError() {
+        assertEquals(
+                ApiResultStatus.ERROR,
+                ApiResultStatus.fromProto(ExceptionalResult.ExceptionalResultStatus.UNRECOGNIZED));
+        assertEquals(ApiResultStatus.ERROR, ApiResultStatus.fromProto(null));
+    }
+
+    /*
+     * The two argument constructor is the pre-existing signature used by every locally generated
+     * failure, so its failures must categorize as LOCAL_FAILURE.
+     */
+    @Test
+    public void testLegacyConstructorCategorizesFailureAsLocal() {
+
+        final TestApiResult result = new TestApiResult(true, "timed out waiting for finishLatch");
+
+        assertTrue(result.isError());
+        assertTrue(result.resultStatus.isError);
+        assertEquals(ApiResultStatus.LOCAL_FAILURE, result.apiResultStatus);
+        assertFalse(result.isReject());
+    }
+
+    @Test
+    public void testSuccessCategorizesAsNone() {
+
+        final TestApiResult result = new TestApiResult(false, "");
+
+        assertFalse(result.isError());
+        assertEquals(ApiResultStatus.NONE, result.apiResultStatus);
+        assertFalse(result.isReject());
+    }
+
+    @Test
+    public void testRejectStatusIsPreservedAndPredicated() {
+
+        final TestApiResult result =
+                new TestApiResult(true, "no Configuration record found", ApiResultStatus.REJECT);
+
+        assertTrue(result.isError());
+        assertEquals(ApiResultStatus.REJECT, result.apiResultStatus);
+        assertTrue(result.isReject());
+    }
+
+    @Test
+    public void testErrorStatusIsNotAReject() {
+
+        final TestApiResult result =
+                new TestApiResult(true, "database error", ApiResultStatus.ERROR);
+
+        assertEquals(ApiResultStatus.ERROR, result.apiResultStatus);
+        assertFalse(result.isReject());
+    }
+
+    /*
+     * A success must never carry a failure category, even if a caller passes one, so that isReject()
+     * cannot report true for a result whose payload is valid.
+     */
+    @Test
+    public void testSuccessOverridesSuppliedFailureStatus() {
+
+        final TestApiResult result = new TestApiResult(false, "", ApiResultStatus.REJECT);
+
+        assertEquals(ApiResultStatus.NONE, result.apiResultStatus);
+        assertFalse(result.isReject());
+    }
+
+    /*
+     * Conversely a failure must always carry some failure category, so callers can switch on
+     * apiResultStatus without handling NONE as a failure case.
+     */
+    @Test
+    public void testFailureWithoutStatusFallsBackToLocalFailure() {
+
+        assertEquals(
+                ApiResultStatus.LOCAL_FAILURE,
+                new TestApiResult(true, "boom", ApiResultStatus.NONE).apiResultStatus);
+        assertEquals(
+                ApiResultStatus.LOCAL_FAILURE,
+                new TestApiResult(true, "boom", null).apiResultStatus);
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/client/result/ApiResultBaseTest.java
+++ b/src/test/java/com/ospreydcs/dp/client/result/ApiResultBaseTest.java
@@ -3,6 +3,17 @@ package com.ospreydcs.dp.client.result;
 import com.ospreydcs.dp.grpc.v1.common.ExceptionalResult;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -124,5 +135,57 @@ public class ApiResultBaseTest {
         assertEquals(
                 ApiResultStatus.LOCAL_FAILURE,
                 new TestApiResult(true, "boom", null).apiResultStatus);
+    }
+
+    /*
+     * RESULT_STATUS_REJECT is 0, the protobuf default, so an ExceptionalResult built without
+     * setExceptionalResultStatus() is indistinguishable on the wire from a deliberate reject and
+     * ApiResultStatus.fromProto() maps it to REJECT.  Callers branch on isReject() to read "target
+     * record does not exist", so such an omission can present as a benign not-found -- and for a
+     * caller deciding whether a save would overwrite, become a silent clobber.  Scan the service
+     * sources so a new dispatcher that forgets the setter fails here rather than in production.
+     */
+    @Test
+    public void testEveryExceptionalResultSetsStatus() throws IOException {
+
+        final Path sourceRoot = Paths.get("src/main/java");
+        assertTrue(
+                "expected to run from the module root, where " + sourceRoot + " exists",
+                Files.isDirectory(sourceRoot));
+
+        // matches a builder chain from newBuilder() up to and including build(), so the setter can
+        // be looked for anywhere within it rather than only on the line that follows
+        final Pattern builderChain = Pattern.compile(
+                "ExceptionalResult\\s*\\.\\s*newBuilder\\s*\\(\\s*\\).*?\\.\\s*build\\s*\\(\\s*\\)",
+                Pattern.DOTALL);
+
+        final List<String> violations = new ArrayList<>();
+        int chainCount = 0;
+
+        try (Stream<Path> sources = Files.walk(sourceRoot)) {
+            for (Path source : sources.filter(p -> p.toString().endsWith(".java")).toList()) {
+
+                final String contents = Files.readString(source, StandardCharsets.UTF_8);
+                final Matcher matcher = builderChain.matcher(contents);
+
+                while (matcher.find()) {
+                    chainCount++;
+                    if (!matcher.group().contains("setExceptionalResultStatus")) {
+                        final long line =
+                                contents.substring(0, matcher.start()).chars().filter(c -> c == '\n').count() + 1;
+                        violations.add(source + ":" + line);
+                    }
+                }
+            }
+        }
+
+        // guard against the regex silently matching nothing, which would make this test vacuous
+        assertTrue(
+                "expected to find ExceptionalResult builders to check, found none",
+                chainCount > 0);
+        assertEquals(
+                "ExceptionalResult built without setExceptionalResultStatus() at " + violations,
+                List.of(),
+                violations);
     }
 }


### PR DESCRIPTION
Closes #230.

## Problem

Client API results flattened every failure to `isError` plus a message, so a caller could not tell a service rejection from a service error without matching on the message string. The dp-desktop-app clobber warning (osprey-dcs/dp-desktop-app#27) needs that distinction to decide whether a save would overwrite an existing record.

## Approach

Adds `ApiResultStatus`, a client-side enum wrapping the three `ExceptionalResultStatus` wire values alongside `NONE` for success and `LOCAL_FAILURE` for failures generated without a response from the service (transport error, await timeout, malformed response sequence). Wrapping the wire enum rather than exposing it keeps callers insulated from protobuf enum evolution; an unrecognized value maps to `ERROR` so an unknown failure is still reported as a failure.

Two decisions settled during triage of #230:

**`isReject()` rather than the originally proposed `isNotFound()`.** The services report a failed validation and an absent record with the same `RESULT_STATUS_REJECT` — `GetConfigurationDispatcher.handleValidationError()` and its not-found branch both send Reject. A not-found predicate built on the status alone would therefore report a rejected malformed request as "the record does not exist", reintroducing the silent-overwrite failure mode this change exists to prevent. The distinction is documented on both the predicate and the enum value.

**Status on `ApiResultBase`, not `ResultStatus`.** `ResultStatus` lives in the server package and is shared with the dispatchers, jobs and validation utilities, which have no use for a client-facing status.

## Compatibility

Purely additive. The existing two-argument constructors are retained and unchanged, so all 30 current call sites and the `isError`/`msg` behavior are unaffected. `ApiResultBase` enforces the invariant in both directions: a success never carries a failure category, and a failure never carries `NONE` — so callers can switch on `apiResultStatus` without handling `NONE` as a failure case.

## Changes

- `ApiResultStatus` (new) — client-side enum and `fromProto()` mapping
- `ApiResultBase` — `apiResultStatus` field, `isError()`, `isReject()`
- 15 result subclasses — status-bearing error constructor alongside the existing one
- 15 response observers across `AnnotationClient`, `QueryClient`, `IngestionClient`, `IngestionStreamClient` — capture the wire status at each exceptional-response site and thread it into result construction

## Finding: overlap constraint reports ERROR, not REJECT

I initially wrote the overlap-constraint test asserting `REJECT` and it failed. The activation overlap check reports through the `MongoSaveResult` error path, which the dispatcher sends as `RESULT_STATUS_ERROR` — so despite reading like a rejection, a caller branching on `isReject()` will not catch it.

That is server-side behavior, not a mapping bug, so this PR pins it rather than changing it: `ConfigurationClientIT.testApiResultStatusErrorOnOverlapConstraint` asserts `ERROR` and documents why. Filed as #235, which also found the pattern is systemic — all 8 `Save*`/`Delete*` annotation dispatchers collapse `MongoSaveResult.isError` the same way, and the server-side tests already call these cases "rejects" (`expectReject`, `expectedRejectMessage`) without ever asserting the wire status. Fixing #235 should flip that test to expect `REJECT`.

## Testing

- `ApiResultBaseTest` (new, 8 cases) — enum mapping including unrecognized/null, and the success/failure category invariants
- `ConfigurationClientIT` (+3 cases) — `NONE` on success, `REJECT` on validation failure, and the equivalence of a validation reject and a not-found reject; the existing not-found test now also asserts the status
- Full integration suite: 50 suites, 0 failures, 0 errors
- Unit suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCBimTpyMZrmuYKQCRExPF
