### PR TITLE
dp-service: fix client observer duplicate-response handling via a shared base

### DIFF
--- a/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
@@ -62,6 +62,12 @@ public class AnnotationClient extends ServiceApiClientBase {
 
         @Override
         protected boolean handleResult(SaveDataSetResponse response) {
+
+            if (!response.hasSaveDataSetResult()) {
+                recordFailure(observerName() + " response does not contain SaveDataSetResult");
+                return false;
+            }
+
             dataSetIdList.add(response.getSaveDataSetResult().getDataSetId());
             return true;
         }
@@ -162,6 +168,12 @@ public class AnnotationClient extends ServiceApiClientBase {
 
         @Override
         protected boolean handleResult(SaveAnnotationResponse response) {
+
+            if (!response.hasSaveAnnotationResult()) {
+                recordFailure(observerName() + " response does not contain SaveAnnotationResult");
+                return false;
+            }
+
             annotationIdList.add(response.getSaveAnnotationResult().getAnnotationId());
             return true;
         }
@@ -754,6 +766,12 @@ public class AnnotationClient extends ServiceApiClientBase {
 
         @Override
         protected boolean handleResult(SavePvMetadataResponse response) {
+
+            if (!response.hasSavePvMetadataResult()) {
+                recordFailure(observerName() + " response does not contain SavePvMetadataResult");
+                return false;
+            }
+
             pvNameList.add(response.getSavePvMetadataResult().getPvName());
             return true;
         }
@@ -908,6 +926,12 @@ public class AnnotationClient extends ServiceApiClientBase {
 
         @Override
         protected boolean handleResult(SaveConfigurationResponse response) {
+
+            if (!response.hasSaveConfigurationResult()) {
+                recordFailure(observerName() + " response does not contain SaveConfigurationResult");
+                return false;
+            }
+
             configurationNameList.add(response.getSaveConfigurationResult().getConfigurationName());
             return true;
         }
@@ -938,6 +962,12 @@ public class AnnotationClient extends ServiceApiClientBase {
 
         @Override
         protected boolean handleResult(SaveConfigurationActivationResponse response) {
+
+            if (!response.hasSaveConfigurationActivationResult()) {
+                recordFailure(observerName() + " response does not contain SaveConfigurationActivationResult");
+                return false;
+            }
+
             clientActivationIdList.add(response.getSaveConfigurationActivationResult().getClientActivationId());
             return true;
         }
@@ -969,6 +999,12 @@ public class AnnotationClient extends ServiceApiClientBase {
 
         @Override
         protected boolean handleResult(GetConfigurationResponse response) {
+
+            if (!response.hasGetConfigurationResult()) {
+                recordFailure(observerName() + " response does not contain GetConfigurationResult");
+                return false;
+            }
+
             configurationList.add(response.getGetConfigurationResult().getConfiguration());
             return true;
         }

--- a/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
@@ -7,8 +7,6 @@ import com.ospreydcs.dp.grpc.v1.common.CalculationsSpec;
 import com.ospreydcs.dp.grpc.v1.common.Timestamp;
 import com.ospreydcs.dp.service.common.protobuf.AttributesUtility;
 import io.grpc.ManagedChannel;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -18,10 +16,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class AnnotationClient extends ServiceApiClientBase {
 

--- a/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
@@ -1,5 +1,6 @@
 package com.ospreydcs.dp.client;
 
+import com.ospreydcs.dp.grpc.v1.common.ExceptionalResult;
 import com.ospreydcs.dp.client.result.*;
 import com.ospreydcs.dp.grpc.v1.annotation.*;
 import com.ospreydcs.dp.grpc.v1.common.CalculationsSpec;
@@ -50,116 +51,33 @@ public class AnnotationClient extends ServiceApiClientBase {
     public record SaveDataSetParams(AnnotationDataSet dataSet) {
     }
     
-    public static class SaveDataSetResponseObserver implements StreamObserver<SaveDataSetResponse> {
+    public static class SaveDataSetResponseObserver
+            extends ApiResponseObserverBase<SaveDataSetResponse> {
 
-        // instance variables
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<String> dataSetIdList = Collections.synchronizedList(new ArrayList<>());
 
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
+        @Override
+        protected boolean hasExceptionalResult(SaveDataSetResponse response) {
+            return response.hasExceptionalResult();
         }
 
-        public boolean isError() { return isError.get(); }
-
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
+        @Override
+        protected ExceptionalResult getExceptionalResult(SaveDataSetResponse response) {
+            return response.getExceptionalResult();
         }
 
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+        @Override
+        protected boolean handleResult(SaveDataSetResponse response) {
+            dataSetIdList.add(response.getSaveDataSetResult().getDataSetId());
+            return true;
+        }
 
         public String getDataSetId() {
-            if (!dataSetIdList.isEmpty()) {
-                return dataSetIdList.get(0);
-            } else {
+            if (dataSetIdList.isEmpty()) {
                 return null;
+            } else {
+                return dataSetIdList.get(0);
             }
-        }
-
-        @Override
-        public void onNext(SaveDataSetResponse response) {
-
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "onNext received exceptional response: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                final SaveDataSetResponse.SaveDataSetResult result = response.getSaveDataSetResult();
-
-                // flag error if already received a response
-                if (!dataSetIdList.isEmpty()) {
-                    final String errorMsg = "onNext received more than one response";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-
-                } else {
-                    dataSetIdList.add(result.getDataSetId());
-                    finishLatch.countDown();
-                }
-            }).start();
-
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "onError error: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                finishLatch.countDown();
-            }).start();
-        }
-
-        @Override
-        public void onCompleted() {
         }
     }
 
@@ -187,124 +105,36 @@ public class AnnotationClient extends ServiceApiClientBase {
         }
     }
 
-    public static class QueryDataSetsResponseObserver implements StreamObserver<QueryDataSetsResponse> {
+    public static class QueryDataSetsResponseObserver
+            extends ApiResponseObserverBase<QueryDataSetsResponse> {
 
-        // instance variables
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<DataSet> dataSetsList =
                 Collections.synchronizedList(new ArrayList<>());
 
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
+        @Override
+        protected boolean hasExceptionalResult(QueryDataSetsResponse response) {
+            return response.hasExceptionalResult();
         }
 
-        public boolean isError() { return isError.get(); }
-
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
+        @Override
+        protected ExceptionalResult getExceptionalResult(QueryDataSetsResponse response) {
+            return response.getExceptionalResult();
         }
 
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+        @Override
+        protected boolean handleResult(QueryDataSetsResponse response) {
+
+            if (!response.hasDataSetsResult()) {
+                recordFailure(observerName() + " response does not contain DataSetsResult");
+                return false;
+            }
+
+            dataSetsList.addAll(response.getDataSetsResult().getDataSetsList());
+            return true;
+        }
 
         public List<DataSet> getDataSetsList() {
             return dataSetsList;
-        }
-
-        @Override
-        public void onNext(QueryDataSetsResponse response) {
-
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "onNext received exceptional response: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                if ( ! response.hasDataSetsResult()) {
-                    final String errorMsg = "QueryDataSetsResponse does not contain DataSetsResult";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-
-                }
-
-                List<DataSet> responseDataSetsList =
-                        response.getDataSetsResult().getDataSetsList();
-
-                // flag error if already received a response
-                if (!dataSetsList.isEmpty()) {
-                    final String errorMsg = "onNext received more than one response";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-
-                } else {
-                    dataSetsList.addAll(responseDataSetsList);
-                    finishLatch.countDown();
-                }
-            }).start();
-
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "onError error: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                finishLatch.countDown();
-            }).start();
-        }
-
-        @Override
-        public void onCompleted() {
         }
     }
 
@@ -321,116 +151,33 @@ public class AnnotationClient extends ServiceApiClientBase {
     ) {
     }
 
-    public static class SaveAnnotationResponseObserver implements StreamObserver<SaveAnnotationResponse> {
+    public static class SaveAnnotationResponseObserver
+            extends ApiResponseObserverBase<SaveAnnotationResponse> {
 
-        // instance variables
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<String> annotationIdList = Collections.synchronizedList(new ArrayList<>());
 
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
+        @Override
+        protected boolean hasExceptionalResult(SaveAnnotationResponse response) {
+            return response.hasExceptionalResult();
         }
 
-        public boolean isError() { return isError.get(); }
-
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
+        @Override
+        protected ExceptionalResult getExceptionalResult(SaveAnnotationResponse response) {
+            return response.getExceptionalResult();
         }
 
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+        @Override
+        protected boolean handleResult(SaveAnnotationResponse response) {
+            annotationIdList.add(response.getSaveAnnotationResult().getAnnotationId());
+            return true;
+        }
 
         public String getAnnotationId() {
-            if (!annotationIdList.isEmpty()) {
-                return annotationIdList.get(0);
-            } else {
+            if (annotationIdList.isEmpty()) {
                 return null;
+            } else {
+                return annotationIdList.get(0);
             }
-        }
-
-        @Override
-        public void onNext(SaveAnnotationResponse response) {
-
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "onNext received exceptional response: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                final SaveAnnotationResponse.SaveAnnotationResult result = response.getSaveAnnotationResult();
-
-                // flag error if already received a response
-                if (!annotationIdList.isEmpty()) {
-                    final String errorMsg = "onNext received more than one response";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-
-                } else {
-                    annotationIdList.add(result.getAnnotationId());
-                    finishLatch.countDown();
-                }
-            }).start();
-
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "onError error: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                finishLatch.countDown();
-            }).start();
-        }
-
-        @Override
-        public void onCompleted() {
         }
     }
 
@@ -477,123 +224,36 @@ public class AnnotationClient extends ServiceApiClientBase {
 
     }
 
-    public static class QueryAnnotationsResponseObserver implements StreamObserver<QueryAnnotationsResponse> {
+    public static class QueryAnnotationsResponseObserver
+            extends ApiResponseObserverBase<QueryAnnotationsResponse> {
 
-        // instance variables
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<QueryAnnotationsResponse.AnnotationsResult.Annotation> annotationsList =
                 Collections.synchronizedList(new ArrayList<>());
 
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
+        @Override
+        protected boolean hasExceptionalResult(QueryAnnotationsResponse response) {
+            return response.hasExceptionalResult();
         }
 
-        public boolean isError() { return isError.get(); }
-
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
+        @Override
+        protected ExceptionalResult getExceptionalResult(QueryAnnotationsResponse response) {
+            return response.getExceptionalResult();
         }
 
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+        @Override
+        protected boolean handleResult(QueryAnnotationsResponse response) {
+
+            if (!response.hasAnnotationsResult()) {
+                recordFailure(observerName() + " response does not contain AnnotationsResult");
+                return false;
+            }
+
+            annotationsList.addAll(response.getAnnotationsResult().getAnnotationsList());
+            return true;
+        }
 
         public List<QueryAnnotationsResponse.AnnotationsResult.Annotation> getAnnotationsList() {
             return annotationsList;
-        }
-
-        @Override
-        public void onNext(QueryAnnotationsResponse response) {
-
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "onNext received exceptional response: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                if ( ! response.hasAnnotationsResult()) {
-                    final String errorMsg = "QueryAnnotationsResponse does not contain AnnotationsResult";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                List<QueryAnnotationsResponse.AnnotationsResult.Annotation> responseAnnotationList =
-                        response.getAnnotationsResult().getAnnotationsList();
-
-                // flag error if already received a response
-                if (!annotationsList.isEmpty()) {
-                    final String errorMsg = "onNext received more than one response";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-
-                } else {
-                    annotationsList.addAll(responseAnnotationList);
-                    finishLatch.countDown();
-                }
-            }).start();
-
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "onError error: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                finishLatch.countDown();
-            }).start();
-        }
-
-        @Override
-        public void onCompleted() {
         }
     }
 
@@ -604,126 +264,40 @@ public class AnnotationClient extends ServiceApiClientBase {
     ) {
     }
 
-    public static class ExportDataResponseObserver implements StreamObserver<ExportDataResponse> {
+    public static class ExportDataResponseObserver
+            extends ApiResponseObserverBase<ExportDataResponse> {
 
-        // instance variables
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<ExportDataResponse.ExportDataResult> resultList =
                 Collections.synchronizedList(new ArrayList<>());
 
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
+        @Override
+        protected boolean hasExceptionalResult(ExportDataResponse response) {
+            return response.hasExceptionalResult();
         }
 
-        public boolean isError() { return isError.get(); }
-
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
+        @Override
+        protected ExceptionalResult getExceptionalResult(ExportDataResponse response) {
+            return response.getExceptionalResult();
         }
 
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+        @Override
+        protected boolean handleResult(ExportDataResponse response) {
+
+            if (!response.hasExportDataResult()) {
+                recordFailure(observerName() + " response does not contain ExportDataResult");
+                return false;
+            }
+
+            resultList.add(response.getExportDataResult());
+            return true;
+        }
 
         public ExportDataResponse.ExportDataResult getResult() {
-            if (!resultList.isEmpty()) {
-                return resultList.get(0);
-            } else {
+            if (resultList.isEmpty()) {
                 return null;
+            } else {
+                return resultList.get(0);
             }
-        }
-
-        @Override
-        public void onNext(ExportDataResponse response) {
-
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "onNext received exceptional response: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                if (! response.hasExportDataResult()) {
-                    final String errorMsg = "ExportDataResponse does not contain ExportDataResult";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                final ExportDataResponse.ExportDataResult result = response.getExportDataResult();
-
-                // flag error if already received a response
-                if (!resultList.isEmpty()) {
-                    final String errorMsg = "onNext received more than one response";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-
-                } else {
-                    resultList.add(result);
-                    finishLatch.countDown();
-                }
-            }).start();
-
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "onError error: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                finishLatch.countDown();
-            }).start();
-        }
-
-        @Override
-        public void onCompleted() {
         }
     }
 
@@ -1169,116 +743,33 @@ public class AnnotationClient extends ServiceApiClientBase {
     ) {
     }
 
-    public static class SavePvMetadataResponseObserver implements StreamObserver<SavePvMetadataResponse> {
+    public static class SavePvMetadataResponseObserver
+            extends ApiResponseObserverBase<SavePvMetadataResponse> {
 
-        // instance variables
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<String> pvNameList = Collections.synchronizedList(new ArrayList<>());
 
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
+        @Override
+        protected boolean hasExceptionalResult(SavePvMetadataResponse response) {
+            return response.hasExceptionalResult();
         }
 
-        public boolean isError() { return isError.get(); }
-
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
+        @Override
+        protected ExceptionalResult getExceptionalResult(SavePvMetadataResponse response) {
+            return response.getExceptionalResult();
         }
 
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+        @Override
+        protected boolean handleResult(SavePvMetadataResponse response) {
+            pvNameList.add(response.getSavePvMetadataResult().getPvName());
+            return true;
+        }
 
         public String getPvName() {
-            if (!pvNameList.isEmpty()) {
-                return pvNameList.get(0);
-            } else {
+            if (pvNameList.isEmpty()) {
                 return null;
+            } else {
+                return pvNameList.get(0);
             }
-        }
-
-        @Override
-        public void onNext(SavePvMetadataResponse response) {
-
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "onNext received exceptional response: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                final SavePvMetadataResponse.SavePvMetadataResult result = response.getSavePvMetadataResult();
-
-                // flag error if already received a response
-                if (!pvNameList.isEmpty()) {
-                    final String errorMsg = "onNext received more than one response";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-
-                } else {
-                    pvNameList.add(result.getPvName());
-                    finishLatch.countDown();
-                }
-            }).start();
-
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "onError error: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                finishLatch.countDown();
-            }).start();
-        }
-
-        @Override
-        public void onCompleted() {
         }
     }
 
@@ -1407,348 +898,93 @@ public class AnnotationClient extends ServiceApiClientBase {
     }
 
     public static class SaveConfigurationResponseObserver
-            implements StreamObserver<SaveConfigurationResponse> {
+            extends ApiResponseObserverBase<SaveConfigurationResponse> {
 
-        // instance variables
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<String> configurationNameList = Collections.synchronizedList(new ArrayList<>());
 
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
+        @Override
+        protected boolean hasExceptionalResult(SaveConfigurationResponse response) {
+            return response.hasExceptionalResult();
         }
 
-        public boolean isError() { return isError.get(); }
-
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
+        @Override
+        protected ExceptionalResult getExceptionalResult(SaveConfigurationResponse response) {
+            return response.getExceptionalResult();
         }
 
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+        @Override
+        protected boolean handleResult(SaveConfigurationResponse response) {
+            configurationNameList.add(response.getSaveConfigurationResult().getConfigurationName());
+            return true;
+        }
 
         public String getConfigurationName() {
-            if (!configurationNameList.isEmpty()) {
-                return configurationNameList.get(0);
-            } else {
+            if (configurationNameList.isEmpty()) {
                 return null;
+            } else {
+                return configurationNameList.get(0);
             }
-        }
-
-        @Override
-        public void onNext(SaveConfigurationResponse response) {
-
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "onNext received exceptional response: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                final SaveConfigurationResponse.SaveConfigurationResult result =
-                        response.getSaveConfigurationResult();
-
-                // flag error if already received a response
-                if (!configurationNameList.isEmpty()) {
-                    final String errorMsg = "onNext received more than one response";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-
-                } else {
-                    configurationNameList.add(result.getConfigurationName());
-                    finishLatch.countDown();
-                }
-            }).start();
-
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "onError error: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                finishLatch.countDown();
-            }).start();
-        }
-
-        @Override
-        public void onCompleted() {
         }
     }
 
     public static class SaveConfigurationActivationResponseObserver
-            implements StreamObserver<SaveConfigurationActivationResponse> {
+            extends ApiResponseObserverBase<SaveConfigurationActivationResponse> {
 
-        // instance variables
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<String> clientActivationIdList = Collections.synchronizedList(new ArrayList<>());
 
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
+        @Override
+        protected boolean hasExceptionalResult(SaveConfigurationActivationResponse response) {
+            return response.hasExceptionalResult();
         }
 
-        public boolean isError() { return isError.get(); }
-
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
+        @Override
+        protected ExceptionalResult getExceptionalResult(SaveConfigurationActivationResponse response) {
+            return response.getExceptionalResult();
         }
 
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+        @Override
+        protected boolean handleResult(SaveConfigurationActivationResponse response) {
+            clientActivationIdList.add(response.getSaveConfigurationActivationResult().getClientActivationId());
+            return true;
+        }
 
         public String getClientActivationId() {
-            if (!clientActivationIdList.isEmpty()) {
-                return clientActivationIdList.get(0);
-            } else {
+            if (clientActivationIdList.isEmpty()) {
                 return null;
+            } else {
+                return clientActivationIdList.get(0);
             }
-        }
-
-        @Override
-        public void onNext(SaveConfigurationActivationResponse response) {
-
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "onNext received exceptional response: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                final SaveConfigurationActivationResponse.SaveConfigurationActivationResult result =
-                        response.getSaveConfigurationActivationResult();
-
-                // flag error if already received a response
-                if (!clientActivationIdList.isEmpty()) {
-                    final String errorMsg = "onNext received more than one response";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-
-                } else {
-                    clientActivationIdList.add(result.getClientActivationId());
-                    finishLatch.countDown();
-                }
-            }).start();
-
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "onError error: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                finishLatch.countDown();
-            }).start();
-        }
-
-        @Override
-        public void onCompleted() {
         }
     }
 
     public static class GetConfigurationResponseObserver
-            implements StreamObserver<GetConfigurationResponse> {
+            extends ApiResponseObserverBase<GetConfigurationResponse> {
 
-        // instance variables
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<com.ospreydcs.dp.grpc.v1.common.Configuration> configurationList =
                 Collections.synchronizedList(new ArrayList<>());
 
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
+        @Override
+        protected boolean hasExceptionalResult(GetConfigurationResponse response) {
+            return response.hasExceptionalResult();
         }
 
-        public boolean isError() { return isError.get(); }
-
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
+        @Override
+        protected ExceptionalResult getExceptionalResult(GetConfigurationResponse response) {
+            return response.getExceptionalResult();
         }
 
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+        @Override
+        protected boolean handleResult(GetConfigurationResponse response) {
+            configurationList.add(response.getGetConfigurationResult().getConfiguration());
+            return true;
+        }
 
         public com.ospreydcs.dp.grpc.v1.common.Configuration getConfiguration() {
-            if (!configurationList.isEmpty()) {
-                return configurationList.get(0);
-            } else {
+            if (configurationList.isEmpty()) {
                 return null;
+            } else {
+                return configurationList.get(0);
             }
-        }
-
-        @Override
-        public void onNext(GetConfigurationResponse response) {
-
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "onNext received exceptional response: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                final GetConfigurationResponse.GetConfigurationResult result =
-                        response.getGetConfigurationResult();
-
-                // flag error if already received a response
-                if (!configurationList.isEmpty()) {
-                    final String errorMsg = "onNext received more than one response";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-
-                } else {
-                    configurationList.add(result.getConfiguration());
-                    finishLatch.countDown();
-                }
-            }).start();
-
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "onError error: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                finishLatch.countDown();
-            }).start();
-        }
-
-        @Override
-        public void onCompleted() {
         }
     }
 

--- a/src/main/java/com/ospreydcs/dp/client/ApiResponseObserverBase.java
+++ b/src/main/java/com/ospreydcs/dp/client/ApiResponseObserverBase.java
@@ -1,0 +1,248 @@
+package com.ospreydcs.dp.client;
+
+import com.ospreydcs.dp.client.result.ApiResultStatus;
+import com.google.protobuf.Message;
+import com.ospreydcs.dp.grpc.v1.common.ExceptionalResult;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Base class for the client API response observers that handle a single-response RPC.
+ *
+ * <p>Every such observer awaits one response, records a failure so the corresponding {@code
+ * sendXxx()} method can build an error {@code ApiResult}, and releases a latch so that {@code
+ * sendXxx()} does not block past the point where the outcome is known.  That machinery was
+ * previously copied into each observer, and the copies drifted: the duplicate-response branch
+ * omitted the {@code countDown()} in every one of them, so a second response stalled the caller
+ * for the full await timeout instead of failing fast.  Fixing that class of defect in one place
+ * is the reason this class exists.
+ *
+ * <p>Subclasses supply only the parts that genuinely differ between RPCs, via {@link
+ * #hasExceptionalResult}, {@link #getExceptionalResult} and {@link #handleResult}.  Everything
+ * else -- the latch, the error state, the await, {@code onError}, and the response-sequence
+ * checks -- is final here.
+ *
+ * <p><strong>Latch discipline.</strong> The latch is released exactly once, by {@link
+ * #recordFailure} or by a successful {@link #handleResult}, and {@link #onNext} routes every path
+ * through one of those.  A path that records a failure without releasing the latch is the
+ * original defect, so subclasses must report failures through {@code recordFailure} rather than
+ * touching the error state directly.
+ *
+ * <p><strong>Threading.</strong> {@code onNext} and {@code onError} dispatch their work onto a new
+ * thread, preserving the behavior of the observers this class replaces: it keeps response handling
+ * off the service handler's thread, so in-process tests exercise the same concurrency an
+ * out-of-process gRPC client would.
+ *
+ * @param <T> the response message type of the RPC
+ */
+public abstract class ApiResponseObserverBase<T extends Message> implements StreamObserver<T> {
+
+    /**
+     * How long {@link #await} waits for a response before reporting a timeout.  Exposed so tests
+     * can drive the timeout path without waiting out the production value.
+     */
+    public static final long DEFAULT_AWAIT_TIMEOUT_SECONDS = 60;
+
+    // instance variables
+    private final CountDownLatch finishLatch = new CountDownLatch(1);
+    private final AtomicBoolean isError = new AtomicBoolean(false);
+    private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+    // categorizes a failure so callers can distinguish a service rejection from a service
+    // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
+    // recorded without a status-bearing response -- a transport error, an await timeout, a
+    // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
+    // getter honest for a call that succeeded.  Only the first status recorded is kept, so
+    // that the status and the message returned by getErrorMessage() describe the same failure.
+    private final AtomicReference<ApiResultStatus> apiResultStatus =
+            new AtomicReference<>(ApiResultStatus.NONE);
+    // guards the response-sequence check.  A separate flag rather than an isEmpty() test on the
+    // subclass payload list, because an observer whose response carries an empty repeated field
+    // stores nothing on the first response and would otherwise fail to recognize the second.
+    private final AtomicBoolean responseReceived = new AtomicBoolean(false);
+
+    private final long awaitTimeoutSeconds;
+
+    protected ApiResponseObserverBase() {
+        this(DEFAULT_AWAIT_TIMEOUT_SECONDS);
+    }
+
+    /**
+     * @param awaitTimeoutSeconds how long {@link #await} waits before reporting a timeout; intended
+     *                            for tests that exercise the timeout path.
+     */
+    protected ApiResponseObserverBase(long awaitTimeoutSeconds) {
+        this.awaitTimeoutSeconds = awaitTimeoutSeconds;
+    }
+
+    /**
+     * Names this observer in its error messages.  Defaults to the concrete class's simple name so
+     * that a message identifies the RPC that produced it without each subclass repeating a
+     * literal.
+     */
+    protected String observerName() {
+        return getClass().getSimpleName();
+    }
+
+    /**
+     * Whether the given response carries an {@code ExceptionalResult} in place of a payload.
+     */
+    protected abstract boolean hasExceptionalResult(T response);
+
+    /**
+     * Returns the {@code ExceptionalResult} from a response for which {@link #hasExceptionalResult}
+     * returned true.
+     */
+    protected abstract ExceptionalResult getExceptionalResult(T response);
+
+    /**
+     * Extracts and stores the payload of a successful response.
+     *
+     * <p>Called at most once per observer, and only for a response that carries no {@code
+     * ExceptionalResult}.  Return false, after calling {@link #recordFailure}, to reject a response
+     * that is well-formed on the wire but unusable -- a response missing the result field it is
+     * required to carry, for instance.  Returning true releases the awaiting caller.
+     *
+     * @return true if the payload was accepted, false if the response was rejected
+     */
+    protected abstract boolean handleResult(T response);
+
+    /**
+     * Records a failure and releases the awaiting caller.
+     *
+     * <p>The message is kept only if it is the first recorded, so that {@link #getErrorMessage} and
+     * {@link #getApiResultStatus} describe the same failure -- the earliest one, which is the one
+     * that caused the call to fail.
+     */
+    protected final void recordFailure(String errorMsg) {
+        recordFailure(errorMsg, null);
+    }
+
+    /**
+     * Records a failure carrying a service-supplied status, and releases the awaiting caller.
+     *
+     * @param apiResultStatus the status to report, or null to leave it at its current value
+     */
+    protected final void recordFailure(String errorMsg, ApiResultStatus apiResultStatus) {
+
+        System.err.println(errorMsg);
+
+        if (apiResultStatus != null) {
+            this.apiResultStatus.compareAndSet(ApiResultStatus.NONE, apiResultStatus);
+        }
+
+        isError.set(true);
+        errorMessageList.add(errorMsg);
+        finishLatch.countDown();
+    }
+
+    /**
+     * Releases the awaiting caller after a payload has been accepted.
+     */
+    private void recordSuccess() {
+        finishLatch.countDown();
+    }
+
+    /**
+     * Waits for the RPC to produce a response, a transport error, or a timeout.
+     *
+     * <p>A timeout is reported as an error: the latch is only counted down by a response or an
+     * onError, so an expired await means no result was received and the caller would otherwise see
+     * a success carrying a null payload.
+     */
+    public final void await() {
+        try {
+            if (!finishLatch.await(awaitTimeoutSeconds, TimeUnit.SECONDS)) {
+                recordFailure(observerName() + " timed out waiting for finishLatch after "
+                        + awaitTimeoutSeconds + " seconds");
+            }
+        } catch (InterruptedException e) {
+            recordFailure(observerName() + " InterruptedException waiting for finishLatch");
+            // restore the interrupt flag so callers up the stack can still observe it
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public final boolean isError() {
+        return isError.get();
+    }
+
+    public final String getErrorMessage() {
+        if (!errorMessageList.isEmpty()) {
+            return errorMessageList.get(0);
+        } else {
+            return "";
+        }
+    }
+
+    public final ApiResultStatus getApiResultStatus() {
+        return apiResultStatus.get();
+    }
+
+    /**
+     * Returns every failure recorded, in the order recorded, for callers that need more than the
+     * first one -- a test asserting that a later failure was processed without displacing the
+     * earlier one, for instance.
+     */
+    public final List<String> getErrorMessageList() {
+        return Collections.unmodifiableList(errorMessageList);
+    }
+
+    @Override
+    public final void onNext(T response) {
+
+        // handle response in separate thread to better simulate out of process grpc,
+        // otherwise response is handled in same thread as service handler that sent it
+        new Thread(() -> {
+
+            // check the response sequence before doing anything else, so that a second response
+            // cannot overwrite the payload or the status recorded from the first.  The duplicate
+            // must release the latch as well: it is a failure the caller needs to see promptly,
+            // and leaving the latch held here was the original defect.
+            if (!responseReceived.compareAndSet(false, true)) {
+                recordFailure(observerName() + " onNext received more than one response");
+                return;
+            }
+
+            if (hasExceptionalResult(response)) {
+                final ExceptionalResult exceptionalResult = getExceptionalResult(response);
+                recordFailure(
+                        observerName() + " onNext received exceptional response: "
+                                + exceptionalResult.getMessage(),
+                        ApiResultStatus.fromProto(exceptionalResult.getExceptionalResultStatus()));
+                return;
+            }
+
+            // handleResult calls recordFailure itself when it rejects the response, so the latch
+            // is released on both branches
+            if (handleResult(response)) {
+                recordSuccess();
+            }
+
+        }).start();
+    }
+
+    @Override
+    public final void onError(Throwable t) {
+
+        // handle response in separate thread to better simulate out of process grpc,
+        // otherwise response is handled in same thread as service handler that sent it
+        new Thread(() -> {
+            final Status status = Status.fromThrowable(t);
+            // the latch must be counted down here, otherwise a transport failure leaves await()
+            // to expire and the caller sees a timeout message instead of the actual gRPC status
+            recordFailure(observerName() + " error: " + status);
+        }).start();
+    }
+
+    @Override
+    public void onCompleted() {
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/client/ApiResponseObserverBase.java
+++ b/src/main/java/com/ospreydcs/dp/client/ApiResponseObserverBase.java
@@ -86,9 +86,20 @@ public abstract class ApiResponseObserverBase<T extends Message> implements Stre
      * Names this observer in its error messages.  Defaults to the concrete class's simple name so
      * that a message identifies the RPC that produced it without each subclass repeating a
      * literal.
+     *
+     * <p>{@code getSimpleName()} is empty for an anonymous subclass, which would leave a message
+     * with no identity at all, so fall back to the nearest named ancestor in that case.
      */
     protected String observerName() {
-        return getClass().getSimpleName();
+
+        for (Class<?> c = getClass(); c != null; c = c.getSuperclass()) {
+            final String simpleName = c.getSimpleName();
+            if (!simpleName.isEmpty()) {
+                return simpleName;
+            }
+        }
+
+        return "ApiResponseObserver";
     }
 
     /**
@@ -117,9 +128,10 @@ public abstract class ApiResponseObserverBase<T extends Message> implements Stre
     /**
      * Records a failure and releases the awaiting caller.
      *
-     * <p>The message is kept only if it is the first recorded, so that {@link #getErrorMessage} and
-     * {@link #getApiResultStatus} describe the same failure -- the earliest one, which is the one
-     * that caused the call to fail.
+     * <p>Every message recorded is retained, in order, and is available from {@link
+     * #getErrorMessageList}.  It is {@link #getErrorMessage} that selects the first one, so that
+     * the message it returns and the status from {@link #getApiResultStatus} describe the same
+     * failure -- the earliest one, which is the one that caused the call to fail.
      */
     protected final void recordFailure(String errorMsg) {
         recordFailure(errorMsg, null);

--- a/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
@@ -68,6 +68,12 @@ public class IngestionClient extends ServiceApiClientBase {
 
         @Override
         protected boolean handleResult(RegisterProviderResponse response) {
+
+            if (!response.hasRegistrationResult()) {
+                recordFailure(observerName() + " response does not contain RegistrationResult");
+                return false;
+            }
+
             responseList.add(response);
             return true;
         }

--- a/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
@@ -50,109 +50,30 @@ public class IngestionClient extends ServiceApiClientBase {
         }
     }
 
-    public static class RegisterProviderResponseObserver implements StreamObserver<RegisterProviderResponse> {
+    public static class RegisterProviderResponseObserver
+            extends ApiResponseObserverBase<RegisterProviderResponse> {
 
-        // instance variables
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
-        private final List<RegisterProviderResponse> responseList = Collections.synchronizedList(new ArrayList<>());
+        private final List<RegisterProviderResponse> responseList =
+                Collections.synchronizedList(new ArrayList<>());
 
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
+        @Override
+        protected boolean hasExceptionalResult(RegisterProviderResponse response) {
+            return response.hasExceptionalResult();
         }
 
-        public boolean isError() { return isError.get(); }
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
+        @Override
+        protected ExceptionalResult getExceptionalResult(RegisterProviderResponse response) {
+            return response.getExceptionalResult();
         }
 
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+        @Override
+        protected boolean handleResult(RegisterProviderResponse response) {
+            responseList.add(response);
+            return true;
+        }
 
         public List<RegisterProviderResponse> getResponseList() {
             return responseList;
-        }
-
-        @Override
-        public void onNext(RegisterProviderResponse response) {
-
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "onNext received exceptional response: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                // flag error if already received a response
-                if (!responseList.isEmpty()) {
-                    final String errorMsg = "onNext received more than one response";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-
-                } else {
-                    responseList.add(response);
-                    finishLatch.countDown();
-                }
-            }).start();
-
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "onError: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                finishLatch.countDown();
-            }).start();
-        }
-
-        @Override
-        public void onCompleted() {
         }
     }
 

--- a/src/main/java/com/ospreydcs/dp/client/IngestionStreamClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/IngestionStreamClient.java
@@ -131,6 +131,8 @@ public class IngestionStreamClient extends ServiceApiClientBase {
                 System.err.println(errorMsg);
                 isError.set(true);
                 errorMessageList.add(errorMsg);
+                // restore the interrupt flag so callers up the stack can still observe it
+                Thread.currentThread().interrupt();
             }
         }
 
@@ -148,6 +150,8 @@ public class IngestionStreamClient extends ServiceApiClientBase {
                 System.err.println(errorMsg);
                 isError.set(true);
                 errorMessageList.add(errorMsg);
+                // restore the interrupt flag so callers up the stack can still observe it
+                Thread.currentThread().interrupt();
             }
         }
 

--- a/src/main/java/com/ospreydcs/dp/client/QueryClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/QueryClient.java
@@ -1,25 +1,18 @@
 package com.ospreydcs.dp.client;
 
-import com.ospreydcs.dp.client.result.ApiResultStatus;
 import com.ospreydcs.dp.client.result.QueryProvidersApiResult;
 import com.ospreydcs.dp.client.result.QueryPvStatsApiResult;
 import com.ospreydcs.dp.client.result.QueryTableApiResult;
+import com.ospreydcs.dp.grpc.v1.common.ExceptionalResult;
 import com.ospreydcs.dp.grpc.v1.common.Timestamp;
 import com.ospreydcs.dp.grpc.v1.query.*;
 import io.grpc.ManagedChannel;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class QueryClient extends ServiceApiClientBase {
 
@@ -34,216 +27,64 @@ public class QueryClient extends ServiceApiClientBase {
     ) {
     }
 
-    public static class QueryTableResponseObserver implements StreamObserver<QueryTableResponse> {
+    public static class QueryTableResponseObserver
+            extends ApiResponseObserverBase<QueryTableResponse> {
 
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<QueryTableResponse> responseList = Collections.synchronizedList(new ArrayList<>());
 
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
+        @Override
+        protected boolean hasExceptionalResult(QueryTableResponse response) {
+            return response.hasExceptionalResult();
         }
 
-        public boolean isError() { return isError.get(); }
-
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
+        @Override
+        protected ExceptionalResult getExceptionalResult(QueryTableResponse response) {
+            return response.getExceptionalResult();
         }
 
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+        @Override
+        protected boolean handleResult(QueryTableResponse response) {
+            responseList.add(response);
+            return true;
+        }
 
         public QueryTableResponse getQueryResponse() {
-            return responseList.get(0);
-        }
-
-        @Override
-        public void onNext(QueryTableResponse response) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "onNext received exceptional response: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-
-                responseList.add(response);
-                finishLatch.countDown();
-                if (responseList.size() > 1) {
-                    System.err.println("QueryTableResponseObserver onNext received more than one response");
-                    isError.set(true);
-                }
-
-            }).start();
-
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "QueryTableResponseObserver error: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // the latch must be counted down here, otherwise a transport failure leaves
-                // await() to expire and the caller sees a timeout message instead of the
-                // actual gRPC status
-                finishLatch.countDown();
-            }).start();
-        }
-
-        @Override
-        public void onCompleted() {
-        }
-    }
-
-    public static class QueryPvStatsResponseObserver implements StreamObserver<QueryPvStatsResponse> {
-
-        // instance variables
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
-        private final List<QueryPvStatsResponse> responseList =
-                Collections.synchronizedList(new ArrayList<>());
-
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
-        }
-
-        public boolean isError() { return isError.get(); }
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
-        }
-
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
-
-        public QueryPvStatsResponse getResponse() {
-            if (responseList.isEmpty() || responseList.size() > 1) {
+            if (responseList.isEmpty()) {
                 return null;
             } else {
                 return responseList.get(0);
             }
         }
+    }
+
+    public static class QueryPvStatsResponseObserver
+            extends ApiResponseObserverBase<QueryPvStatsResponse> {
+
+        private final List<QueryPvStatsResponse> responseList =
+                Collections.synchronizedList(new ArrayList<>());
 
         @Override
-        public void onNext(QueryPvStatsResponse response) {
-
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "QueryResponseColumnInfoObserver onNext received exception response: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                // flag error if already received a response
-                if (!responseList.isEmpty()) {
-                    final String errorMsg = "QueryResponseColumnInfoObserver onNext received more than one response";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-
-                } else {
-                    responseList.add(response);
-                    finishLatch.countDown();
-                }
-            }).start();
-
+        protected boolean hasExceptionalResult(QueryPvStatsResponse response) {
+            return response.hasExceptionalResult();
         }
 
         @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "QueryResponseColumnInfoObserver error: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                finishLatch.countDown();
-            }).start();
+        protected ExceptionalResult getExceptionalResult(QueryPvStatsResponse response) {
+            return response.getExceptionalResult();
         }
 
         @Override
-        public void onCompleted() {
+        protected boolean handleResult(QueryPvStatsResponse response) {
+            responseList.add(response);
+            return true;
+        }
+
+        public QueryPvStatsResponse getResponse() {
+            if (responseList.isEmpty()) {
+                return null;
+            } else {
+                return responseList.get(0);
+            }
         }
     }
 
@@ -273,122 +114,36 @@ public class QueryClient extends ServiceApiClientBase {
         }
     }
 
-    public static class QueryProvidersResponseObserver implements StreamObserver<QueryProvidersResponse> {
+    public static class QueryProvidersResponseObserver
+            extends ApiResponseObserverBase<QueryProvidersResponse> {
 
-        // instance variables
-        private final CountDownLatch finishLatch = new CountDownLatch(1);
-        private final AtomicBoolean isError = new AtomicBoolean(false);
-        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
-        // categorizes a failure so callers can distinguish a service rejection from a service
-        // error.  Defaults to NONE, which ApiResultBase maps to LOCAL_FAILURE when a failure was
-        // recorded without a status-bearing response -- a transport error, an await timeout, a
-        // malformed response sequence.  Defaulting to NONE rather than LOCAL_FAILURE keeps this
-        // getter honest for a call that succeeded.  Only the first status recorded is kept, so
-        // that the status and the message returned by getErrorMessage() describe the same failure.
-        private final AtomicReference<ApiResultStatus> apiResultStatus =
-                new AtomicReference<>(ApiResultStatus.NONE);
         private final List<QueryProvidersResponse.ProvidersResult.ProviderInfo> providerInfoList =
                 Collections.synchronizedList(new ArrayList<>());
 
-        public void await() {
-            try {
-                // a timeout must be reported as an error: the latch is only counted down by a
-                // response or an onError, so an expired await means no result was received and
-                // the caller would otherwise see a success carrying a null payload
-                if (!finishLatch.await(1, TimeUnit.MINUTES)) {
-                    final String errorMsg = "timed out waiting for finishLatch";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                }
-            } catch (InterruptedException e) {
-                final String errorMsg = "InterruptedException waiting for finishLatch";
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                // restore the interrupt flag so callers up the stack can still observe it
-                Thread.currentThread().interrupt();
-            }
+        @Override
+        protected boolean hasExceptionalResult(QueryProvidersResponse response) {
+            return response.hasExceptionalResult();
         }
 
-        public boolean isError() { return isError.get(); }
-        public String getErrorMessage() {
-            if (!errorMessageList.isEmpty()) {
-                return errorMessageList.get(0);
-            } else {
-                return "";
-            }
+        @Override
+        protected ExceptionalResult getExceptionalResult(QueryProvidersResponse response) {
+            return response.getExceptionalResult();
         }
 
-        public ApiResultStatus getApiResultStatus() { return apiResultStatus.get(); }
+        @Override
+        protected boolean handleResult(QueryProvidersResponse response) {
+
+            if (!response.hasProvidersResult()) {
+                recordFailure(observerName() + " response does not contain ProvidersResult");
+                return false;
+            }
+
+            providerInfoList.addAll(response.getProvidersResult().getProviderInfosList());
+            return true;
+        }
 
         public List<QueryProvidersResponse.ProvidersResult.ProviderInfo> getProviderInfoList() {
             return providerInfoList;
-        }
-
-        @Override
-        public void onNext(QueryProvidersResponse response) {
-
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-
-                if (response.hasExceptionalResult()) {
-                    final String errorMsg = "onNext received ExceptionalResult: "
-                            + response.getExceptionalResult().getMessage();
-                    System.err.println(errorMsg);
-                    apiResultStatus.compareAndSet(
-                            ApiResultStatus.NONE,
-                            ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                if (!response.hasProvidersResult()) {
-                    final String errorMsg = "QueryProvidersResponse does not contain ProvidersResult";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-                    finishLatch.countDown();
-                    return;
-                }
-
-                final QueryProvidersResponse.ProvidersResult providersResult = response.getProvidersResult();
-                Objects.requireNonNull(providersResult);
-
-                // flag error if already received a response
-                if (!providerInfoList.isEmpty()) {
-                    final String errorMsg = "onNext received more than one response";
-                    System.err.println(errorMsg);
-                    isError.set(true);
-                    errorMessageList.add(errorMsg);
-
-                } else {
-                    providerInfoList.addAll(response.getProvidersResult().getProviderInfosList());
-                    finishLatch.countDown();
-                }
-            }).start();
-
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // handle response in separate thread to better simulate out of process grpc,
-            // otherwise response is handled in same thread as service handler that sent it
-            new Thread(() -> {
-                final Status status = Status.fromThrowable(t);
-                final String errorMsg = "onError: " + status;
-                System.err.println(errorMsg);
-                isError.set(true);
-                errorMessageList.add(errorMsg);
-                finishLatch.countDown();
-            }).start();
-        }
-
-        @Override
-        public void onCompleted() {
         }
     }
 

--- a/src/test/java/com/ospreydcs/dp/client/ApiResponseObserverBaseTest.java
+++ b/src/test/java/com/ospreydcs/dp/client/ApiResponseObserverBaseTest.java
@@ -90,10 +90,20 @@ public class ApiResponseObserverBaseTest {
         final QueryClient.QueryTableResponseObserver observer =
                 new QueryClient.QueryTableResponseObserver();
 
+        // deliver the first response and let it settle before sending the second.  onNext
+        // dispatches to a new thread, so firing both back to back leaves which one wins the
+        // sequence check undefined -- and await() can then return on the winner's countDown
+        // before the loser's thread has recorded anything.
         observer.onNext(QueryTableResponse.newBuilder().build());
-        observer.onNext(QueryTableResponse.newBuilder().build());
-
         assertReturnsPromptly("QueryTableResponseObserver.await()", observer::await);
+        assertFalse("the first response must not be an error", observer.isError());
+
+        // the duplicate must fail fast rather than leaving a caller to wait out the timeout.
+        // The latch is already released, so timing the duplicate's own await() is what would
+        // have caught the missing countDown: measure that it returns without expiring.
+        observer.onNext(QueryTableResponse.newBuilder().build());
+        awaitErrorRecorded(observer);
+        assertReturnsPromptly("await() after a duplicate", observer::await);
 
         assertTrue("a duplicate response must be reported as an error", observer.isError());
         assertTrue(

--- a/src/test/java/com/ospreydcs/dp/client/ApiResponseObserverBaseTest.java
+++ b/src/test/java/com/ospreydcs/dp/client/ApiResponseObserverBaseTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Provides test coverage for the response-sequence handling shared by the client API response
@@ -66,7 +67,15 @@ public class ApiResponseObserverBaseTest {
         final Instant deadline = Instant.now().plus(AWAIT_BOUND);
 
         while (!condition.getAsBoolean() && Instant.now().isBefore(deadline)) {
-            Thread.onSpinWait();
+            // park briefly rather than spinning: these conditions resolve in milliseconds, so the
+            // poll interval is never the limiting factor, and a bare spin would peg a core for the
+            // full bound on a machine loaded enough to actually approach it
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                fail(description + " was interrupted while waiting");
+            }
         }
 
         assertTrue(

--- a/src/test/java/com/ospreydcs/dp/client/ApiResponseObserverBaseTest.java
+++ b/src/test/java/com/ospreydcs/dp/client/ApiResponseObserverBaseTest.java
@@ -2,6 +2,7 @@ package com.ospreydcs.dp.client;
 
 import com.ospreydcs.dp.client.result.ApiResultStatus;
 import com.ospreydcs.dp.grpc.v1.common.ExceptionalResult;
+import com.ospreydcs.dp.grpc.v1.annotation.SaveDataSetResponse;
 import com.ospreydcs.dp.grpc.v1.query.QueryProvidersResponse;
 import com.ospreydcs.dp.grpc.v1.query.QueryTableResponse;
 import org.junit.Test;
@@ -273,5 +274,30 @@ public class ApiResponseObserverBaseTest {
         assertTrue(
                 "expected the timeout message, got: " + observer.getErrorMessage(),
                 observer.getErrorMessage().contains("timed out"));
+    }
+
+    /*
+     * A save response carrying neither an exceptional result nor its result field is rejected
+     * rather than reported as a success with an empty-string id.  The save observers previously
+     * read the payload unconditionally, so an unset result oneof produced a default-instance
+     * result and the caller received a successful ApiResult whose id was "" -- a silent wrong
+     * answer of the same shape as the duplicate-response defect this class was introduced to fix.
+     */
+    @Test
+    public void testSaveResponseMissingResultIsRejected() {
+
+        final AnnotationClient.SaveDataSetResponseObserver observer =
+                new AnnotationClient.SaveDataSetResponseObserver();
+
+        // neither branch of the result oneof is set
+        observer.onNext(SaveDataSetResponse.newBuilder().build());
+
+        assertReturnsPromptly("SaveDataSetResponseObserver.await()", observer::await);
+
+        assertTrue("a response with no result field must be an error", observer.isError());
+        assertTrue(
+                "expected the missing-result message, got: " + observer.getErrorMessage(),
+                observer.getErrorMessage().contains("does not contain SaveDataSetResult"));
+        assertNull("no id may be reported for a rejected response", observer.getDataSetId());
     }
 }

--- a/src/test/java/com/ospreydcs/dp/client/ApiResponseObserverBaseTest.java
+++ b/src/test/java/com/ospreydcs/dp/client/ApiResponseObserverBaseTest.java
@@ -1,0 +1,258 @@
+package com.ospreydcs.dp.client;
+
+import com.ospreydcs.dp.client.result.ApiResultStatus;
+import com.ospreydcs.dp.grpc.v1.common.ExceptionalResult;
+import com.ospreydcs.dp.grpc.v1.query.QueryProvidersResponse;
+import com.ospreydcs.dp.grpc.v1.query.QueryTableResponse;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Provides test coverage for the response-sequence handling shared by the client API response
+ * observers via {@link ApiResponseObserverBase}.
+ *
+ * <p>These cover the two defects that motivated lifting the machinery into a base class:
+ *
+ * <ul>
+ *   <li>A duplicate response was detected but left the latch held, so the caller blocked for the
+ *       full await timeout instead of failing fast.  As with {@link ResponseObserverErrorTest},
+ *       the wait <em>is</em> the defect, so these assert on elapsed time as well as content.
+ *   <li>{@code QueryTableResponseObserver} counted the latch down before checking for a duplicate,
+ *       so the second response raced the caller and its error flag was usually read too late.
+ * </ul>
+ *
+ * <p>The observers are plain StreamObservers, so no server, channel or database is involved.  A
+ * short await timeout is used where the timeout path itself is under test, so that the case is
+ * covered in milliseconds rather than the production minute.
+ */
+public class ApiResponseObserverBaseTest {
+
+    // an await that returns within this bound cannot have waited out the one minute timeout the
+    // observers use by default, while leaving ample headroom for a slow CI machine
+    private static final Duration AWAIT_BOUND = Duration.ofSeconds(10);
+
+    /*
+     * Asserts that the given wait returns promptly rather than expiring.
+     */
+    private static void assertReturnsPromptly(String description, Runnable wait) {
+
+        final Instant start = Instant.now();
+        wait.run();
+        final Duration elapsed = Duration.between(start, Instant.now());
+
+        assertTrue(
+                description + " did not return promptly, took " + elapsed.toMillis()
+                        + "ms, which means the duplicate response left the latch held",
+                elapsed.compareTo(AWAIT_BOUND) < 0);
+    }
+
+    /*
+     * onNext dispatches its work to a new thread, so a response delivered after the latch has
+     * already been released -- a duplicate -- is not necessarily visible by the time onNext
+     * returns.  await() cannot be used to wait for it, since the latch is already at zero.  Poll
+     * for the error flag instead, which is what the duplicate sets, rather than sleeping a fixed
+     * interval that would be either flaky or slow.
+     */
+    private static void awaitCondition(String description, BooleanSupplier condition) {
+
+        final Instant deadline = Instant.now().plus(AWAIT_BOUND);
+
+        while (!condition.getAsBoolean() && Instant.now().isBefore(deadline)) {
+            Thread.onSpinWait();
+        }
+
+        assertTrue(
+                description + " did not happen within " + AWAIT_BOUND.toSeconds() + " seconds",
+                condition.getAsBoolean());
+    }
+
+    private static void awaitErrorRecorded(ApiResponseObserverBase<?> observer) {
+        awaitCondition("the observer recording an error", observer::isError);
+    }
+
+    /*
+     * A second response must be reported as an error and must release the caller immediately.
+     * Before the fix the duplicate branch set the error flag but omitted the countDown, so await()
+     * blocked for the full timeout and then overwrote nothing -- the caller waited a minute to
+     * learn about a failure that was already known.
+     */
+    @Test
+    public void testDuplicateResponseFailsFast() {
+
+        final QueryClient.QueryTableResponseObserver observer =
+                new QueryClient.QueryTableResponseObserver();
+
+        observer.onNext(QueryTableResponse.newBuilder().build());
+        observer.onNext(QueryTableResponse.newBuilder().build());
+
+        assertReturnsPromptly("QueryTableResponseObserver.await()", observer::await);
+
+        assertTrue("a duplicate response must be reported as an error", observer.isError());
+        assertTrue(
+                "expected the duplicate-response message, got: " + observer.getErrorMessage(),
+                observer.getErrorMessage().contains("more than one response"));
+    }
+
+    /*
+     * The duplicate must not displace the payload or the status recorded from the first response.
+     * QueryTableResponseObserver previously appended every response to its list and counted down
+     * before checking the sequence, so the check raced the caller reading isError().
+     */
+    @Test
+    public void testDuplicateResponseDoesNotDisplaceFirstResult() {
+
+        final QueryClient.QueryProvidersResponseObserver observer =
+                new QueryClient.QueryProvidersResponseObserver();
+
+        final QueryProvidersResponse first = QueryProvidersResponse.newBuilder()
+                .setProvidersResult(QueryProvidersResponse.ProvidersResult.newBuilder()
+                        .addProviderInfos(QueryProvidersResponse.ProvidersResult.ProviderInfo
+                                .newBuilder().setId("provider-one").build())
+                        .build())
+                .build();
+
+        final QueryProvidersResponse second = QueryProvidersResponse.newBuilder()
+                .setProvidersResult(QueryProvidersResponse.ProvidersResult.newBuilder()
+                        .addProviderInfos(QueryProvidersResponse.ProvidersResult.ProviderInfo
+                                .newBuilder().setId("provider-two").build())
+                        .build())
+                .build();
+
+        observer.onNext(first);
+        observer.await();
+        observer.onNext(second);
+        awaitErrorRecorded(observer);
+
+        assertTrue(observer.isError());
+        assertEquals(
+                "the duplicate must not be appended to the payload",
+                1,
+                observer.getProviderInfoList().size());
+        assertEquals("provider-one", observer.getProviderInfoList().get(0).getId());
+    }
+
+    /*
+     * An exceptional result carries the service's status through to the caller, and a duplicate
+     * arriving afterward must not overwrite it -- getErrorMessage() and getApiResultStatus() are
+     * required to describe the same failure.
+     */
+    @Test
+    public void testExceptionalResultStatusSurvivesDuplicate() {
+
+        final QueryClient.QueryTableResponseObserver observer =
+                new QueryClient.QueryTableResponseObserver();
+
+        observer.onNext(QueryTableResponse.newBuilder()
+                .setExceptionalResult(ExceptionalResult.newBuilder()
+                        .setExceptionalResultStatus(
+                                ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT)
+                        .setMessage("rejected by service")
+                        .build())
+                .build());
+
+        assertReturnsPromptly("QueryTableResponseObserver.await()", observer::await);
+
+        // isError is already set by the exceptional result, so wait for the duplicate's own
+        // message to land -- that is what proves the duplicate was processed and that the
+        // assertions below are checking the first failure survived rather than a race
+        observer.onNext(QueryTableResponse.newBuilder().build());
+        awaitCondition(
+                "the duplicate response being recorded",
+                () -> observer.getErrorMessageList().size() > 1);
+
+        assertTrue(observer.isError());
+        assertEquals(ApiResultStatus.REJECT, observer.getApiResultStatus());
+        assertTrue(
+                "expected the service message, got: " + observer.getErrorMessage(),
+                observer.getErrorMessage().contains("rejected by service"));
+        assertNull("an exceptional result carries no payload", observer.getQueryResponse());
+    }
+
+    /*
+     * A response missing the result field it is required to carry is rejected rather than stored,
+     * and must release the caller.  Previously QueryProvidersResponseObserver called
+     * Objects.requireNonNull here, on the onNext thread, where the resulting NPE was swallowed and
+     * the latch was never counted down.
+     */
+    @Test
+    public void testResponseMissingResultIsRejected() {
+
+        final QueryClient.QueryProvidersResponseObserver observer =
+                new QueryClient.QueryProvidersResponseObserver();
+
+        observer.onNext(QueryProvidersResponse.newBuilder().build());
+
+        assertReturnsPromptly("QueryProvidersResponseObserver.await()", observer::await);
+
+        assertTrue(observer.isError());
+        assertTrue(
+                "expected the missing-result message, got: " + observer.getErrorMessage(),
+                observer.getErrorMessage().contains("does not contain ProvidersResult"));
+        assertTrue(observer.getProviderInfoList().isEmpty());
+    }
+
+    /*
+     * A normal single response must not be reported as an error, so that the sequence check does
+     * not turn a successful call into a failure.
+     */
+    @Test
+    public void testSingleResponseSucceeds() {
+
+        final QueryClient.QueryTableResponseObserver observer =
+                new QueryClient.QueryTableResponseObserver();
+
+        final QueryTableResponse response = QueryTableResponse.newBuilder().build();
+        observer.onNext(response);
+
+        assertReturnsPromptly("QueryTableResponseObserver.await()", observer::await);
+
+        assertFalse(observer.isError());
+        assertEquals("", observer.getErrorMessage());
+        assertEquals(ApiResultStatus.NONE, observer.getApiResultStatus());
+        assertEquals(response, observer.getQueryResponse());
+    }
+
+    /*
+     * An await that expires must be reported as an error, so that the caller cannot mistake a hung
+     * RPC for a success carrying a null payload.  Uses a short timeout so the case is covered
+     * without waiting out the production value.
+     */
+    @Test
+    public void testAwaitTimeoutIsReportedAsError() {
+
+        final ApiResponseObserverBase<QueryTableResponse> observer =
+                new ApiResponseObserverBase<>(1) {
+
+                    @Override
+                    protected boolean hasExceptionalResult(QueryTableResponse response) {
+                        return response.hasExceptionalResult();
+                    }
+
+                    @Override
+                    protected ExceptionalResult getExceptionalResult(QueryTableResponse response) {
+                        return response.getExceptionalResult();
+                    }
+
+                    @Override
+                    protected boolean handleResult(QueryTableResponse response) {
+                        return true;
+                    }
+                };
+
+        // never deliver a response, so the await expires
+        observer.await();
+
+        assertTrue("an expired await must be reported as an error", observer.isError());
+        assertTrue(
+                "expected the timeout message, got: " + observer.getErrorMessage(),
+                observer.getErrorMessage().contains("timed out"));
+    }
+}


### PR DESCRIPTION
Fixes #228.

## Background

The `com.ospreydcs.dp.client` observers each carried their own copy of the same ~100 lines of latch, error-state and await machinery. Triage found that two of the three defects the issue originally reported had already been fixed in the interim by #234 (`b9eddbe` for the discarded `await()` timeout result and the missing `Thread.currentThread().interrupt()`; `2a7715c` for observers that never counted down in `onError()`). The issue description has been updated to match the remaining scope.

What was left is below.

## Defect 1 — duplicate-response branch never counts the latch down

Every duplicate-response branch detected the second response and recorded the error, but omitted `finishLatch.countDown()`. The caller blocked for the full one-minute await timeout before learning about a failure that was already known. 12 observers: 9 in `AnnotationClient`, 2 in `QueryClient`, 1 in `IngestionClient`. (`AnnotationClient` gained three configuration observers in #234, so the count is higher than the 6 the issue originally reported.)

Now that the `await()` timeout is reported as an error, the caller does eventually see a failure — so this is a latency defect, not a correctness one.

## Defect 2 — `QueryTableResponseObserver` counts down before checking the sequence

Found during triage, folded in here at the reviewer's request. This observer did not follow the shape of the other 12:

```java
responseList.add(response);
finishLatch.countDown();
if (responseList.size() > 1) { ...; isError.set(true); }
```

The first response released the latch, so `await()` returned and `sendQueryTable()` read `isError()` — the second response's `isError.set(true)` raced the caller and was usually lost. The caller received response #1 reported as a **success**.

Unlike Defect 1 this is a silent wrong answer rather than a stall, which is the more serious failure mode.

## Defect 3 — save responses missing their result field report success

Found in review, fixed here. The save observers read the payload without first checking the
result `oneof`:

```java
dataSetIdList.add(response.getSaveDataSetResult().getDataSetId());
```

A response carrying neither an `ExceptionalResult` nor its result field yields a
default-instance result, so the caller received a **successful** `ApiResult` whose id was the
empty string. The query observers (`QueryDataSets`, `QueryAnnotations`, `ExportData`,
`QueryProviders`) already guarded against this; the save observers never did.

Like Defect 2 this is a silent wrong answer rather than a stall. Seven observers gain the
guard — `SaveDataSet`, `SaveAnnotation`, `SavePvMetadata`, `SaveConfiguration`,
`SaveConfigurationActivation`, `GetConfiguration` in `AnnotationClient`, and `RegisterProvider`
in `IngestionClient`. `RegisterProvider` is included because its observer stores the whole
response and `RegisterProviderApiResult` reads it directly, so a missing `RegistrationResult`
propagated into the result object rather than being caught at the boundary.

All seven response types define their result in a `oneof`, so `hasXxxResult()` distinguishes the
unset case from an empty payload.

## Approach

Rather than apply the same three-line fix 12 times, the shared machinery is lifted into `ApiResponseObserverBase<T>`. Three design points make this class of bug unrepeatable:

- **The latch is released on every path** — `recordFailure()` always counts down, and an accepted `handleResult()` counts down. There is no way to record a failure and leave the latch held, which was the original defect. Subclasses report failures through `recordFailure()` rather than touching the error state directly.
- **The sequence check runs before any state is recorded**, so a duplicate cannot displace the first response's payload or status. This is what fixes Defect 2.
- **A subclass rejects an unusable response by returning false from `handleResult()`**, after calling `recordFailure()`, so a malformed response travels the same path as any other failure instead of being read as a payload. This is what fixes Defect 3.

Subclasses implement only `hasExceptionalResult()`, `getExceptionalResult()` and `handleResult()`. The await timeout is now a constructor parameter defaulting to one minute, so the timeout path is testable without waiting out the production value.

**Net −485 lines** (820 insertions, 1305 deletions).

## Also fixed

Two things that fell out of the migration:

- `QueryProvidersResponseObserver` called `Objects.requireNonNull` on the `onNext` thread, where the resulting NPE was swallowed and the latch was never released — a malformed response hung the caller for the full minute. Now reported through `recordFailure()`.
- `SubscribeDataEventResponseObserver`'s two `InterruptedException` catches were still missing `Thread.currentThread().interrupt()`. `b9eddbe` covered the `finishLatch` sites; these use `ackLatch`/`closeLatch`. Fixed in place — the observer is otherwise out of scope.

## Out of scope

`SubscribeDataEventResponseObserver` is a long-lived streaming observer, not request/response. `IngestDataResponseObserver` initializes its latch to the expected response count, so a "duplicate" is a normal response for it. Neither is migrated.

## Behavior change worth a look

`QueryPvStatsResponseObserver.getResponse()` previously returned `null` when `responseList.size() > 1`. Duplicates are no longer stored, so that guard is gone and it returns the first response — which is what the guard was approximating.

## Testing

New `ApiResponseObserverBaseTest` (7 cases): duplicate-response fast failure (asserting on **elapsed time**, since the wait is the defect), first-result retention across a duplicate, exceptional-result status retention across a duplicate, missing-result rejection on a query response, missing-result rejection on a save response, single-response success, and the await timeout via the injectable value. The existing `ResponseObserverErrorTest` continues to cover `onError` latch release.

- Full unit suite: **302 passed**
- Client integration tests against a live service (`PvMetadataClientIT`, `ConfigurationClientIT`): **25 passed**

Public API of all three modified clients was diffed against `main` to confirm nothing was lost in the migration — every removed member is one now inherited from the base class.

## Review fixes

Applied after the initial review, in `a30a0aa`:

- `recordFailure()` javadoc said the message was "kept only if it is the first recorded", which
  describes what `getErrorMessage()` selects rather than what is stored. Every message is retained
  and available from `getErrorMessageList()`, which the tests rely on. Reworded.
- `observerName()` returned `getClass().getSimpleName()`, empty for an anonymous subclass, leaving
  the timeout message with no identity. Now walks up to the nearest named ancestor. Production
  observers are all named classes, so this only affected test subclasses.
- The test poll loop parks 1ms per iteration instead of spinning on `Thread.onSpinWait()`.
- Removed six imports in `AnnotationClient` the migration had made unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCBimTpyMZrmuYKQCRExPF

