### PR TITLE
dp-service #238: Sample Status API service handlers and Query V2 selector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ When modifying gRPC APIs:
 - **pvMetadata**: PV metadata records (pvName unique index, aliases index; tags, attributes, description, modifiedBy, createdAt, updatedAt)
 - **configurations**: Machine configuration records (configurationName unique index, category index; tags, attributes, description, modifiedBy, createdAt, updatedAt)
 - **configurationActivations**: Time-bounded activations of configurations (clientActivationId unique sparse index; configurationName, internalCategory, startTime, endTime indexes; tags, attributes, description, modifiedBy, createdAt, updatedAt)
+- **sampleStatusBuckets**: Sample status storage (SampleStatusBucketDocument: pvName/domain/layer identity, embedded DataTimestampsDocument, firstTimeNanos/lastTimeNanos epoch-nanos scalars, statusCodes/confidence/reasons arrays, source/modifiedBy/updatedTime; indexes on (pvName, domain, layer, firstTimeNanos) and (domain, layer, firstTimeNanos))
 
 ### Document Embedding Pattern
 MongoDB documents use embedded protobuf serialization:
@@ -290,6 +291,56 @@ Like the max-bucket-span invariant, the failure mode is a **silent wrong answer*
 
 - **Never collapse the fragments** into a single `[min begin, max end)` window for sample filtering; that window spans the gaps. `computeWindowBegin()` deliberately returns only a begin — there is no correct single upper bound. Do not reintroduce a window end.
 - **`TimestampDataMap.getColumnIndex()` is a mutator.** It appends unseen names to the list that determines the emitted/exported column set, so it must be called for every column regardless of whether any sample survives trimming — otherwise a PV with no in-range samples is silently dropped instead of emitted as an all-empty column. `addColumnsToTable()` registers columns up front for this reason; `AnnotationCalculationsIT` (16 columns expected) is the regression guard.
+
+## Sample Status API (issue #238)
+
+The Annotation Service implements the Sample Status API (`saveSampleStatuses`, `querySampleStatuses`,
+`querySampleStatusesStream`, `deleteSampleStatuses`; the two domain-registry methods are deferred
+stubs). An individual status is keyed by **(pvName, timestamp, domain, layer)** at nanosecond
+precision; storage is the `sampleStatusBuckets` collection.
+
+### Storage invariant: no duplicate identity keys
+No two documents may ever assert a status for the same identity key. The save path maintains this
+with a **carve-and-insert upsert** (`MongoSyncAnnotationClient.saveSampleStatuses()`): exactly-colliding
+timestamps are carved out of existing overlapping documents (via `SampleStatusDocumentUtility.removeTimestamps()`),
+then the incoming column is inserted whole, preserving its axis representation. Documents whose spans
+overlap but whose timestamps don't collide are left untouched, provenance intact. Carve rewrites happen
+**before** the insert so a mid-write failure can never leave duplicate keys (partial persistence on
+error is documented API behavior). Rewritten documents take the incoming save's source/modifiedBy and
+a fresh server-set updatedTime; delete-path trims keep the original provenance (deletion is not a save).
+
+### Key semantics
+- **Delete is exact at the sample axis** `[beginTime, endTime)`: boundary documents are trimmed/split
+  via `removeRange()` (an evenly spaced surviving run re-emits as a SamplingClock, so an interior
+  delete splits a clock document into two clocks); counts are individual statuses, not documents.
+- **Query returns boundary buckets whole** (span-overlap test `firstTimeNanos < end AND lastTimeNanos >= begin`),
+  ordered by (pvName, domain, layer, firstTimeNanos) — a total order under the storage invariant.
+- **Keyset paging** (`SampleStatusPageToken`): the token encodes the last-returned sort position, not a
+  skip offset (documents are rewritten in place, so offsets drift). Unparseable tokens are **rejected**
+  per the contract — unlike pvMetadata/configuration, which silently reset to page 0.
+- **No maximum document span**: sparse labeling over an arbitrarily wide range is first-class, so a
+  status frame has no `maxBucketSpanSeconds`-style cap and **no #197-style firstTime lower bound may
+  ever be added** to sampleStatusBuckets overlap queries.
+- Validation lives in `SampleStatusValidationUtility` (whole-request reject; strictly increasing
+  TimestampLists — equal timestamps would collapse identity keys).
+- Config keys (`AnnotationHandler` section, in **both** application.yml files):
+  `sampleStatusQueryDefaultPageSize` (10000), `sampleStatusQueryMaxPageSize` (100000, silent clamp),
+  `sampleStatusSaveMaxStatuses` (1000000 per-request cap).
+
+### QuerySpec.sampleStatusSelector (Query V2)
+Supported by `querySamples`/`querySamplesStream` only; `QueryV2Resolver` **rejects** it on
+bucket-oriented methods (whole storage buckets cannot represent per-sample filtering). The validated
+selector is carried as `ResolvedStatusFilter` on `ResolvedQuery`;
+`MongoSyncQueryClient.resolveSampleStatusTimestamps()` fetches per-PV matching-timestamp sets over the
+same clamped page window as bucket retrieval, and `TabularDataUtility.SampleStatusFilter` applies the
+per-sample test during assembly (INCLUDE keeps iff labeled at the **exact** timestamp; EXCLUDE drops
+iff labeled). Composition with `configurationSelector` is by intersection — both the fragment retention
+test and the status test are applied in the same per-sample retention decision. A DB error or corrupt
+status document during the join surfaces as `DpException`/error, never as "no statuses" (in EXCLUDE
+mode that would silently return filtered-out samples). Filtered samples are simply never inserted into
+the `TimestampDataMap`, so missing values and all-PVs-filtered row omission fall out of the existing
+representation; the `getColumnIndex()` registration invariant still guarantees all-filtered PVs emit
+all-empty columns.
 
 ## Performance Benchmarking Framework
 Benchmarks in `com.ospreydcs.dp.service.ingest.benchmark`:

--- a/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
@@ -4,9 +4,13 @@ import com.ospreydcs.dp.grpc.v1.common.ExceptionalResult;
 import com.ospreydcs.dp.client.result.*;
 import com.ospreydcs.dp.grpc.v1.annotation.*;
 import com.ospreydcs.dp.grpc.v1.common.CalculationsSpec;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusBucket;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusFrame;
+import com.ospreydcs.dp.grpc.v1.common.TimeRange;
 import com.ospreydcs.dp.grpc.v1.common.Timestamp;
 import com.ospreydcs.dp.service.common.protobuf.AttributesUtility;
 import io.grpc.ManagedChannel;
+import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -16,6 +20,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class AnnotationClient extends ServiceApiClientBase {
 
@@ -1253,6 +1260,455 @@ public class AnnotationClient extends ServiceApiClientBase {
     ) {
         final GetConfigurationRequest request = buildGetConfigurationRequest(configurationName);
         return sendGetConfiguration(request);
+    }
+
+    // =========================================================
+    // Sample Status API
+    // =========================================================
+
+    public static class SaveSampleStatusesResponseObserver
+            extends ApiResponseObserverBase<SaveSampleStatusesResponse> {
+
+        private final List<Long> savedCountList = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        protected boolean hasExceptionalResult(SaveSampleStatusesResponse response) {
+            return response.hasExceptionalResult();
+        }
+
+        @Override
+        protected ExceptionalResult getExceptionalResult(SaveSampleStatusesResponse response) {
+            return response.getExceptionalResult();
+        }
+
+        @Override
+        protected boolean handleResult(SaveSampleStatusesResponse response) {
+
+            if (!response.hasSaveSampleStatusesResult()) {
+                recordFailure(observerName() + " response does not contain SaveSampleStatusesResult");
+                return false;
+            }
+
+            savedCountList.add(response.getSaveSampleStatusesResult().getSavedCount());
+            return true;
+        }
+
+        public Long getSavedCount() {
+            if (savedCountList.isEmpty()) {
+                return null;
+            } else {
+                return savedCountList.get(0);
+            }
+        }
+    }
+
+    public static class QuerySampleStatusesResponseObserver
+            extends ApiResponseObserverBase<QuerySampleStatusesResponse> {
+
+        private final List<SampleStatusBucket> bucketList = Collections.synchronizedList(new ArrayList<>());
+        private final AtomicReference<String> nextPageToken = new AtomicReference<>("");
+
+        @Override
+        protected boolean hasExceptionalResult(QuerySampleStatusesResponse response) {
+            return response.hasExceptionalResult();
+        }
+
+        @Override
+        protected ExceptionalResult getExceptionalResult(QuerySampleStatusesResponse response) {
+            return response.getExceptionalResult();
+        }
+
+        @Override
+        protected boolean handleResult(QuerySampleStatusesResponse response) {
+
+            if (!response.hasQuerySampleStatusesResult()) {
+                recordFailure(observerName() + " response does not contain QuerySampleStatusesResult");
+                return false;
+            }
+
+            bucketList.addAll(response.getQuerySampleStatusesResult().getSampleStatusBucketsList());
+            nextPageToken.set(response.getQuerySampleStatusesResult().getNextPageToken());
+            return true;
+        }
+
+        public List<SampleStatusBucket> getSampleStatusBuckets() {
+            return bucketList;
+        }
+
+        public String getNextPageToken() {
+            return nextPageToken.get();
+        }
+    }
+
+    public static class DeleteSampleStatusesResponseObserver
+            extends ApiResponseObserverBase<DeleteSampleStatusesResponse> {
+
+        private final List<Long> deletedCountList = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        protected boolean hasExceptionalResult(DeleteSampleStatusesResponse response) {
+            return response.hasExceptionalResult();
+        }
+
+        @Override
+        protected ExceptionalResult getExceptionalResult(DeleteSampleStatusesResponse response) {
+            return response.getExceptionalResult();
+        }
+
+        @Override
+        protected boolean handleResult(DeleteSampleStatusesResponse response) {
+
+            if (!response.hasDeleteSampleStatusesResult()) {
+                recordFailure(observerName() + " response does not contain DeleteSampleStatusesResult");
+                return false;
+            }
+
+            deletedCountList.add(response.getDeleteSampleStatusesResult().getDeletedCount());
+            return true;
+        }
+
+        public Long getDeletedCount() {
+            if (deletedCountList.isEmpty()) {
+                return null;
+            } else {
+                return deletedCountList.get(0);
+            }
+        }
+    }
+
+    /**
+     * Observer for the server-streaming querySampleStatusesStream(). Unlike the single-response
+     * observers this cannot extend ApiResponseObserverBase (which treats a second response as a
+     * failure): it accumulates buckets across all streamed messages, processed inline because gRPC
+     * delivers stream messages serially and accumulation order matters, and releases its caller at
+     * stream completion, transport error, or the first exceptional message.
+     */
+    public static class QuerySampleStatusesStreamResponseObserver
+            implements StreamObserver<QuerySampleStatusesResponse> {
+
+        private final CountDownLatch finishLatch = new CountDownLatch(1);
+        private final AtomicBoolean isError = new AtomicBoolean(false);
+        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final AtomicReference<ApiResultStatus> apiResultStatus =
+                new AtomicReference<>(ApiResultStatus.NONE);
+        private final List<SampleStatusBucket> bucketList = Collections.synchronizedList(new ArrayList<>());
+
+        public void await() {
+            try {
+                if (!finishLatch.await(ApiResponseObserverBase.DEFAULT_AWAIT_TIMEOUT_SECONDS,
+                        java.util.concurrent.TimeUnit.SECONDS)) {
+                    recordFailure("QuerySampleStatusesStreamResponseObserver timed out waiting for "
+                            + "finishLatch", null);
+                }
+            } catch (InterruptedException e) {
+                recordFailure("QuerySampleStatusesStreamResponseObserver InterruptedException "
+                        + "waiting for finishLatch", null);
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        public boolean isError() {
+            return isError.get();
+        }
+
+        public String getErrorMessage() {
+            return errorMessageList.isEmpty() ? "" : errorMessageList.get(0);
+        }
+
+        public ApiResultStatus getApiResultStatus() {
+            return apiResultStatus.get();
+        }
+
+        public List<SampleStatusBucket> getSampleStatusBuckets() {
+            return bucketList;
+        }
+
+        private void recordFailure(String errorMsg, ApiResultStatus status) {
+            if (status != null) {
+                apiResultStatus.compareAndSet(ApiResultStatus.NONE, status);
+            }
+            isError.set(true);
+            errorMessageList.add(errorMsg);
+            finishLatch.countDown();
+        }
+
+        @Override
+        public void onNext(QuerySampleStatusesResponse response) {
+            if (response.hasExceptionalResult()) {
+                final ExceptionalResult exceptionalResult = response.getExceptionalResult();
+                recordFailure(
+                        "QuerySampleStatusesStreamResponseObserver onNext received exceptional "
+                                + "response: " + exceptionalResult.getMessage(),
+                        ApiResultStatus.fromProto(exceptionalResult.getExceptionalResultStatus()));
+                return;
+            }
+            if (!response.hasQuerySampleStatusesResult()) {
+                recordFailure("QuerySampleStatusesStreamResponseObserver response does not contain "
+                        + "QuerySampleStatusesResult", null);
+                return;
+            }
+            bucketList.addAll(response.getQuerySampleStatusesResult().getSampleStatusBucketsList());
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            recordFailure("QuerySampleStatusesStreamResponseObserver onError: "
+                    + io.grpc.Status.fromThrowable(t), null);
+        }
+
+        @Override
+        public void onCompleted() {
+            finishLatch.countDown();
+        }
+    }
+
+    public SaveSampleStatusesApiResult sendSaveSampleStatuses(
+            SaveSampleStatusesRequest request
+    ) {
+        final DpAnnotationServiceGrpc.DpAnnotationServiceStub asyncStub =
+                DpAnnotationServiceGrpc.newStub(channel);
+
+        final SaveSampleStatusesResponseObserver responseObserver = new SaveSampleStatusesResponseObserver();
+
+        // send request in separate thread to better simulate out of process grpc,
+        // otherwise service handles request in this thread
+        new Thread(() -> {
+            asyncStub.saveSampleStatuses(request, responseObserver);
+        }).start();
+
+        responseObserver.await();
+
+        if (responseObserver.isError()) {
+            return new SaveSampleStatusesApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
+        } else {
+            return new SaveSampleStatusesApiResult(responseObserver.getSavedCount());
+        }
+    }
+
+    /**
+     * Batch upsert of sample statuses.  Each frame assigns statuses in one (domain, layer) to
+     * samples of one or more PVs on a shared time axis; upsert is per individual status keyed by
+     * (pvName, timestamp, domain, layer) and is a FULL REPLACE — re-saving a key with empty
+     * confidence/reasons clears the stored values.  source and modifiedBy are request-scoped
+     * provenance applying to all frames, so batch frames from a single producer per request.  On
+     * success the result carries the total count of individual statuses upserted.
+     */
+    public SaveSampleStatusesApiResult saveSampleStatuses(
+            List<SampleStatusFrame> frames, String source, String modifiedBy
+    ) {
+        final SaveSampleStatusesRequest.Builder requestBuilder = SaveSampleStatusesRequest.newBuilder();
+        if (frames != null) {
+            requestBuilder.addAllFrames(frames);
+        }
+        if (source != null) {
+            requestBuilder.setSource(source);
+        }
+        if (modifiedBy != null) {
+            requestBuilder.setModifiedBy(modifiedBy);
+        }
+        return sendSaveSampleStatuses(requestBuilder.build());
+    }
+
+    /*
+     * Parameters for querySampleStatuses() / querySampleStatusesStream().  beginTime and endTime
+     * are required (half-open [beginTime, endTime)); pvNames, domains and layers are optional
+     * filters where an empty/null list matches all values.  limit is the page size for the unary
+     * method (0 = server default) and the per-message chunk size for the streaming method.
+     * pageToken continues a unary query from a prior result's nextPageToken and must be null/empty
+     * for the streaming method.
+     */
+    public record QuerySampleStatusesParams(
+            Timestamp beginTime,
+            Timestamp endTime,
+            List<String> pvNames,
+            List<String> domains,
+            List<String> layers,
+            int limit,
+            String pageToken
+    ) {
+    }
+
+    public static QuerySampleStatusesRequest buildQuerySampleStatusesRequest(QuerySampleStatusesParams params) {
+
+        final QuerySampleStatusesRequest.Builder requestBuilder = QuerySampleStatusesRequest.newBuilder();
+
+        final TimeRange.Builder timeRangeBuilder = TimeRange.newBuilder();
+        if (params.beginTime() != null) {
+            timeRangeBuilder.setBeginTime(params.beginTime());
+        }
+        if (params.endTime() != null) {
+            timeRangeBuilder.setEndTime(params.endTime());
+        }
+        requestBuilder.setTimeRange(timeRangeBuilder);
+
+        if (params.pvNames() != null) {
+            requestBuilder.addAllPvNames(params.pvNames());
+        }
+        if (params.domains() != null) {
+            requestBuilder.addAllDomains(params.domains());
+        }
+        if (params.layers() != null) {
+            requestBuilder.addAllLayers(params.layers());
+        }
+        if (params.limit() > 0) {
+            requestBuilder.setLimit(params.limit());
+        }
+        if (params.pageToken() != null && !params.pageToken().isBlank()) {
+            requestBuilder.setPageToken(params.pageToken());
+        }
+
+        return requestBuilder.build();
+    }
+
+    public QuerySampleStatusesApiResult sendQuerySampleStatuses(
+            QuerySampleStatusesRequest request
+    ) {
+        final DpAnnotationServiceGrpc.DpAnnotationServiceStub asyncStub =
+                DpAnnotationServiceGrpc.newStub(channel);
+
+        final QuerySampleStatusesResponseObserver responseObserver = new QuerySampleStatusesResponseObserver();
+
+        new Thread(() -> {
+            asyncStub.querySampleStatuses(request, responseObserver);
+        }).start();
+
+        responseObserver.await();
+
+        if (responseObserver.isError()) {
+            return new QuerySampleStatusesApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
+        } else {
+            return new QuerySampleStatusesApiResult(
+                    responseObserver.getSampleStatusBuckets(), responseObserver.getNextPageToken());
+        }
+    }
+
+    /**
+     * Unary sample status query with resumable paging.  Bucket selection is the TimeRange overlap
+     * test and boundary buckets are returned WHOLE, so a returned bucket may contain statuses
+     * outside [beginTime, endTime).  An empty query result is a success with an empty bucket list.
+     * Pass a prior result's nextPageToken as params.pageToken to fetch the next page; an empty
+     * nextPageToken on the result indicates the last page.
+     */
+    public QuerySampleStatusesApiResult querySampleStatuses(
+            QuerySampleStatusesParams params
+    ) {
+        final QuerySampleStatusesRequest request = buildQuerySampleStatusesRequest(params);
+        return sendQuerySampleStatuses(request);
+    }
+
+    public QuerySampleStatusesApiResult sendQuerySampleStatusesStream(
+            QuerySampleStatusesRequest request
+    ) {
+        final DpAnnotationServiceGrpc.DpAnnotationServiceStub asyncStub =
+                DpAnnotationServiceGrpc.newStub(channel);
+
+        final QuerySampleStatusesStreamResponseObserver responseObserver =
+                new QuerySampleStatusesStreamResponseObserver();
+
+        new Thread(() -> {
+            asyncStub.querySampleStatusesStream(request, responseObserver);
+        }).start();
+
+        responseObserver.await();
+
+        if (responseObserver.isError()) {
+            return new QuerySampleStatusesApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
+        } else {
+            // streaming is fire-and-consume: the buckets are the accumulated result of the whole
+            // stream and there is no continuation token
+            return new QuerySampleStatusesApiResult(responseObserver.getSampleStatusBuckets(), "");
+        }
+    }
+
+    /**
+     * Server-streaming sample status query.  Streams to completion and accumulates the buckets of
+     * every message into a single result; params.pageToken must be null/empty (a non-empty token
+     * is rejected by the server).  Use querySampleStatuses() when resumable paging is required.
+     */
+    public QuerySampleStatusesApiResult querySampleStatusesStream(
+            QuerySampleStatusesParams params
+    ) {
+        final QuerySampleStatusesRequest request = buildQuerySampleStatusesRequest(params);
+        return sendQuerySampleStatusesStream(request);
+    }
+
+    /*
+     * Parameters for deleteSampleStatuses().  beginTime, endTime, domain and layer are required —
+     * every delete is scoped to a single producer stream.  pvNames is optional: a null/empty list
+     * is a DELIBERATE WILDCARD deleting the (domain, layer)'s statuses for ALL PVs in the range
+     * (the layer-retirement path).
+     */
+    public record DeleteSampleStatusesParams(
+            Timestamp beginTime,
+            Timestamp endTime,
+            List<String> pvNames,
+            String domain,
+            String layer
+    ) {
+    }
+
+    public static DeleteSampleStatusesRequest buildDeleteSampleStatusesRequest(DeleteSampleStatusesParams params) {
+
+        final DeleteSampleStatusesRequest.Builder requestBuilder = DeleteSampleStatusesRequest.newBuilder();
+
+        final TimeRange.Builder timeRangeBuilder = TimeRange.newBuilder();
+        if (params.beginTime() != null) {
+            timeRangeBuilder.setBeginTime(params.beginTime());
+        }
+        if (params.endTime() != null) {
+            timeRangeBuilder.setEndTime(params.endTime());
+        }
+        requestBuilder.setTimeRange(timeRangeBuilder);
+
+        if (params.pvNames() != null) {
+            requestBuilder.addAllPvNames(params.pvNames());
+        }
+        if (params.domain() != null) {
+            requestBuilder.setDomain(params.domain());
+        }
+        if (params.layer() != null) {
+            requestBuilder.setLayer(params.layer());
+        }
+
+        return requestBuilder.build();
+    }
+
+    public DeleteSampleStatusesApiResult sendDeleteSampleStatuses(
+            DeleteSampleStatusesRequest request
+    ) {
+        final DpAnnotationServiceGrpc.DpAnnotationServiceStub asyncStub =
+                DpAnnotationServiceGrpc.newStub(channel);
+
+        final DeleteSampleStatusesResponseObserver responseObserver = new DeleteSampleStatusesResponseObserver();
+
+        new Thread(() -> {
+            asyncStub.deleteSampleStatuses(request, responseObserver);
+        }).start();
+
+        responseObserver.await();
+
+        if (responseObserver.isError()) {
+            return new DeleteSampleStatusesApiResult(
+                    true, responseObserver.getErrorMessage(), responseObserver.getApiResultStatus());
+        } else {
+            return new DeleteSampleStatusesApiResult(responseObserver.getDeletedCount());
+        }
+    }
+
+    /**
+     * Deletes sample statuses within the half-open range [beginTime, endTime) for a single
+     * required (domain, layer).  Unlike query, deletion is EXACT at the sample axis: only statuses
+     * whose timestamps fall within the range are removed, and the server trims or splits boundary
+     * storage buckets as needed.  A delete matching nothing is a success with deletedCount = 0.
+     */
+    public DeleteSampleStatusesApiResult deleteSampleStatuses(
+            DeleteSampleStatusesParams params
+    ) {
+        final DeleteSampleStatusesRequest request = buildDeleteSampleStatusesRequest(params);
+        return sendDeleteSampleStatuses(request);
     }
 
 }

--- a/src/main/java/com/ospreydcs/dp/client/result/DeleteSampleStatusesApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/DeleteSampleStatusesApiResult.java
@@ -1,0 +1,23 @@
+package com.ospreydcs.dp.client.result;
+
+public class DeleteSampleStatusesApiResult extends ApiResultBase {
+
+    // instance variables
+    public final long deletedCount;
+
+    public DeleteSampleStatusesApiResult(boolean isError, String errorMessage) {
+        super(isError, errorMessage);
+        this.deletedCount = 0;
+    }
+
+    public DeleteSampleStatusesApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.deletedCount = 0;
+    }
+
+    public DeleteSampleStatusesApiResult(long deletedCount) {
+        super(false, "");
+        this.deletedCount = deletedCount;
+    }
+
+}

--- a/src/main/java/com/ospreydcs/dp/client/result/QuerySampleStatusesApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/QuerySampleStatusesApiResult.java
@@ -1,0 +1,36 @@
+package com.ospreydcs.dp.client.result;
+
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusBucket;
+
+import java.util.List;
+
+/**
+ * Result of querySampleStatuses() / querySampleStatusesStream(). For the unary method,
+ * nextPageToken is non-empty when more pages are available; for the streaming method the buckets
+ * are the accumulated result of the whole stream and nextPageToken is always empty.
+ */
+public class QuerySampleStatusesApiResult extends ApiResultBase {
+
+    // instance variables
+    public final List<SampleStatusBucket> sampleStatusBuckets;
+    public final String nextPageToken;
+
+    public QuerySampleStatusesApiResult(boolean isError, String errorMessage) {
+        super(isError, errorMessage);
+        this.sampleStatusBuckets = null;
+        this.nextPageToken = "";
+    }
+
+    public QuerySampleStatusesApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.sampleStatusBuckets = null;
+        this.nextPageToken = "";
+    }
+
+    public QuerySampleStatusesApiResult(List<SampleStatusBucket> sampleStatusBuckets, String nextPageToken) {
+        super(false, "");
+        this.sampleStatusBuckets = sampleStatusBuckets;
+        this.nextPageToken = nextPageToken != null ? nextPageToken : "";
+    }
+
+}

--- a/src/main/java/com/ospreydcs/dp/client/result/SaveSampleStatusesApiResult.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/SaveSampleStatusesApiResult.java
@@ -1,0 +1,23 @@
+package com.ospreydcs.dp.client.result;
+
+public class SaveSampleStatusesApiResult extends ApiResultBase {
+
+    // instance variables
+    public final long savedCount;
+
+    public SaveSampleStatusesApiResult(boolean isError, String errorMessage) {
+        super(isError, errorMessage);
+        this.savedCount = 0;
+    }
+
+    public SaveSampleStatusesApiResult(boolean isError, String errorMessage, ApiResultStatus apiResultStatus) {
+        super(isError, errorMessage, apiResultStatus);
+        this.savedCount = 0;
+    }
+
+    public SaveSampleStatusesApiResult(long savedCount) {
+        super(false, "");
+        this.savedCount = savedCount;
+    }
+
+}

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/SampleStatusValidationUtility.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/SampleStatusValidationUtility.java
@@ -1,0 +1,246 @@
+package com.ospreydcs.dp.service.annotation.handler;
+
+import com.ospreydcs.dp.grpc.v1.annotation.DeleteSampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.SaveSampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.common.DataTimestamps;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusColumn;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusFrame;
+import com.ospreydcs.dp.grpc.v1.common.SamplingClock;
+import com.ospreydcs.dp.grpc.v1.common.TimeRange;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.service.common.model.ResultStatus;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Validation for the Sample Status API requests, per the contract in annotation.proto. Requests
+ * are validated and rejected as a whole: nothing is persisted on rejection.
+ *
+ * <p>Note: unlike ingestion's data frames, sample status frames have no maximum time span — sparse
+ * labeling over an arbitrarily wide range (e.g. a TimestampList naming a handful of suspect
+ * points across months) is first-class. The only size limit is the configurable cap on total
+ * statuses per request.
+ */
+public class SampleStatusValidationUtility {
+
+    public static ResultStatus validateSaveSampleStatusesRequest(
+            SaveSampleStatusesRequest request,
+            long maxStatusesPerRequest
+    ) {
+        if (request.getFramesList().isEmpty()) {
+            return new ResultStatus(true,
+                    "SaveSampleStatusesRequest.frames must contain at least one SampleStatusFrame");
+        }
+
+        long totalStatuses = 0;
+        for (int frameIndex = 0; frameIndex < request.getFramesCount(); frameIndex++) {
+            final SampleStatusFrame frame = request.getFrames(frameIndex);
+            final String framePath = "SaveSampleStatusesRequest.frames[" + frameIndex + "]";
+
+            if (frame.getDomain().isBlank()) {
+                return new ResultStatus(true, framePath + ".domain must be specified");
+            }
+            if (frame.getLayer().isBlank()) {
+                return new ResultStatus(true, framePath + ".layer must be specified");
+            }
+            if (!frame.hasDataTimestamps()) {
+                return new ResultStatus(true, framePath + ".dataTimestamps must be provided");
+            }
+
+            final ResultStatus timestampsStatus =
+                    validateFrameDataTimestamps(framePath, frame.getDataTimestamps());
+            if (timestampsStatus.isError) {
+                return timestampsStatus;
+            }
+            final int timestampCount = timestampCount(frame.getDataTimestamps());
+
+            if (frame.getStatusColumnsList().isEmpty()) {
+                return new ResultStatus(true, framePath + " must contain at least one statusColumn");
+            }
+
+            final Set<String> framePvNames = new HashSet<>();
+            for (int columnIndex = 0; columnIndex < frame.getStatusColumnsCount(); columnIndex++) {
+                final SampleStatusColumn column = frame.getStatusColumns(columnIndex);
+                final String columnPath = framePath + ".statusColumns[" + columnIndex + "]";
+
+                if (column.getPvName().isBlank()) {
+                    return new ResultStatus(true, columnPath + ".pvName must be specified");
+                }
+                if (!framePvNames.add(column.getPvName())) {
+                    return new ResultStatus(true, framePath
+                            + " contains more than one statusColumn for PV: " + column.getPvName());
+                }
+                if (column.getStatusCodesCount() != timestampCount) {
+                    return new ResultStatus(true, columnPath + ".statusCodes.length mismatch: expected "
+                            + timestampCount + ", got: " + column.getStatusCodesCount());
+                }
+                if (column.getConfidenceCount() != 0 && column.getConfidenceCount() != timestampCount) {
+                    return new ResultStatus(true, columnPath + ".confidence must be empty or contain "
+                            + "exactly one entry per timestamp: expected 0 or " + timestampCount
+                            + ", got: " + column.getConfidenceCount());
+                }
+                if (column.getReasonsCount() != 0 && column.getReasonsCount() != timestampCount) {
+                    return new ResultStatus(true, columnPath + ".reasons must be empty or contain "
+                            + "exactly one entry per timestamp: expected 0 or " + timestampCount
+                            + ", got: " + column.getReasonsCount());
+                }
+            }
+
+            totalStatuses += (long) timestampCount * frame.getStatusColumnsCount();
+        }
+
+        if (totalStatuses > maxStatusesPerRequest) {
+            return new ResultStatus(true, "SaveSampleStatusesRequest exceeds maximum statuses per "
+                    + "request: " + totalStatuses + " > " + maxStatusesPerRequest);
+        }
+
+        return new ResultStatus(false, "");
+    }
+
+    private static int timestampCount(DataTimestamps dataTimestamps) {
+        return switch (dataTimestamps.getValueCase()) {
+            case SAMPLINGCLOCK -> dataTimestamps.getSamplingClock().getCount();
+            case TIMESTAMPLIST -> dataTimestamps.getTimestampList().getTimestampsCount();
+            default -> 0;
+        };
+    }
+
+    private static ResultStatus validateFrameDataTimestamps(String framePath, DataTimestamps dataTimestamps) {
+
+        switch (dataTimestamps.getValueCase()) {
+
+            case SAMPLINGCLOCK -> {
+                final SamplingClock clock = dataTimestamps.getSamplingClock();
+                if (clock.getCount() < 1) {
+                    return new ResultStatus(true, framePath
+                            + ".dataTimestamps.samplingClock.count must be >= 1, got: " + clock.getCount());
+                }
+                if (clock.getPeriodNanos() <= 0) {
+                    return new ResultStatus(true, framePath
+                            + ".dataTimestamps.samplingClock.periodNanos must be > 0, got: "
+                            + clock.getPeriodNanos());
+                }
+                if (!clock.hasStartTime()) {
+                    return new ResultStatus(true, framePath
+                            + ".dataTimestamps.samplingClock.startTime must be provided");
+                }
+                final ResultStatus startStatus = validateTimestamp(
+                        framePath + ".dataTimestamps.samplingClock.startTime", clock.getStartTime());
+                if (startStatus.isError) {
+                    return startStatus;
+                }
+                // reject axes whose epoch-nanos arithmetic would overflow
+                try {
+                    final long startNanos = Math.addExact(
+                            Math.multiplyExact(clock.getStartTime().getEpochSeconds(), 1_000_000_000L),
+                            clock.getStartTime().getNanoseconds());
+                    Math.addExact(startNanos, Math.multiplyExact((long) clock.getCount() - 1, clock.getPeriodNanos()));
+                } catch (ArithmeticException ex) {
+                    return new ResultStatus(true, framePath
+                            + ".dataTimestamps.samplingClock time axis exceeds representable range");
+                }
+            }
+
+            case TIMESTAMPLIST -> {
+                final List<Timestamp> timestamps = dataTimestamps.getTimestampList().getTimestampsList();
+                if (timestamps.isEmpty()) {
+                    return new ResultStatus(true, framePath
+                            + ".dataTimestamps.timestampList.timestamps cannot be empty");
+                }
+                Timestamp previous = null;
+                for (int i = 0; i < timestamps.size(); i++) {
+                    final Timestamp current = timestamps.get(i);
+                    final ResultStatus timestampStatus = validateTimestamp(
+                            framePath + ".dataTimestamps.timestampList.timestamps[" + i + "]", current);
+                    if (timestampStatus.isError) {
+                        return timestampStatus;
+                    }
+                    // strictly increasing: equal timestamps would collapse identity keys within the frame
+                    if (previous != null
+                            && (current.getEpochSeconds() < previous.getEpochSeconds()
+                            || (current.getEpochSeconds() == previous.getEpochSeconds()
+                            && current.getNanoseconds() <= previous.getNanoseconds()))) {
+                        return new ResultStatus(true, framePath
+                                + ".dataTimestamps.timestampList.timestamps[" + i + "] is not strictly increasing: "
+                                + "previous=" + previous.getEpochSeconds() + "." + previous.getNanoseconds()
+                                + ", current=" + current.getEpochSeconds() + "." + current.getNanoseconds());
+                    }
+                    previous = current;
+                }
+            }
+
+            default -> {
+                return new ResultStatus(true, framePath
+                        + ".dataTimestamps must specify either SamplingClock or TimestampList");
+            }
+        }
+
+        return new ResultStatus(false, "");
+    }
+
+    public static ResultStatus validateQuerySampleStatusesRequest(QuerySampleStatusesRequest request) {
+        return validateTimeRange("QuerySampleStatusesRequest", request.hasTimeRange(), request.getTimeRange());
+    }
+
+    public static ResultStatus validateDeleteSampleStatusesRequest(DeleteSampleStatusesRequest request) {
+
+        final ResultStatus timeRangeStatus =
+                validateTimeRange("DeleteSampleStatusesRequest", request.hasTimeRange(), request.getTimeRange());
+        if (timeRangeStatus.isError) {
+            return timeRangeStatus;
+        }
+        if (request.getDomain().isBlank()) {
+            return new ResultStatus(true, "DeleteSampleStatusesRequest.domain must be specified");
+        }
+        if (request.getLayer().isBlank()) {
+            return new ResultStatus(true, "DeleteSampleStatusesRequest.layer must be specified");
+        }
+        return new ResultStatus(false, "");
+    }
+
+    private static ResultStatus validateTimeRange(String requestPath, boolean hasTimeRange, TimeRange timeRange) {
+
+        if (!hasTimeRange) {
+            return new ResultStatus(true, requestPath + ".timeRange must be provided");
+        }
+        if (!timeRange.hasBeginTime()) {
+            return new ResultStatus(true, requestPath + ".timeRange.beginTime must be provided");
+        }
+        if (!timeRange.hasEndTime()) {
+            return new ResultStatus(true, requestPath + ".timeRange.endTime must be provided");
+        }
+        final ResultStatus beginStatus =
+                validateTimestamp(requestPath + ".timeRange.beginTime", timeRange.getBeginTime());
+        if (beginStatus.isError) {
+            return beginStatus;
+        }
+        final ResultStatus endStatus =
+                validateTimestamp(requestPath + ".timeRange.endTime", timeRange.getEndTime());
+        if (endStatus.isError) {
+            return endStatus;
+        }
+
+        final Timestamp begin = timeRange.getBeginTime();
+        final Timestamp end = timeRange.getEndTime();
+        final boolean beginBeforeEnd = begin.getEpochSeconds() < end.getEpochSeconds()
+                || (begin.getEpochSeconds() == end.getEpochSeconds()
+                && begin.getNanoseconds() < end.getNanoseconds());
+        if (!beginBeforeEnd) {
+            return new ResultStatus(true, requestPath + ".timeRange.beginTime must be before endTime");
+        }
+        return new ResultStatus(false, "");
+    }
+
+    private static ResultStatus validateTimestamp(String fieldPath, Timestamp timestamp) {
+        if (timestamp.getEpochSeconds() < 0
+                || timestamp.getNanoseconds() < 0
+                || timestamp.getNanoseconds() >= 1_000_000_000) {
+            return new ResultStatus(true, fieldPath + " has invalid values: seconds="
+                    + timestamp.getEpochSeconds() + ", nanos=" + timestamp.getNanoseconds());
+        }
+        return new ResultStatus(false, "");
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/SampleStatusValidationUtility.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/SampleStatusValidationUtility.java
@@ -26,6 +26,13 @@ import java.util.Set;
  */
 public class SampleStatusValidationUtility {
 
+    /**
+     * Largest epochSeconds whose conversion to signed 64-bit epoch-nanos does not overflow
+     * (~year 2262). Every Sample Status timestamp is validated against this, because the storage
+     * and query paths key on epoch-nanos scalars throughout.
+     */
+    static final long MAX_EPOCH_SECONDS = Long.MAX_VALUE / 1_000_000_000L;
+
     public static ResultStatus validateSaveSampleStatusesRequest(
             SaveSampleStatusesRequest request,
             long maxStatusesPerRequest
@@ -132,12 +139,12 @@ public class SampleStatusValidationUtility {
                 if (startStatus.isError) {
                     return startStatus;
                 }
-                // reject axes whose epoch-nanos arithmetic would overflow
+                // startTime itself is already range-checked by validateTimestamp above; the axis
+                // can still run off the end of the epoch-nanos range at its last sample
                 try {
-                    final long startNanos = Math.addExact(
-                            Math.multiplyExact(clock.getStartTime().getEpochSeconds(), 1_000_000_000L),
-                            clock.getStartTime().getNanoseconds());
-                    Math.addExact(startNanos, Math.multiplyExact((long) clock.getCount() - 1, clock.getPeriodNanos()));
+                    Math.addExact(
+                            validatedEpochNanos(clock.getStartTime()),
+                            Math.multiplyExact((long) clock.getCount() - 1, clock.getPeriodNanos()));
                 } catch (ArithmeticException ex) {
                     return new ResultStatus(true, framePath
                             + ".dataTimestamps.samplingClock time axis exceeds representable range");
@@ -234,6 +241,16 @@ public class SampleStatusValidationUtility {
         return new ResultStatus(false, "");
     }
 
+    /**
+     * Validates a single timestamp's field ranges and its representability as epoch-nanos.
+     *
+     * <p>The epoch-nanos check is not cosmetic: the storage and query paths convert every
+     * timestamp to a signed 64-bit epoch-nanos scalar (firstTimeNanos/lastTimeNanos, the overlap
+     * predicates, the keyset paging token). An epochSeconds above
+     * {@link #MAX_EPOCH_SECONDS} (~year 2262) silently wraps negative, which would write a
+     * document that no subsequent overlap query can find, or build a time range that matches the
+     * wrong set. Rejecting here keeps that class of silent wrong answer out of the collection.
+     */
     private static ResultStatus validateTimestamp(String fieldPath, Timestamp timestamp) {
         if (timestamp.getEpochSeconds() < 0
                 || timestamp.getNanoseconds() < 0
@@ -241,6 +258,18 @@ public class SampleStatusValidationUtility {
             return new ResultStatus(true, fieldPath + " has invalid values: seconds="
                     + timestamp.getEpochSeconds() + ", nanos=" + timestamp.getNanoseconds());
         }
+        if (timestamp.getEpochSeconds() > MAX_EPOCH_SECONDS) {
+            return new ResultStatus(true, fieldPath + " exceeds representable epoch-nanos range: seconds="
+                    + timestamp.getEpochSeconds() + ", maximum=" + MAX_EPOCH_SECONDS);
+        }
         return new ResultStatus(false, "");
+    }
+
+    /**
+     * Converts a validated timestamp to epoch-nanos. Only safe on a timestamp that has passed
+     * {@link #validateTimestamp}.
+     */
+    private static long validatedEpochNanos(Timestamp timestamp) {
+        return timestamp.getEpochSeconds() * 1_000_000_000L + timestamp.getNanoseconds();
     }
 }

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/interfaces/AnnotationHandlerInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/interfaces/AnnotationHandlerInterface.java
@@ -77,4 +77,20 @@ public interface AnnotationHandlerInterface {
     void handleGetActiveConfigurations(
             GetActiveConfigurationsRequest request,
             StreamObserver<GetActiveConfigurationsResponse> responseObserver);
+
+    void handleSaveSampleStatuses(
+            SaveSampleStatusesRequest request,
+            StreamObserver<SaveSampleStatusesResponse> responseObserver);
+
+    void handleQuerySampleStatuses(
+            QuerySampleStatusesRequest request,
+            StreamObserver<QuerySampleStatusesResponse> responseObserver);
+
+    void handleQuerySampleStatusesStream(
+            QuerySampleStatusesRequest request,
+            StreamObserver<QuerySampleStatusesResponse> responseObserver);
+
+    void handleDeleteSampleStatuses(
+            DeleteSampleStatusesRequest request,
+            StreamObserver<DeleteSampleStatusesResponse> responseObserver);
 }

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/model/SampleStatusPageToken.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/model/SampleStatusPageToken.java
@@ -1,0 +1,56 @@
+package com.ospreydcs.dp.service.annotation.handler.model;
+
+import org.bson.Document;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Keyset page token for querySampleStatuses: the sort position of the last bucket returned, in
+ * result order (pvName, domain, layer, firstTimeNanos). Resuming filters strictly greater in
+ * tuple order, so page boundaries always fall between complete buckets and remain stable while
+ * the collection is rewritten in place (carves, splits) — a skip-offset token would drift.
+ *
+ * <p>The position is unique: two documents for the same (pvName, domain, layer) sharing
+ * firstTimeNanos would both assert the identity key of that first timestamp, which the storage
+ * invariant forbids.
+ *
+ * <p>Unparseable tokens decode to null and are rejected by the caller, per the API contract
+ * (unlike the metadata APIs' skip-offset tokens, which silently reset to the first page).
+ */
+public record SampleStatusPageToken(String pvName, String domain, String layer, long firstTimeNanos) {
+
+    private static final String KEY_PV_NAME = "pvName";
+    private static final String KEY_DOMAIN = "domain";
+    private static final String KEY_LAYER = "layer";
+    private static final String KEY_FIRST_TIME_NANOS = "firstTimeNanos";
+
+    public String encode() {
+        final Document document = new Document()
+                .append(KEY_PV_NAME, pvName)
+                .append(KEY_DOMAIN, domain)
+                .append(KEY_LAYER, layer)
+                .append(KEY_FIRST_TIME_NANOS, firstTimeNanos);
+        return Base64.getEncoder().encodeToString(document.toJson().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Decodes a token issued by {@link #encode()}, returning null for anything unparseable.
+     */
+    public static SampleStatusPageToken decode(String token) {
+        try {
+            final Document document = Document.parse(
+                    new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8));
+            final String pvName = document.getString(KEY_PV_NAME);
+            final String domain = document.getString(KEY_DOMAIN);
+            final String layer = document.getString(KEY_LAYER);
+            final Number firstTimeNanos = (Number) document.get(KEY_FIRST_TIME_NANOS);
+            if (pvName == null || domain == null || layer == null || firstTimeNanos == null) {
+                return null;
+            }
+            return new SampleStatusPageToken(pvName, domain, layer, firstTimeNanos.longValue());
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/MongoAnnotationHandler.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/MongoAnnotationHandler.java
@@ -27,6 +27,34 @@ public class MongoAnnotationHandler extends QueueHandlerBase implements Annotati
     // configuration
     public static final String CFG_KEY_NUM_WORKERS = "AnnotationHandler.numWorkers";
     public static final int DEFAULT_NUM_WORKERS = 7;
+    public static final String CFG_KEY_SAMPLE_STATUS_QUERY_DEFAULT_PAGE_SIZE =
+            "AnnotationHandler.sampleStatusQueryDefaultPageSize";
+    public static final int DEFAULT_SAMPLE_STATUS_QUERY_DEFAULT_PAGE_SIZE = 10_000;
+    public static final String CFG_KEY_SAMPLE_STATUS_QUERY_MAX_PAGE_SIZE =
+            "AnnotationHandler.sampleStatusQueryMaxPageSize";
+    public static final int DEFAULT_SAMPLE_STATUS_QUERY_MAX_PAGE_SIZE = 100_000;
+    public static final String CFG_KEY_SAMPLE_STATUS_SAVE_MAX_STATUSES =
+            "AnnotationHandler.sampleStatusSaveMaxStatuses";
+    public static final long DEFAULT_SAMPLE_STATUS_SAVE_MAX_STATUSES = 1_000_000L;
+
+    /**
+     * Resolves the effective page size for a sample status query: a requested limit of 0 selects
+     * the configured default, and a larger request is silently clamped to the configured maximum
+     * (consistent with Query API V2 page-size handling).
+     */
+    public static int sampleStatusQueryPageSize(int requestedLimit) {
+        final int defaultPageSize = configMgr().getConfigInteger(
+                CFG_KEY_SAMPLE_STATUS_QUERY_DEFAULT_PAGE_SIZE, DEFAULT_SAMPLE_STATUS_QUERY_DEFAULT_PAGE_SIZE);
+        final int maxPageSize = configMgr().getConfigInteger(
+                CFG_KEY_SAMPLE_STATUS_QUERY_MAX_PAGE_SIZE, DEFAULT_SAMPLE_STATUS_QUERY_MAX_PAGE_SIZE);
+        final int limit = requestedLimit > 0 ? requestedLimit : defaultPageSize;
+        return Math.min(limit, maxPageSize);
+    }
+
+    public static long sampleStatusSaveMaxStatuses() {
+        return configMgr().getConfigLong(
+                CFG_KEY_SAMPLE_STATUS_SAVE_MAX_STATUSES, DEFAULT_SAMPLE_STATUS_SAVE_MAX_STATUSES);
+    }
 
     // instance variables
     private final MongoAnnotationClientInterface mongoAnnotationClient;
@@ -490,6 +518,78 @@ public class MongoAnnotationHandler extends QueueHandlerBase implements Annotati
                 new GetActiveConfigurationsJob(request, responseObserver, mongoAnnotationClient);
 
         logger.debug("adding GetActiveConfigurationsJob id: {} to queue", responseObserver.hashCode());
+
+        try {
+            requestQueue.put(job);
+        } catch (InterruptedException e) {
+            logger.error("InterruptedException waiting for requestQueue.put");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void handleSaveSampleStatuses(
+            SaveSampleStatusesRequest request,
+            StreamObserver<SaveSampleStatusesResponse> responseObserver
+    ) {
+        final SaveSampleStatusesJob job =
+                new SaveSampleStatusesJob(request, responseObserver, mongoAnnotationClient);
+
+        logger.debug("adding SaveSampleStatusesJob id: {} to queue", responseObserver.hashCode());
+
+        try {
+            requestQueue.put(job);
+        } catch (InterruptedException e) {
+            logger.error("InterruptedException waiting for requestQueue.put");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void handleQuerySampleStatuses(
+            QuerySampleStatusesRequest request,
+            StreamObserver<QuerySampleStatusesResponse> responseObserver
+    ) {
+        final QuerySampleStatusesJob job =
+                new QuerySampleStatusesJob(request, responseObserver, mongoAnnotationClient);
+
+        logger.debug("adding QuerySampleStatusesJob id: {} to queue", responseObserver.hashCode());
+
+        try {
+            requestQueue.put(job);
+        } catch (InterruptedException e) {
+            logger.error("InterruptedException waiting for requestQueue.put");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void handleQuerySampleStatusesStream(
+            QuerySampleStatusesRequest request,
+            StreamObserver<QuerySampleStatusesResponse> responseObserver
+    ) {
+        final QuerySampleStatusesStreamJob job =
+                new QuerySampleStatusesStreamJob(request, responseObserver, mongoAnnotationClient);
+
+        logger.debug("adding QuerySampleStatusesStreamJob id: {} to queue", responseObserver.hashCode());
+
+        try {
+            requestQueue.put(job);
+        } catch (InterruptedException e) {
+            logger.error("InterruptedException waiting for requestQueue.put");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void handleDeleteSampleStatuses(
+            DeleteSampleStatusesRequest request,
+            StreamObserver<DeleteSampleStatusesResponse> responseObserver
+    ) {
+        final DeleteSampleStatusesJob job =
+                new DeleteSampleStatusesJob(request, responseObserver, mongoAnnotationClient);
+
+        logger.debug("adding DeleteSampleStatusesJob id: {} to queue", responseObserver.hashCode());
 
         try {
             requestQueue.put(job);

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/client/MongoAnnotationClientInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/client/MongoAnnotationClientInterface.java
@@ -1,11 +1,15 @@
 package com.ospreydcs.dp.service.annotation.handler.mongo.client;
 
 import com.mongodb.client.MongoCursor;
+import com.ospreydcs.dp.grpc.v1.annotation.DeleteSampleStatusesRequest;
 import com.ospreydcs.dp.grpc.v1.annotation.QueryAnnotationsRequest;
 import com.ospreydcs.dp.grpc.v1.annotation.QueryConfigurationActivationsRequest;
 import com.ospreydcs.dp.grpc.v1.annotation.QueryConfigurationsRequest;
 import com.ospreydcs.dp.grpc.v1.annotation.QueryDataSetsRequest;
 import com.ospreydcs.dp.grpc.v1.annotation.QueryPvMetadataRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.SaveSampleStatusesRequest;
+import com.ospreydcs.dp.service.annotation.handler.model.SampleStatusPageToken;
 import com.ospreydcs.dp.service.common.bson.annotation.AnnotationDocument;
 import com.ospreydcs.dp.service.common.bson.calculations.CalculationsDocument;
 import com.ospreydcs.dp.service.common.bson.configuration.ConfigurationActivationDocument;
@@ -14,10 +18,12 @@ import com.ospreydcs.dp.service.common.bson.dataset.DataSetDocument;
 import com.ospreydcs.dp.service.common.bson.pvmetadata.PvMetadataDocument;
 import com.ospreydcs.dp.service.common.model.ConfigurationActivationQueryResult;
 import com.ospreydcs.dp.service.common.model.ConfigurationQueryResult;
+import com.ospreydcs.dp.service.common.model.MongoCountResult;
 import com.ospreydcs.dp.service.common.model.MongoDeleteResult;
 import com.ospreydcs.dp.service.common.model.MongoInsertOneResult;
 import com.ospreydcs.dp.service.common.model.MongoSaveResult;
 import com.ospreydcs.dp.service.common.model.PvMetadataQueryResult;
+import com.ospreydcs.dp.service.common.model.SampleStatusQueryResult;
 
 import java.time.Instant;
 
@@ -71,4 +77,11 @@ public interface MongoAnnotationClientInterface {
     MongoDeleteResult deleteConfigurationActivationByCompositeKey(String configurationName, Instant startTime);
 
     ConfigurationActivationQueryResult getActiveConfigurations(Instant timestamp);
+
+    MongoCountResult saveSampleStatuses(SaveSampleStatusesRequest request);
+
+    SampleStatusQueryResult executeQuerySampleStatuses(
+            QuerySampleStatusesRequest request, int limit, SampleStatusPageToken position);
+
+    MongoCountResult deleteSampleStatuses(DeleteSampleStatusesRequest request);
 }

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/client/MongoSyncAnnotationClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/client/MongoSyncAnnotationClient.java
@@ -8,11 +8,17 @@ import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.InsertOneResult;
 import com.mongodb.client.result.UpdateResult;
+import com.ospreydcs.dp.grpc.v1.annotation.DeleteSampleStatusesRequest;
 import com.ospreydcs.dp.grpc.v1.annotation.QueryAnnotationsRequest;
 import com.ospreydcs.dp.grpc.v1.annotation.QueryConfigurationActivationsRequest;
 import com.ospreydcs.dp.grpc.v1.annotation.QueryConfigurationsRequest;
 import com.ospreydcs.dp.grpc.v1.annotation.QueryDataSetsRequest;
 import com.ospreydcs.dp.grpc.v1.annotation.QueryPvMetadataRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.SaveSampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusColumn;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusFrame;
+import com.ospreydcs.dp.service.annotation.handler.model.SampleStatusPageToken;
 import com.ospreydcs.dp.service.common.bson.BsonConstants;
 import com.ospreydcs.dp.service.common.bson.annotation.AnnotationDocument;
 import com.ospreydcs.dp.service.common.bson.calculations.CalculationsDocument;
@@ -20,12 +26,17 @@ import com.ospreydcs.dp.service.common.bson.dataset.DataSetDocument;
 import com.ospreydcs.dp.service.common.bson.configuration.ConfigurationActivationDocument;
 import com.ospreydcs.dp.service.common.bson.configuration.ConfigurationDocument;
 import com.ospreydcs.dp.service.common.bson.pvmetadata.PvMetadataDocument;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusBucketDocument;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusDocumentUtility;
+import com.ospreydcs.dp.service.common.exception.DpException;
 import com.ospreydcs.dp.service.common.model.ConfigurationActivationQueryResult;
 import com.ospreydcs.dp.service.common.model.ConfigurationQueryResult;
+import com.ospreydcs.dp.service.common.model.MongoCountResult;
 import com.ospreydcs.dp.service.common.model.MongoDeleteResult;
 import com.ospreydcs.dp.service.common.model.MongoInsertOneResult;
 import com.ospreydcs.dp.service.common.model.MongoSaveResult;
 import com.ospreydcs.dp.service.common.model.PvMetadataQueryResult;
+import com.ospreydcs.dp.service.common.model.SampleStatusQueryResult;
 import com.ospreydcs.dp.service.common.mongo.MongoQueryFilterBuilder;
 import com.ospreydcs.dp.service.common.mongo.MongoSyncClient;
 import org.apache.logging.log4j.LogManager;
@@ -37,7 +48,9 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.mongodb.client.model.Filters.*;
@@ -1237,6 +1250,240 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
             logger.error("getActiveConfigurations: mongo exception: {}", ex.getMessage());
             return null;
         }
+    }
+
+    // =========================================================
+    // Sample Status
+    // =========================================================
+
+    /**
+     * Carve-and-insert upsert: for each incoming column, exactly-colliding timestamps are carved
+     * out of existing overlapping documents (maintaining the invariant that no two documents
+     * assert the same (pvName, timestamp, domain, layer) identity key), then the incoming column
+     * is inserted as a new document preserving its axis representation. Existing documents with
+     * overlapping spans but no colliding timestamps are left untouched, provenance intact.
+     *
+     * <p>Carve rewrites happen before the insert, so a mid-write failure can lose replaced
+     * statuses but never leaves two documents asserting the same key. Partial persistence on
+     * error is documented API behavior; the returned count reflects the statuses persisted before
+     * the failure.
+     */
+    @Override
+    public MongoCountResult saveSampleStatuses(SaveSampleStatusesRequest request) {
+
+        final Instant now = Instant.now();
+        long savedCount = 0;
+
+        // frames processed in request order so a later frame's write wins on duplicate keys
+        for (SampleStatusFrame frame : request.getFramesList()) {
+
+            final List<Long> frameTimestamps =
+                    SampleStatusDocumentUtility.timestampNanosList(frame.getDataTimestamps());
+            final Set<Long> frameTimestampSet = new HashSet<>(frameTimestamps);
+            final long frameFirstNanos = frameTimestamps.get(0);
+            final long frameLastNanos = frameTimestamps.get(frameTimestamps.size() - 1);
+
+            for (SampleStatusColumn column : frame.getStatusColumnsList()) {
+
+                // Find existing documents overlapping the incoming span for this identity prefix.
+                // A Mongo error here must abort the save rather than be read as "no overlap",
+                // which would insert colliding documents and violate the storage invariant.
+                final List<SampleStatusBucketDocument> overlappingDocuments = new ArrayList<>();
+                try {
+                    mongoCollectionSampleStatusBuckets.find(and(
+                            eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_PV_NAME, column.getPvName()),
+                            eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_DOMAIN, frame.getDomain()),
+                            eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_LAYER, frame.getLayer()),
+                            lte(BsonConstants.BSON_KEY_SAMPLE_STATUS_FIRST_TIME_NANOS, frameLastNanos),
+                            gte(BsonConstants.BSON_KEY_SAMPLE_STATUS_LAST_TIME_NANOS, frameFirstNanos)
+                    )).into(overlappingDocuments);
+                } catch (MongoException ex) {
+                    final String errorMsg = "MongoException querying overlapping sample status documents: "
+                            + ex.getMessage();
+                    logger.error("saveSampleStatuses overlap query error: {}", ex.getMessage(), ex);
+                    return new MongoCountResult(true, errorMsg, savedCount);
+                }
+
+                try {
+                    for (SampleStatusBucketDocument existingDocument : overlappingDocuments) {
+                        final SampleStatusDocumentUtility.RemovalResult removal =
+                                SampleStatusDocumentUtility.removeTimestamps(existingDocument, frameTimestampSet);
+                        if (removal.removedCount() == 0) {
+                            continue;
+                        }
+                        mongoCollectionSampleStatusBuckets.deleteOne(
+                                eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_ID, existingDocument.getId()));
+                        for (SampleStatusBucketDocument replacement : removal.replacementDocuments()) {
+                            // rewritten documents take the incoming save's provenance and a fresh
+                            // updatedTime ("most recent save affecting the bucket")
+                            replacement.setSource(request.getSource().isBlank() ? null : request.getSource());
+                            replacement.setModifiedBy(
+                                    request.getModifiedBy().isBlank() ? null : request.getModifiedBy());
+                            replacement.setUpdatedTime(now);
+                            mongoCollectionSampleStatusBuckets.insertOne(replacement);
+                        }
+                    }
+
+                    final SampleStatusBucketDocument newDocument =
+                            SampleStatusBucketDocument.fromSampleStatusColumn(
+                                    frame.getDomain(),
+                                    frame.getLayer(),
+                                    frame.getDataTimestamps(),
+                                    column,
+                                    request.getSource(),
+                                    request.getModifiedBy(),
+                                    now);
+                    mongoCollectionSampleStatusBuckets.insertOne(newDocument);
+
+                } catch (MongoException | DpException ex) {
+                    final String errorMsg = "error writing sample status documents for PV: "
+                            + column.getPvName() + ": " + ex.getMessage();
+                    logger.error("saveSampleStatuses write error: {}", ex.getMessage(), ex);
+                    return new MongoCountResult(true, errorMsg, savedCount);
+                }
+
+                savedCount += frameTimestamps.size();
+            }
+        }
+
+        return new MongoCountResult(false, "", savedCount);
+    }
+
+    /**
+     * Filter resuming a keyset-paged sample status query strictly after the given sort position
+     * in (pvName, domain, layer, firstTimeNanos) tuple order.
+     */
+    private static Bson sampleStatusResumeFilter(SampleStatusPageToken position) {
+        return or(
+                gt(BsonConstants.BSON_KEY_SAMPLE_STATUS_PV_NAME, position.pvName()),
+                and(
+                        eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_PV_NAME, position.pvName()),
+                        gt(BsonConstants.BSON_KEY_SAMPLE_STATUS_DOMAIN, position.domain())),
+                and(
+                        eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_PV_NAME, position.pvName()),
+                        eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_DOMAIN, position.domain()),
+                        gt(BsonConstants.BSON_KEY_SAMPLE_STATUS_LAYER, position.layer())),
+                and(
+                        eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_PV_NAME, position.pvName()),
+                        eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_DOMAIN, position.domain()),
+                        eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_LAYER, position.layer()),
+                        gt(BsonConstants.BSON_KEY_SAMPLE_STATUS_FIRST_TIME_NANOS, position.firstTimeNanos())));
+    }
+
+    @Override
+    public SampleStatusQueryResult executeQuerySampleStatuses(
+            QuerySampleStatusesRequest request,
+            int limit,
+            SampleStatusPageToken position
+    ) {
+        final long beginNanos =
+                SampleStatusDocumentUtility.timestampNanos(request.getTimeRange().getBeginTime());
+        final long endNanos =
+                SampleStatusDocumentUtility.timestampNanos(request.getTimeRange().getEndTime());
+
+        final List<Bson> filters = new ArrayList<>();
+        // TimeRange overlap test: firstTime < endTime AND lastTime >= beginTime; boundary
+        // documents are returned whole (not trimmed), matching queryBuckets
+        filters.add(lt(BsonConstants.BSON_KEY_SAMPLE_STATUS_FIRST_TIME_NANOS, endNanos));
+        filters.add(gte(BsonConstants.BSON_KEY_SAMPLE_STATUS_LAST_TIME_NANOS, beginNanos));
+        // filter fields combine with AND across fields, OR within a field; empty list = match all
+        if (!request.getPvNamesList().isEmpty()) {
+            filters.add(in(BsonConstants.BSON_KEY_SAMPLE_STATUS_PV_NAME, request.getPvNamesList()));
+        }
+        if (!request.getDomainsList().isEmpty()) {
+            filters.add(in(BsonConstants.BSON_KEY_SAMPLE_STATUS_DOMAIN, request.getDomainsList()));
+        }
+        if (!request.getLayersList().isEmpty()) {
+            filters.add(in(BsonConstants.BSON_KEY_SAMPLE_STATUS_LAYER, request.getLayersList()));
+        }
+        if (position != null) {
+            filters.add(sampleStatusResumeFilter(position));
+        }
+
+        // Fetch limit+1 to detect whether a next page exists without an extra count query.
+        final List<SampleStatusBucketDocument> documents = new ArrayList<>();
+        try {
+            mongoCollectionSampleStatusBuckets.find(and(filters))
+                    .sort(ascending(
+                            BsonConstants.BSON_KEY_SAMPLE_STATUS_PV_NAME,
+                            BsonConstants.BSON_KEY_SAMPLE_STATUS_DOMAIN,
+                            BsonConstants.BSON_KEY_SAMPLE_STATUS_LAYER,
+                            BsonConstants.BSON_KEY_SAMPLE_STATUS_FIRST_TIME_NANOS))
+                    .limit(limit + 1)
+                    .into(documents);
+        } catch (MongoException ex) {
+            logger.error("executeQuerySampleStatuses: mongo exception: {}", ex.getMessage(), ex);
+            return null;
+        }
+
+        String nextPageToken = "";
+        if (documents.size() > limit) {
+            documents.remove(documents.size() - 1); // trim the extra probe document
+            final SampleStatusBucketDocument lastDocument = documents.get(documents.size() - 1);
+            nextPageToken = new SampleStatusPageToken(
+                    lastDocument.getPvName(),
+                    lastDocument.getDomain(),
+                    lastDocument.getLayer(),
+                    lastDocument.getFirstTimeNanos()).encode();
+        }
+
+        return new SampleStatusQueryResult(documents, nextPageToken);
+    }
+
+    /**
+     * Deletion is exact at the sample axis: documents fully inside [beginTime, endTime) are
+     * removed, boundary documents are trimmed or split via removeRange(). Trimmed survivors keep
+     * their original provenance — deletion is not a save. The count accumulates individual
+     * statuses removed, not documents.
+     */
+    @Override
+    public MongoCountResult deleteSampleStatuses(DeleteSampleStatusesRequest request) {
+
+        final long beginNanos =
+                SampleStatusDocumentUtility.timestampNanos(request.getTimeRange().getBeginTime());
+        final long endNanos =
+                SampleStatusDocumentUtility.timestampNanos(request.getTimeRange().getEndTime());
+
+        final List<Bson> filters = new ArrayList<>();
+        filters.add(eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_DOMAIN, request.getDomain()));
+        filters.add(eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_LAYER, request.getLayer()));
+        // empty pvNames is a deliberate wildcard deleting the (domain, layer)'s statuses for all PVs
+        if (!request.getPvNamesList().isEmpty()) {
+            filters.add(in(BsonConstants.BSON_KEY_SAMPLE_STATUS_PV_NAME, request.getPvNamesList()));
+        }
+        filters.add(lt(BsonConstants.BSON_KEY_SAMPLE_STATUS_FIRST_TIME_NANOS, endNanos));
+        filters.add(gte(BsonConstants.BSON_KEY_SAMPLE_STATUS_LAST_TIME_NANOS, beginNanos));
+
+        long deletedCount = 0;
+
+        // Iterate with a cursor rather than materializing the matched set: a wildcard delete
+        // (layer retirement) can match many documents. Replacement documents inserted during
+        // iteration never re-match the filter (a prefix run ends before beginTime, a suffix run
+        // starts at or after endTime), so the loop cannot observe its own writes.
+        try (MongoCursor<SampleStatusBucketDocument> cursor =
+                     mongoCollectionSampleStatusBuckets.find(and(filters)).iterator()) {
+            while (cursor.hasNext()) {
+                final SampleStatusBucketDocument document = cursor.next();
+                final SampleStatusDocumentUtility.RemovalResult removal =
+                        SampleStatusDocumentUtility.removeRange(document, beginNanos, endNanos);
+                if (removal.removedCount() == 0) {
+                    // span overlaps the range but no individual sample falls inside it
+                    continue;
+                }
+                mongoCollectionSampleStatusBuckets.deleteOne(
+                        eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_ID, document.getId()));
+                for (SampleStatusBucketDocument replacement : removal.replacementDocuments()) {
+                    mongoCollectionSampleStatusBuckets.insertOne(replacement);
+                }
+                deletedCount += removal.removedCount();
+            }
+        } catch (MongoException | DpException ex) {
+            final String errorMsg = "error deleting sample status documents: " + ex.getMessage();
+            logger.error("deleteSampleStatuses error: {}", ex.getMessage(), ex);
+            return new MongoCountResult(true, errorMsg, deletedCount);
+        }
+
+        return new MongoCountResult(false, "", deletedCount);
     }
 
 }

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/DeleteSampleStatusesDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/DeleteSampleStatusesDispatcher.java
@@ -1,0 +1,40 @@
+package com.ospreydcs.dp.service.annotation.handler.mongo.dispatch;
+
+import com.ospreydcs.dp.grpc.v1.annotation.DeleteSampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.DeleteSampleStatusesResponse;
+import com.ospreydcs.dp.service.annotation.service.AnnotationServiceImpl;
+import com.ospreydcs.dp.service.common.handler.Dispatcher;
+import com.ospreydcs.dp.service.common.model.MongoCountResult;
+import com.ospreydcs.dp.service.common.model.ResultStatus;
+import io.grpc.stub.StreamObserver;
+
+public class DeleteSampleStatusesDispatcher extends Dispatcher {
+
+    private final StreamObserver<DeleteSampleStatusesResponse> responseObserver;
+    private final DeleteSampleStatusesRequest request;
+
+    public DeleteSampleStatusesDispatcher(
+            StreamObserver<DeleteSampleStatusesResponse> responseObserver,
+            DeleteSampleStatusesRequest request
+    ) {
+        this.responseObserver = responseObserver;
+        this.request = request;
+    }
+
+    public void handleValidationError(ResultStatus resultStatus) {
+        AnnotationServiceImpl.sendDeleteSampleStatusesResponseReject(resultStatus.msg, responseObserver);
+    }
+
+    public void handleError(String errorMsg) {
+        AnnotationServiceImpl.sendDeleteSampleStatusesResponseError(errorMsg, responseObserver);
+    }
+
+    public void handleResult(MongoCountResult result) {
+        if (result.isError) {
+            AnnotationServiceImpl.sendDeleteSampleStatusesResponseError(result.message, responseObserver);
+        } else {
+            // a delete matching nothing is a success with deletedCount = 0, not an ExceptionalResult
+            AnnotationServiceImpl.sendDeleteSampleStatusesResponseSuccess(result.count, responseObserver);
+        }
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/QuerySampleStatusesDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/QuerySampleStatusesDispatcher.java
@@ -1,0 +1,65 @@
+package com.ospreydcs.dp.service.annotation.handler.mongo.dispatch;
+
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesResponse;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusBucket;
+import com.ospreydcs.dp.service.annotation.service.AnnotationServiceImpl;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusBucketDocument;
+import com.ospreydcs.dp.service.common.exception.DpException;
+import com.ospreydcs.dp.service.common.handler.Dispatcher;
+import com.ospreydcs.dp.service.common.model.ResultStatus;
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QuerySampleStatusesDispatcher extends Dispatcher {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final StreamObserver<QuerySampleStatusesResponse> responseObserver;
+    private final QuerySampleStatusesRequest request;
+
+    public QuerySampleStatusesDispatcher(
+            StreamObserver<QuerySampleStatusesResponse> responseObserver,
+            QuerySampleStatusesRequest request
+    ) {
+        this.responseObserver = responseObserver;
+        this.request = request;
+    }
+
+    public void handleValidationError(ResultStatus resultStatus) {
+        AnnotationServiceImpl.sendQuerySampleStatusesResponseReject(resultStatus.msg, responseObserver);
+    }
+
+    public void handleError(String errorMsg) {
+        AnnotationServiceImpl.sendQuerySampleStatusesResponseError(errorMsg, responseObserver);
+    }
+
+    public void handleResult(List<SampleStatusBucketDocument> documents, String nextPageToken) {
+
+        final List<SampleStatusBucket> buckets = new ArrayList<>();
+        for (SampleStatusBucketDocument document : documents) {
+            try {
+                buckets.add(document.toSampleStatusBucket());
+            } catch (DpException ex) {
+                // a malformed stored document must produce a reportable error, never an unchecked throw
+                final String errorMsg = "error converting SampleStatusBucketDocument to SampleStatusBucket: "
+                        + ex.getMessage();
+                logger.error("handleResult: {}", ex.getMessage(), ex);
+                handleError(errorMsg);
+                return;
+            }
+        }
+
+        final QuerySampleStatusesResponse.QuerySampleStatusesResult result =
+                QuerySampleStatusesResponse.QuerySampleStatusesResult.newBuilder()
+                        .addAllSampleStatusBuckets(buckets)
+                        .setNextPageToken(nextPageToken != null ? nextPageToken : "")
+                        .build();
+
+        AnnotationServiceImpl.sendQuerySampleStatusesResponse(result, responseObserver);
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/QuerySampleStatusesStreamDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/QuerySampleStatusesStreamDispatcher.java
@@ -1,0 +1,80 @@
+package com.ospreydcs.dp.service.annotation.handler.mongo.dispatch;
+
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesResponse;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusBucket;
+import com.ospreydcs.dp.service.annotation.service.AnnotationServiceImpl;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusBucketDocument;
+import com.ospreydcs.dp.service.common.exception.DpException;
+import com.ospreydcs.dp.service.common.handler.Dispatcher;
+import com.ospreydcs.dp.service.common.model.ResultStatus;
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Dispatcher for the server-streaming querySampleStatusesStream(): each page of documents is sent
+ * as one streamed response message via handleChunk() (nextPageToken is always empty — streaming
+ * is fire-and-consume), and handleCompleted() closes the stream after the last page. Errors are
+ * sent as an ExceptionalResult message followed by stream completion.
+ */
+public class QuerySampleStatusesStreamDispatcher extends Dispatcher {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final StreamObserver<QuerySampleStatusesResponse> responseObserver;
+    private final QuerySampleStatusesRequest request;
+
+    public QuerySampleStatusesStreamDispatcher(
+            StreamObserver<QuerySampleStatusesResponse> responseObserver,
+            QuerySampleStatusesRequest request
+    ) {
+        this.responseObserver = responseObserver;
+        this.request = request;
+    }
+
+    public void handleValidationError(ResultStatus resultStatus) {
+        AnnotationServiceImpl.sendQuerySampleStatusesResponseReject(resultStatus.msg, responseObserver);
+    }
+
+    public void handleError(String errorMsg) {
+        AnnotationServiceImpl.sendQuerySampleStatusesResponseError(errorMsg, responseObserver);
+    }
+
+    /**
+     * Sends one page of documents as a streamed response message. Returns false if a conversion
+     * error was dispatched instead (the caller must stop streaming).
+     */
+    public boolean handleChunk(List<SampleStatusBucketDocument> documents) {
+
+        final List<SampleStatusBucket> buckets = new ArrayList<>();
+        for (SampleStatusBucketDocument document : documents) {
+            try {
+                buckets.add(document.toSampleStatusBucket());
+            } catch (DpException ex) {
+                // a malformed stored document must produce a reportable error, never an unchecked throw
+                final String errorMsg = "error converting SampleStatusBucketDocument to SampleStatusBucket: "
+                        + ex.getMessage();
+                logger.error("handleChunk: {}", ex.getMessage(), ex);
+                handleError(errorMsg);
+                return false;
+            }
+        }
+
+        final QuerySampleStatusesResponse.QuerySampleStatusesResult result =
+                QuerySampleStatusesResponse.QuerySampleStatusesResult.newBuilder()
+                        .addAllSampleStatusBuckets(buckets)
+                        .setNextPageToken("")
+                        .build();
+
+        AnnotationServiceImpl.sendQuerySampleStatusesResponseStreamChunk(result, responseObserver);
+        return true;
+    }
+
+    public void handleCompleted() {
+        AnnotationServiceImpl.sendQuerySampleStatusesResponseStreamComplete(responseObserver);
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SaveSampleStatusesDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SaveSampleStatusesDispatcher.java
@@ -1,0 +1,39 @@
+package com.ospreydcs.dp.service.annotation.handler.mongo.dispatch;
+
+import com.ospreydcs.dp.grpc.v1.annotation.SaveSampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.SaveSampleStatusesResponse;
+import com.ospreydcs.dp.service.annotation.service.AnnotationServiceImpl;
+import com.ospreydcs.dp.service.common.handler.Dispatcher;
+import com.ospreydcs.dp.service.common.model.MongoCountResult;
+import com.ospreydcs.dp.service.common.model.ResultStatus;
+import io.grpc.stub.StreamObserver;
+
+public class SaveSampleStatusesDispatcher extends Dispatcher {
+
+    private final StreamObserver<SaveSampleStatusesResponse> responseObserver;
+    private final SaveSampleStatusesRequest request;
+
+    public SaveSampleStatusesDispatcher(
+            StreamObserver<SaveSampleStatusesResponse> responseObserver,
+            SaveSampleStatusesRequest request
+    ) {
+        this.responseObserver = responseObserver;
+        this.request = request;
+    }
+
+    public void handleValidationError(ResultStatus resultStatus) {
+        AnnotationServiceImpl.sendSaveSampleStatusesResponseReject(resultStatus.msg, responseObserver);
+    }
+
+    public void handleError(String errorMsg) {
+        AnnotationServiceImpl.sendSaveSampleStatusesResponseError(errorMsg, responseObserver);
+    }
+
+    public void handleResult(MongoCountResult result) {
+        if (result.isError) {
+            AnnotationServiceImpl.sendSaveSampleStatusesResponseError(result.message, responseObserver);
+        } else {
+            AnnotationServiceImpl.sendSaveSampleStatusesResponseSuccess(result.count, responseObserver);
+        }
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/job/DeleteSampleStatusesJob.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/job/DeleteSampleStatusesJob.java
@@ -1,0 +1,49 @@
+package com.ospreydcs.dp.service.annotation.handler.mongo.job;
+
+import com.ospreydcs.dp.grpc.v1.annotation.DeleteSampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.DeleteSampleStatusesResponse;
+import com.ospreydcs.dp.service.annotation.handler.SampleStatusValidationUtility;
+import com.ospreydcs.dp.service.annotation.handler.mongo.client.MongoAnnotationClientInterface;
+import com.ospreydcs.dp.service.annotation.handler.mongo.dispatch.DeleteSampleStatusesDispatcher;
+import com.ospreydcs.dp.service.common.handler.HandlerJob;
+import com.ospreydcs.dp.service.common.model.MongoCountResult;
+import com.ospreydcs.dp.service.common.model.ResultStatus;
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class DeleteSampleStatusesJob extends HandlerJob {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final DeleteSampleStatusesRequest request;
+    private final StreamObserver<DeleteSampleStatusesResponse> responseObserver;
+    private final MongoAnnotationClientInterface mongoClient;
+    private final DeleteSampleStatusesDispatcher dispatcher;
+
+    public DeleteSampleStatusesJob(
+            DeleteSampleStatusesRequest request,
+            StreamObserver<DeleteSampleStatusesResponse> responseObserver,
+            MongoAnnotationClientInterface mongoClient
+    ) {
+        this.request = request;
+        this.responseObserver = responseObserver;
+        this.mongoClient = mongoClient;
+        this.dispatcher = new DeleteSampleStatusesDispatcher(responseObserver, request);
+    }
+
+    @Override
+    public void execute() {
+        logger.debug("executing DeleteSampleStatusesJob id: {}", responseObserver.hashCode());
+
+        final ResultStatus resultStatus =
+                SampleStatusValidationUtility.validateDeleteSampleStatusesRequest(request);
+        if (resultStatus.isError) {
+            dispatcher.handleValidationError(resultStatus);
+            return;
+        }
+
+        final MongoCountResult result = mongoClient.deleteSampleStatuses(request);
+        dispatcher.handleResult(result);
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/job/QuerySampleStatusesJob.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/job/QuerySampleStatusesJob.java
@@ -1,0 +1,69 @@
+package com.ospreydcs.dp.service.annotation.handler.mongo.job;
+
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesResponse;
+import com.ospreydcs.dp.service.annotation.handler.SampleStatusValidationUtility;
+import com.ospreydcs.dp.service.annotation.handler.model.SampleStatusPageToken;
+import com.ospreydcs.dp.service.annotation.handler.mongo.MongoAnnotationHandler;
+import com.ospreydcs.dp.service.annotation.handler.mongo.client.MongoAnnotationClientInterface;
+import com.ospreydcs.dp.service.annotation.handler.mongo.dispatch.QuerySampleStatusesDispatcher;
+import com.ospreydcs.dp.service.common.handler.HandlerJob;
+import com.ospreydcs.dp.service.common.model.ResultStatus;
+import com.ospreydcs.dp.service.common.model.SampleStatusQueryResult;
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class QuerySampleStatusesJob extends HandlerJob {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final QuerySampleStatusesRequest request;
+    private final StreamObserver<QuerySampleStatusesResponse> responseObserver;
+    private final MongoAnnotationClientInterface mongoClient;
+    private final QuerySampleStatusesDispatcher dispatcher;
+
+    public QuerySampleStatusesJob(
+            QuerySampleStatusesRequest request,
+            StreamObserver<QuerySampleStatusesResponse> responseObserver,
+            MongoAnnotationClientInterface mongoClient
+    ) {
+        this.request = request;
+        this.responseObserver = responseObserver;
+        this.mongoClient = mongoClient;
+        this.dispatcher = new QuerySampleStatusesDispatcher(responseObserver, request);
+    }
+
+    @Override
+    public void execute() {
+        logger.debug("executing QuerySampleStatusesJob id: {}", responseObserver.hashCode());
+
+        final ResultStatus resultStatus =
+                SampleStatusValidationUtility.validateQuerySampleStatusesRequest(request);
+        if (resultStatus.isError) {
+            dispatcher.handleValidationError(resultStatus);
+            return;
+        }
+
+        // a non-empty pageToken must be one this server issued; unparseable tokens are rejected
+        SampleStatusPageToken position = null;
+        if (!request.getPageToken().isBlank()) {
+            position = SampleStatusPageToken.decode(request.getPageToken());
+            if (position == null) {
+                dispatcher.handleValidationError(new ResultStatus(
+                        true, "QuerySampleStatusesRequest.pageToken is not a valid page token"));
+                return;
+            }
+        }
+
+        final int limit = MongoAnnotationHandler.sampleStatusQueryPageSize(request.getLimit());
+
+        final SampleStatusQueryResult queryResult =
+                mongoClient.executeQuerySampleStatuses(request, limit, position);
+        if (queryResult == null) {
+            dispatcher.handleError("error executing sample status query");
+            return;
+        }
+        dispatcher.handleResult(queryResult.getDocuments(), queryResult.getNextPageToken());
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/job/QuerySampleStatusesStreamJob.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/job/QuerySampleStatusesStreamJob.java
@@ -1,0 +1,93 @@
+package com.ospreydcs.dp.service.annotation.handler.mongo.job;
+
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesResponse;
+import com.ospreydcs.dp.service.annotation.handler.SampleStatusValidationUtility;
+import com.ospreydcs.dp.service.annotation.handler.model.SampleStatusPageToken;
+import com.ospreydcs.dp.service.annotation.handler.mongo.MongoAnnotationHandler;
+import com.ospreydcs.dp.service.annotation.handler.mongo.client.MongoAnnotationClientInterface;
+import com.ospreydcs.dp.service.annotation.handler.mongo.dispatch.QuerySampleStatusesStreamDispatcher;
+import com.ospreydcs.dp.service.common.handler.HandlerJob;
+import com.ospreydcs.dp.service.common.model.ResultStatus;
+import com.ospreydcs.dp.service.common.model.SampleStatusQueryResult;
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Job for the server-streaming querySampleStatusesStream(): pages through the result internally
+ * (keyset positions never cross the wire) and streams one response message per limit-sized chunk
+ * until the result is exhausted. Streaming is fire-and-consume: a non-empty request pageToken is
+ * rejected and streamed messages carry no continuation tokens.
+ */
+public class QuerySampleStatusesStreamJob extends HandlerJob {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final QuerySampleStatusesRequest request;
+    private final StreamObserver<QuerySampleStatusesResponse> responseObserver;
+    private final MongoAnnotationClientInterface mongoClient;
+    private final QuerySampleStatusesStreamDispatcher dispatcher;
+
+    public QuerySampleStatusesStreamJob(
+            QuerySampleStatusesRequest request,
+            StreamObserver<QuerySampleStatusesResponse> responseObserver,
+            MongoAnnotationClientInterface mongoClient
+    ) {
+        this.request = request;
+        this.responseObserver = responseObserver;
+        this.mongoClient = mongoClient;
+        this.dispatcher = new QuerySampleStatusesStreamDispatcher(responseObserver, request);
+    }
+
+    @Override
+    public void execute() {
+        logger.debug("executing QuerySampleStatusesStreamJob id: {}", responseObserver.hashCode());
+
+        final ResultStatus resultStatus =
+                SampleStatusValidationUtility.validateQuerySampleStatusesRequest(request);
+        if (resultStatus.isError) {
+            dispatcher.handleValidationError(resultStatus);
+            return;
+        }
+
+        if (!request.getPageToken().isBlank()) {
+            dispatcher.handleValidationError(new ResultStatus(true,
+                    "QuerySampleStatusesRequest.pageToken must be empty for querySampleStatusesStream"));
+            return;
+        }
+
+        final int limit = MongoAnnotationHandler.sampleStatusQueryPageSize(request.getLimit());
+
+        SampleStatusPageToken position = null;
+        boolean firstChunk = true;
+        while (true) {
+            final SampleStatusQueryResult queryResult =
+                    mongoClient.executeQuerySampleStatuses(request, limit, position);
+            if (queryResult == null) {
+                dispatcher.handleError("error executing sample status query");
+                return;
+            }
+
+            // an empty overall result streams a single empty-result message (success, not
+            // exceptional); an empty trailing page is not re-sent
+            if (!queryResult.getDocuments().isEmpty() || firstChunk) {
+                if (!dispatcher.handleChunk(queryResult.getDocuments())) {
+                    return;
+                }
+            }
+            firstChunk = false;
+
+            if (queryResult.getNextPageToken().isEmpty()) {
+                break;
+            }
+            position = SampleStatusPageToken.decode(queryResult.getNextPageToken());
+            if (position == null) {
+                dispatcher.handleError("error decoding internal page token");
+                return;
+            }
+        }
+
+        dispatcher.handleCompleted();
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/job/SaveSampleStatusesJob.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/job/SaveSampleStatusesJob.java
@@ -1,0 +1,51 @@
+package com.ospreydcs.dp.service.annotation.handler.mongo.job;
+
+import com.ospreydcs.dp.grpc.v1.annotation.SaveSampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.SaveSampleStatusesResponse;
+import com.ospreydcs.dp.service.annotation.handler.SampleStatusValidationUtility;
+import com.ospreydcs.dp.service.annotation.handler.mongo.MongoAnnotationHandler;
+import com.ospreydcs.dp.service.annotation.handler.mongo.client.MongoAnnotationClientInterface;
+import com.ospreydcs.dp.service.annotation.handler.mongo.dispatch.SaveSampleStatusesDispatcher;
+import com.ospreydcs.dp.service.common.handler.HandlerJob;
+import com.ospreydcs.dp.service.common.model.MongoCountResult;
+import com.ospreydcs.dp.service.common.model.ResultStatus;
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class SaveSampleStatusesJob extends HandlerJob {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final SaveSampleStatusesRequest request;
+    private final StreamObserver<SaveSampleStatusesResponse> responseObserver;
+    private final MongoAnnotationClientInterface mongoClient;
+    private final SaveSampleStatusesDispatcher dispatcher;
+
+    public SaveSampleStatusesJob(
+            SaveSampleStatusesRequest request,
+            StreamObserver<SaveSampleStatusesResponse> responseObserver,
+            MongoAnnotationClientInterface mongoClient
+    ) {
+        this.request = request;
+        this.responseObserver = responseObserver;
+        this.mongoClient = mongoClient;
+        this.dispatcher = new SaveSampleStatusesDispatcher(responseObserver, request);
+    }
+
+    @Override
+    public void execute() {
+        logger.debug("executing SaveSampleStatusesJob id: {}", responseObserver.hashCode());
+
+        // the request is validated and rejected as a whole; nothing is persisted on rejection
+        final ResultStatus resultStatus = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                request, MongoAnnotationHandler.sampleStatusSaveMaxStatuses());
+        if (resultStatus.isError) {
+            dispatcher.handleValidationError(resultStatus);
+            return;
+        }
+
+        final MongoCountResult result = mongoClient.saveSampleStatuses(request);
+        dispatcher.handleResult(result);
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/annotation/service/AnnotationServiceImpl.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/service/AnnotationServiceImpl.java
@@ -1452,4 +1452,224 @@ public class AnnotationServiceImpl extends DpAnnotationServiceGrpc.DpAnnotationS
                 .build());
         responseObserver.onCompleted();
     }
+
+    // =========================================================
+    // saveSampleStatuses
+    // =========================================================
+
+    private static SaveSampleStatusesResponse saveSampleStatusesResponseExceptionalResult(
+            String msg, ExceptionalResult.ExceptionalResultStatus status) {
+        final ExceptionalResult exceptionalResult = ExceptionalResult.newBuilder()
+                .setExceptionalResultStatus(status)
+                .setMessage(msg)
+                .build();
+        return SaveSampleStatusesResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setExceptionalResult(exceptionalResult)
+                .build();
+    }
+
+    public static void sendSaveSampleStatusesResponseReject(
+            String msg, StreamObserver<SaveSampleStatusesResponse> responseObserver) {
+        responseObserver.onNext(saveSampleStatusesResponseExceptionalResult(
+                msg, ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT));
+        responseObserver.onCompleted();
+    }
+
+    public static void sendSaveSampleStatusesResponseError(
+            String msg, StreamObserver<SaveSampleStatusesResponse> responseObserver) {
+        responseObserver.onNext(saveSampleStatusesResponseExceptionalResult(
+                msg, ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR));
+        responseObserver.onCompleted();
+    }
+
+    public static void sendSaveSampleStatusesResponseSuccess(
+            long savedCount, StreamObserver<SaveSampleStatusesResponse> responseObserver) {
+        final SaveSampleStatusesResponse.SaveSampleStatusesResult result =
+                SaveSampleStatusesResponse.SaveSampleStatusesResult.newBuilder()
+                        .setSavedCount(savedCount)
+                        .build();
+        responseObserver.onNext(SaveSampleStatusesResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setSaveSampleStatusesResult(result)
+                .build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void saveSampleStatuses(
+            SaveSampleStatusesRequest request,
+            StreamObserver<SaveSampleStatusesResponse> responseObserver
+    ) {
+        logger.info("id: {} saveSampleStatuses request received frames: {}",
+                responseObserver.hashCode(), request.getFramesCount());
+        handler.handleSaveSampleStatuses(request, responseObserver);
+    }
+
+    // =========================================================
+    // querySampleStatuses / querySampleStatusesStream
+    // =========================================================
+
+    private static QuerySampleStatusesResponse querySampleStatusesResponseExceptionalResult(
+            String msg, ExceptionalResult.ExceptionalResultStatus status) {
+        final ExceptionalResult exceptionalResult = ExceptionalResult.newBuilder()
+                .setExceptionalResultStatus(status)
+                .setMessage(msg)
+                .build();
+        return QuerySampleStatusesResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setExceptionalResult(exceptionalResult)
+                .build();
+    }
+
+    public static void sendQuerySampleStatusesResponseReject(
+            String msg, StreamObserver<QuerySampleStatusesResponse> responseObserver) {
+        responseObserver.onNext(querySampleStatusesResponseExceptionalResult(
+                msg, ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT));
+        responseObserver.onCompleted();
+    }
+
+    public static void sendQuerySampleStatusesResponseError(
+            String msg, StreamObserver<QuerySampleStatusesResponse> responseObserver) {
+        responseObserver.onNext(querySampleStatusesResponseExceptionalResult(
+                msg, ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR));
+        responseObserver.onCompleted();
+    }
+
+    public static void sendQuerySampleStatusesResponse(
+            QuerySampleStatusesResponse.QuerySampleStatusesResult result,
+            StreamObserver<QuerySampleStatusesResponse> responseObserver) {
+        responseObserver.onNext(QuerySampleStatusesResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setQuerySampleStatusesResult(result)
+                .build());
+        responseObserver.onCompleted();
+    }
+
+    public static void sendQuerySampleStatusesResponseStreamChunk(
+            QuerySampleStatusesResponse.QuerySampleStatusesResult result,
+            StreamObserver<QuerySampleStatusesResponse> responseObserver) {
+        responseObserver.onNext(QuerySampleStatusesResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setQuerySampleStatusesResult(result)
+                .build());
+    }
+
+    public static void sendQuerySampleStatusesResponseStreamComplete(
+            StreamObserver<QuerySampleStatusesResponse> responseObserver) {
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void querySampleStatuses(
+            QuerySampleStatusesRequest request,
+            StreamObserver<QuerySampleStatusesResponse> responseObserver
+    ) {
+        logger.info("id: {} querySampleStatuses request received", responseObserver.hashCode());
+        handler.handleQuerySampleStatuses(request, responseObserver);
+    }
+
+    @Override
+    public void querySampleStatusesStream(
+            QuerySampleStatusesRequest request,
+            StreamObserver<QuerySampleStatusesResponse> responseObserver
+    ) {
+        logger.info("id: {} querySampleStatusesStream request received", responseObserver.hashCode());
+        handler.handleQuerySampleStatusesStream(request, responseObserver);
+    }
+
+    // =========================================================
+    // deleteSampleStatuses
+    // =========================================================
+
+    private static DeleteSampleStatusesResponse deleteSampleStatusesResponseExceptionalResult(
+            String msg, ExceptionalResult.ExceptionalResultStatus status) {
+        final ExceptionalResult exceptionalResult = ExceptionalResult.newBuilder()
+                .setExceptionalResultStatus(status)
+                .setMessage(msg)
+                .build();
+        return DeleteSampleStatusesResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setExceptionalResult(exceptionalResult)
+                .build();
+    }
+
+    public static void sendDeleteSampleStatusesResponseReject(
+            String msg, StreamObserver<DeleteSampleStatusesResponse> responseObserver) {
+        responseObserver.onNext(deleteSampleStatusesResponseExceptionalResult(
+                msg, ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT));
+        responseObserver.onCompleted();
+    }
+
+    public static void sendDeleteSampleStatusesResponseError(
+            String msg, StreamObserver<DeleteSampleStatusesResponse> responseObserver) {
+        responseObserver.onNext(deleteSampleStatusesResponseExceptionalResult(
+                msg, ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR));
+        responseObserver.onCompleted();
+    }
+
+    public static void sendDeleteSampleStatusesResponseSuccess(
+            long deletedCount, StreamObserver<DeleteSampleStatusesResponse> responseObserver) {
+        final DeleteSampleStatusesResponse.DeleteSampleStatusesResult result =
+                DeleteSampleStatusesResponse.DeleteSampleStatusesResult.newBuilder()
+                        .setDeletedCount(deletedCount)
+                        .build();
+        responseObserver.onNext(DeleteSampleStatusesResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setDeleteSampleStatusesResult(result)
+                .build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void deleteSampleStatuses(
+            DeleteSampleStatusesRequest request,
+            StreamObserver<DeleteSampleStatusesResponse> responseObserver
+    ) {
+        logger.info("id: {} deleteSampleStatuses request received domain: {} layer: {}",
+                responseObserver.hashCode(), request.getDomain(), request.getLayer());
+        handler.handleDeleteSampleStatuses(request, responseObserver);
+    }
+
+    // =========================================================
+    // saveSampleStatusDomain (stub — not yet implemented)
+    // =========================================================
+
+    @Override
+    public void saveSampleStatusDomain(
+            SaveSampleStatusDomainRequest request,
+            StreamObserver<SaveSampleStatusDomainResponse> responseObserver
+    ) {
+        logger.info("id: {} saveSampleStatusDomain request received", responseObserver.hashCode());
+        final ExceptionalResult exceptionalResult = ExceptionalResult.newBuilder()
+                .setExceptionalResultStatus(ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR)
+                .setMessage("saveSampleStatusDomain is not yet implemented")
+                .build();
+        responseObserver.onNext(SaveSampleStatusDomainResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setExceptionalResult(exceptionalResult)
+                .build());
+        responseObserver.onCompleted();
+    }
+
+    // =========================================================
+    // querySampleStatusDomains (stub — not yet implemented)
+    // =========================================================
+
+    @Override
+    public void querySampleStatusDomains(
+            QuerySampleStatusDomainsRequest request,
+            StreamObserver<QuerySampleStatusDomainsResponse> responseObserver
+    ) {
+        logger.info("id: {} querySampleStatusDomains request received", responseObserver.hashCode());
+        final ExceptionalResult exceptionalResult = ExceptionalResult.newBuilder()
+                .setExceptionalResultStatus(ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_ERROR)
+                .setMessage("querySampleStatusDomains is not yet implemented")
+                .build();
+        responseObserver.onNext(QuerySampleStatusDomainsResponse.newBuilder()
+                .setResponseTime(TimestampUtility.getTimestampNow())
+                .setExceptionalResult(exceptionalResult)
+                .build());
+        responseObserver.onCompleted();
+    }
 }

--- a/src/main/java/com/ospreydcs/dp/service/common/bson/BsonConstants.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/bson/BsonConstants.java
@@ -90,4 +90,12 @@ public class BsonConstants {
     public static final String BSON_KEY_ACTIVATION_END_TIME = "endTime";
     public static final String BSON_KEY_ACTIVATION_DESCRIPTION = "description";
     public static final String BSON_KEY_ACTIVATION_MODIFIED_BY = "modifiedBy";
+
+    // sampleStatusBuckets collection
+    public static final String BSON_KEY_SAMPLE_STATUS_ID = "_id";
+    public static final String BSON_KEY_SAMPLE_STATUS_PV_NAME = "pvName";
+    public static final String BSON_KEY_SAMPLE_STATUS_DOMAIN = "domain";
+    public static final String BSON_KEY_SAMPLE_STATUS_LAYER = "layer";
+    public static final String BSON_KEY_SAMPLE_STATUS_FIRST_TIME_NANOS = "firstTimeNanos";
+    public static final String BSON_KEY_SAMPLE_STATUS_LAST_TIME_NANOS = "lastTimeNanos";
 }

--- a/src/main/java/com/ospreydcs/dp/service/common/bson/samplestatus/SampleStatusBucketDocument.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/bson/samplestatus/SampleStatusBucketDocument.java
@@ -1,0 +1,240 @@
+package com.ospreydcs.dp.service.common.bson.samplestatus;
+
+import com.ospreydcs.dp.grpc.v1.common.DataTimestamps;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusBucket;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusColumn;
+import com.ospreydcs.dp.service.common.bson.DataTimestampsDocument;
+import com.ospreydcs.dp.service.common.bson.TimestampDocument;
+import com.ospreydcs.dp.service.common.exception.DpException;
+import com.ospreydcs.dp.service.common.protobuf.TimestampUtility;
+import org.bson.types.ObjectId;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * MongoDB document for the sampleStatusBuckets collection: statuses for one PV in one
+ * (domain, layer) over a contiguous time period, paralleling BucketDocument for time-series data.
+ *
+ * <p>Storage invariant: no two documents ever assert a status for the same identity key
+ * (pvName, timestamp, domain, layer). The save path maintains this by carving colliding
+ * timestamps out of existing documents before inserting new ones (see
+ * MongoSyncAnnotationClient.saveSampleStatuses()), which is what lets the query path return
+ * documents whole with no read-time conflict resolution.
+ *
+ * <p>The time span is denormalized to firstTimeNanos/lastTimeNanos epoch-nanos scalars so the
+ * overlap predicate is a plain indexed range comparison, avoiding the seconds/nanos $or
+ * construction that defeats index bounds on the buckets collection (#198). Note that unlike data
+ * buckets, sample status documents have no maximum span: sparse labeling over an arbitrarily wide
+ * range is first-class, so overlap queries must not assume a bounded document span (no #197-style
+ * firstTime lower bound).
+ */
+public class SampleStatusBucketDocument {
+
+    // instance variables
+    private ObjectId id;
+    private String pvName;
+    private String domain;
+    private String layer;
+    private DataTimestampsDocument dataTimestamps;
+    private long firstTimeNanos;
+    private long lastTimeNanos;
+    private List<Integer> statusCodes;
+    private List<Float> confidence;
+    private List<String> reasons;
+    private String source;
+    private String modifiedBy;
+    private Instant updatedTime;
+
+    public ObjectId getId() {
+        return id;
+    }
+
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    public String getPvName() {
+        return pvName;
+    }
+
+    public void setPvName(String pvName) {
+        this.pvName = pvName;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
+    public String getLayer() {
+        return layer;
+    }
+
+    public void setLayer(String layer) {
+        this.layer = layer;
+    }
+
+    public DataTimestampsDocument getDataTimestamps() {
+        return dataTimestamps;
+    }
+
+    public void setDataTimestamps(DataTimestampsDocument dataTimestamps) {
+        this.dataTimestamps = dataTimestamps;
+    }
+
+    public long getFirstTimeNanos() {
+        return firstTimeNanos;
+    }
+
+    public void setFirstTimeNanos(long firstTimeNanos) {
+        this.firstTimeNanos = firstTimeNanos;
+    }
+
+    public long getLastTimeNanos() {
+        return lastTimeNanos;
+    }
+
+    public void setLastTimeNanos(long lastTimeNanos) {
+        this.lastTimeNanos = lastTimeNanos;
+    }
+
+    public List<Integer> getStatusCodes() {
+        return statusCodes;
+    }
+
+    public void setStatusCodes(List<Integer> statusCodes) {
+        this.statusCodes = statusCodes;
+    }
+
+    public List<Float> getConfidence() {
+        return confidence;
+    }
+
+    public void setConfidence(List<Float> confidence) {
+        this.confidence = confidence;
+    }
+
+    public List<String> getReasons() {
+        return reasons;
+    }
+
+    public void setReasons(List<String> reasons) {
+        this.reasons = reasons;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getModifiedBy() {
+        return modifiedBy;
+    }
+
+    public void setModifiedBy(String modifiedBy) {
+        this.modifiedBy = modifiedBy;
+    }
+
+    public Instant getUpdatedTime() {
+        return updatedTime;
+    }
+
+    public void setUpdatedTime(Instant updatedTime) {
+        this.updatedTime = updatedTime;
+    }
+
+    private static long timestampDocumentNanos(TimestampDocument timestampDocument) {
+        return timestampDocument.getSeconds() * 1_000_000_000L + timestampDocument.getNanos();
+    }
+
+    public static SampleStatusBucketDocument fromSampleStatusColumn(
+            String domain,
+            String layer,
+            DataTimestamps dataTimestamps,
+            SampleStatusColumn column,
+            String source,
+            String modifiedBy,
+            Instant updatedTime
+    ) {
+        final SampleStatusBucketDocument document = new SampleStatusBucketDocument();
+
+        document.setPvName(column.getPvName());
+        document.setDomain(domain);
+        document.setLayer(layer);
+
+        final DataTimestampsDocument dataTimestampsDocument =
+                DataTimestampsDocument.fromDataTimestamps(dataTimestamps);
+        document.setDataTimestamps(dataTimestampsDocument);
+        document.setFirstTimeNanos(timestampDocumentNanos(dataTimestampsDocument.getFirstTime()));
+        document.setLastTimeNanos(timestampDocumentNanos(dataTimestampsDocument.getLastTime()));
+
+        document.setStatusCodes(new ArrayList<>(column.getStatusCodesList()));
+        if (!column.getConfidenceList().isEmpty()) {
+            document.setConfidence(new ArrayList<>(column.getConfidenceList()));
+        }
+        if (!column.getReasonsList().isEmpty()) {
+            document.setReasons(new ArrayList<>(column.getReasonsList()));
+        }
+
+        if (source != null && !source.isBlank()) {
+            document.setSource(source);
+        }
+        if (modifiedBy != null && !modifiedBy.isBlank()) {
+            document.setModifiedBy(modifiedBy);
+        }
+        document.setUpdatedTime(updatedTime);
+
+        return document;
+    }
+
+    public SampleStatusBucket toSampleStatusBucket() throws DpException {
+
+        final SampleStatusColumn.Builder columnBuilder = SampleStatusColumn.newBuilder();
+        if (this.pvName != null) {
+            columnBuilder.setPvName(this.pvName);
+        }
+        if (this.statusCodes != null) {
+            columnBuilder.addAllStatusCodes(this.statusCodes);
+        }
+        if (this.confidence != null) {
+            columnBuilder.addAllConfidence(this.confidence);
+        }
+        if (this.reasons != null) {
+            columnBuilder.addAllReasons(this.reasons);
+        }
+
+        final SampleStatusBucket.Builder builder = SampleStatusBucket.newBuilder();
+        if (this.domain != null) {
+            builder.setDomain(this.domain);
+        }
+        if (this.layer != null) {
+            builder.setLayer(this.layer);
+        }
+        if (this.dataTimestamps == null) {
+            // surface a malformed stored document as a reportable error, never an unchecked throw
+            throw new DpException(
+                    "SampleStatusBucketDocument missing dataTimestamps for document with id: " + this.id);
+        }
+        builder.setDataTimestamps(this.dataTimestamps.toDataTimestamps());
+        builder.setStatusColumn(columnBuilder.build());
+        if (this.source != null) {
+            builder.setSource(this.source);
+        }
+        if (this.modifiedBy != null) {
+            builder.setModifiedBy(this.modifiedBy);
+        }
+        if (this.updatedTime != null) {
+            builder.setUpdatedTime(TimestampUtility.getTimestampFromInstant(this.updatedTime));
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/common/bson/samplestatus/SampleStatusDocumentUtility.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/bson/samplestatus/SampleStatusDocumentUtility.java
@@ -1,0 +1,268 @@
+package com.ospreydcs.dp.service.common.bson.samplestatus;
+
+import com.ospreydcs.dp.grpc.v1.common.DataTimestamps;
+import com.ospreydcs.dp.grpc.v1.common.SamplingClock;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.grpc.v1.common.TimestampList;
+import com.ospreydcs.dp.service.common.bson.DataTimestampsDocument;
+import com.ospreydcs.dp.service.common.exception.DpException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Sample-wise operations on SampleStatusBucketDocuments, shared by the save path (carving
+ * colliding timestamps out of existing documents to maintain the no-duplicate-identity-key
+ * storage invariant) and the delete path (trimming/splitting boundary documents so deletion is
+ * exact at the sample axis).
+ *
+ * <p>Documents are expanded to per-sample points keyed by epoch-nanos timestamps, filtered, and
+ * rebuilt. A rebuilt run of two or more evenly spaced points re-emits as a SamplingClock axis
+ * (so trimming a clock document yields a shorter clock, and an interior delete splits it into
+ * two clock documents); anything else re-emits as a TimestampList.
+ */
+public class SampleStatusDocumentUtility {
+
+    /** One sample status expanded from a document: companions are null when the document has none. */
+    public record StatusPoint(long timestampNanos, int statusCode, Float confidence, String reason) {}
+
+    /**
+     * Outcome of removing samples from a document: the documents that replace it (empty when no
+     * samples survive), and the number of samples removed. A removedCount of zero means the
+     * document was untouched and must not be rewritten.
+     */
+    public record RemovalResult(List<SampleStatusBucketDocument> replacementDocuments, long removedCount) {
+
+        public static final RemovalResult UNTOUCHED = new RemovalResult(List.of(), 0);
+    }
+
+    public static long timestampNanos(Timestamp timestamp) {
+        return timestamp.getEpochSeconds() * 1_000_000_000L + timestamp.getNanoseconds();
+    }
+
+    public static Timestamp timestampFromNanos(long epochNanos) {
+        return Timestamp.newBuilder()
+                .setEpochSeconds(Math.floorDiv(epochNanos, 1_000_000_000L))
+                .setNanoseconds(Math.floorMod(epochNanos, 1_000_000_000L))
+                .build();
+    }
+
+    /**
+     * Returns the epoch-nanos timestamp of each sample specified by a DataTimestamps axis, in
+     * axis order.
+     */
+    public static List<Long> timestampNanosList(DataTimestamps dataTimestamps) {
+
+        final List<Long> result = new ArrayList<>();
+
+        switch (dataTimestamps.getValueCase()) {
+            case SAMPLINGCLOCK -> {
+                final SamplingClock clock = dataTimestamps.getSamplingClock();
+                final long startNanos = timestampNanos(clock.getStartTime());
+                for (int i = 0; i < clock.getCount(); i++) {
+                    result.add(startNanos + i * clock.getPeriodNanos());
+                }
+            }
+            case TIMESTAMPLIST -> {
+                for (Timestamp timestamp : dataTimestamps.getTimestampList().getTimestampsList()) {
+                    result.add(timestampNanos(timestamp));
+                }
+            }
+            default -> {
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Expands a document to its per-sample points. A stored document whose arrays do not line up
+     * with its time axis is malformed and surfaces as DpException per the bucket-deserialization
+     * contract.
+     */
+    public static List<StatusPoint> expandDocument(SampleStatusBucketDocument document) throws DpException {
+
+        if (document.getDataTimestamps() == null) {
+            throw new DpException(
+                    "SampleStatusBucketDocument missing dataTimestamps for document with id: " + document.getId());
+        }
+        final List<Long> timestamps = timestampNanosList(document.getDataTimestamps().toDataTimestamps());
+
+        final List<Integer> statusCodes = document.getStatusCodes();
+        if (statusCodes == null || statusCodes.size() != timestamps.size()) {
+            throw new DpException(
+                    "SampleStatusBucketDocument statusCodes size does not match timestamp count for document with id: "
+                            + document.getId());
+        }
+        final List<Float> confidence = document.getConfidence();
+        if (confidence != null && confidence.size() != timestamps.size()) {
+            throw new DpException(
+                    "SampleStatusBucketDocument confidence size does not match timestamp count for document with id: "
+                            + document.getId());
+        }
+        final List<String> reasons = document.getReasons();
+        if (reasons != null && reasons.size() != timestamps.size()) {
+            throw new DpException(
+                    "SampleStatusBucketDocument reasons size does not match timestamp count for document with id: "
+                            + document.getId());
+        }
+
+        final List<StatusPoint> points = new ArrayList<>(timestamps.size());
+        for (int i = 0; i < timestamps.size(); i++) {
+            points.add(new StatusPoint(
+                    timestamps.get(i),
+                    statusCodes.get(i),
+                    confidence == null ? null : confidence.get(i),
+                    reasons == null ? null : reasons.get(i)));
+        }
+        return points;
+    }
+
+    /**
+     * Removes the samples whose timestamps appear in the given set (exact nanosecond equality).
+     * Used by the save path to carve identity-key collisions out of existing documents before
+     * inserting the incoming column.
+     */
+    public static RemovalResult removeTimestamps(
+            SampleStatusBucketDocument document,
+            Set<Long> timestampNanosToRemove
+    ) throws DpException {
+
+        final List<StatusPoint> points = expandDocument(document);
+        final List<StatusPoint> survivors = new ArrayList<>(points.size());
+        for (StatusPoint point : points) {
+            if (!timestampNanosToRemove.contains(point.timestampNanos())) {
+                survivors.add(point);
+            }
+        }
+
+        final long removedCount = points.size() - survivors.size();
+        if (removedCount == 0) {
+            return RemovalResult.UNTOUCHED;
+        }
+        if (survivors.isEmpty()) {
+            return new RemovalResult(List.of(), removedCount);
+        }
+        return new RemovalResult(List.of(buildReplacementDocument(document, survivors)), removedCount);
+    }
+
+    /**
+     * Removes the samples whose timestamps fall within the half-open range
+     * [beginNanos, endNanos). Survivors before and after the range become separate replacement
+     * documents, so an interior deletion splits the document in two and neither replacement spans
+     * the deleted gap.
+     */
+    public static RemovalResult removeRange(
+            SampleStatusBucketDocument document,
+            long beginNanos,
+            long endNanos
+    ) throws DpException {
+
+        final List<StatusPoint> points = expandDocument(document);
+        final List<StatusPoint> beforeRange = new ArrayList<>();
+        final List<StatusPoint> afterRange = new ArrayList<>();
+        long removedCount = 0;
+        for (StatusPoint point : points) {
+            if (point.timestampNanos() < beginNanos) {
+                beforeRange.add(point);
+            } else if (point.timestampNanos() >= endNanos) {
+                afterRange.add(point);
+            } else {
+                removedCount++;
+            }
+        }
+
+        if (removedCount == 0) {
+            return RemovalResult.UNTOUCHED;
+        }
+        final List<SampleStatusBucketDocument> replacements = new ArrayList<>(2);
+        if (!beforeRange.isEmpty()) {
+            replacements.add(buildReplacementDocument(document, beforeRange));
+        }
+        if (!afterRange.isEmpty()) {
+            replacements.add(buildReplacementDocument(document, afterRange));
+        }
+        return new RemovalResult(replacements, removedCount);
+    }
+
+    /**
+     * Builds the DataTimestamps axis for a run of points: two or more evenly spaced points
+     * re-emit as a SamplingClock, anything else as a TimestampList.
+     */
+    public static DataTimestamps buildDataTimestamps(List<StatusPoint> points) {
+
+        if (points.size() >= 2) {
+            final long period = points.get(1).timestampNanos() - points.get(0).timestampNanos();
+            boolean evenlySpaced = true;
+            for (int i = 2; i < points.size(); i++) {
+                if (points.get(i).timestampNanos() - points.get(i - 1).timestampNanos() != period) {
+                    evenlySpaced = false;
+                    break;
+                }
+            }
+            if (evenlySpaced) {
+                return DataTimestamps.newBuilder()
+                        .setSamplingClock(SamplingClock.newBuilder()
+                                .setStartTime(timestampFromNanos(points.get(0).timestampNanos()))
+                                .setPeriodNanos(period)
+                                .setCount(points.size()))
+                        .build();
+            }
+        }
+
+        final TimestampList.Builder listBuilder = TimestampList.newBuilder();
+        for (StatusPoint point : points) {
+            listBuilder.addTimestamps(timestampFromNanos(point.timestampNanos()));
+        }
+        return DataTimestamps.newBuilder().setTimestampList(listBuilder).build();
+    }
+
+    /**
+     * Builds a replacement document holding the given surviving points. Identity and provenance
+     * fields are copied from the original: the delete path preserves them as-is, and the save
+     * path overwrites provenance with the incoming request's before inserting (rewritten
+     * documents take the incoming source/modifiedBy and a fresh updatedTime).
+     */
+    private static SampleStatusBucketDocument buildReplacementDocument(
+            SampleStatusBucketDocument original,
+            List<StatusPoint> points
+    ) {
+        final SampleStatusBucketDocument document = new SampleStatusBucketDocument();
+
+        document.setPvName(original.getPvName());
+        document.setDomain(original.getDomain());
+        document.setLayer(original.getLayer());
+        document.setSource(original.getSource());
+        document.setModifiedBy(original.getModifiedBy());
+        document.setUpdatedTime(original.getUpdatedTime());
+
+        document.setDataTimestamps(DataTimestampsDocument.fromDataTimestamps(buildDataTimestamps(points)));
+        document.setFirstTimeNanos(points.get(0).timestampNanos());
+        document.setLastTimeNanos(points.get(points.size() - 1).timestampNanos());
+
+        final List<Integer> statusCodes = new ArrayList<>(points.size());
+        for (StatusPoint point : points) {
+            statusCodes.add(point.statusCode());
+        }
+        document.setStatusCodes(statusCodes);
+
+        // companion presence is homogeneous within a document, so probe the original's arrays
+        if (original.getConfidence() != null) {
+            final List<Float> confidence = new ArrayList<>(points.size());
+            for (StatusPoint point : points) {
+                confidence.add(point.confidence());
+            }
+            document.setConfidence(confidence);
+        }
+        if (original.getReasons() != null) {
+            final List<String> reasons = new ArrayList<>(points.size());
+            for (StatusPoint point : points) {
+                reasons.add(point.reason());
+            }
+            document.setReasons(reasons);
+        }
+
+        return document;
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/common/model/MongoCountResult.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/model/MongoCountResult.java
@@ -1,0 +1,20 @@
+package com.ospreydcs.dp.service.common.model;
+
+/**
+ * Result of a MongoDB operation whose outcome is a count of affected items, e.g. individual
+ * sample statuses upserted by saveSampleStatuses or removed by deleteSampleStatuses. On error the
+ * count reflects the items already persisted/removed before the failure (partial persistence is
+ * documented behavior for those operations).
+ */
+public class MongoCountResult {
+
+    public final boolean isError;
+    public final String message;
+    public final long count;
+
+    public MongoCountResult(boolean isError, String message, long count) {
+        this.isError = isError;
+        this.message = message;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/common/model/SampleStatusQueryResult.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/model/SampleStatusQueryResult.java
@@ -1,0 +1,28 @@
+package com.ospreydcs.dp.service.common.model;
+
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusBucketDocument;
+
+import java.util.List;
+
+/**
+ * Result of a paginated sample status query, bundling the current page of documents with the
+ * next-page token (empty string when no further pages exist).
+ */
+public class SampleStatusQueryResult {
+
+    private final List<SampleStatusBucketDocument> documents;
+    private final String nextPageToken;
+
+    public SampleStatusQueryResult(List<SampleStatusBucketDocument> documents, String nextPageToken) {
+        this.documents = documents;
+        this.nextPageToken = nextPageToken;
+    }
+
+    public List<SampleStatusBucketDocument> getDocuments() {
+        return documents;
+    }
+
+    public String getNextPageToken() {
+        return nextPageToken;
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoAsyncClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoAsyncClient.java
@@ -174,4 +174,16 @@ public class MongoAsyncClient extends MongoClientBase {
         // configurationActivations indexes not used by async client
         return true;
     }
+
+    @Override
+    protected boolean initMongoCollectionSampleStatusBuckets(String collectionName) {
+        // sampleStatusBuckets collection not used by async client
+        return true;
+    }
+
+    @Override
+    protected boolean createMongoIndexSampleStatusBuckets(Bson fieldNamesBson) {
+        // sampleStatusBuckets indexes not used by async client
+        return true;
+    }
 }

--- a/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoClientBase.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoClientBase.java
@@ -5,6 +5,7 @@ import com.ospreydcs.dp.service.common.bson.annotation.AnnotationDocument;
 import com.ospreydcs.dp.service.common.bson.configuration.ConfigurationActivationDocument;
 import com.ospreydcs.dp.service.common.bson.configuration.ConfigurationDocument;
 import com.ospreydcs.dp.service.common.bson.pvmetadata.PvMetadataDocument;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusBucketDocument;
 import com.ospreydcs.dp.service.common.bson.calculations.CalculationsDataFrameDocument;
 import com.ospreydcs.dp.service.common.bson.calculations.CalculationsDocument;
 import com.ospreydcs.dp.service.common.bson.column.*;
@@ -42,6 +43,7 @@ public abstract class MongoClientBase {
     public static final String COLLECTION_NAME_PV_METADATA = "pvMetadata";
     public static final String COLLECTION_NAME_CONFIGURATIONS = "configurations";
     public static final String COLLECTION_NAME_CONFIGURATION_ACTIVATIONS = "configurationActivations";
+    public static final String COLLECTION_NAME_SAMPLE_STATUS_BUCKETS = "sampleStatusBuckets";
 
     // configuration
     public static final int DEFAULT_NUM_WORKERS = 7;
@@ -73,6 +75,8 @@ public abstract class MongoClientBase {
     protected abstract boolean initMongoCollectionConfigurationActivations(String collectionName);
     protected abstract boolean createMongoIndexConfigurationActivations(Bson fieldNamesBson);
     protected abstract boolean createMongoIndexConfigurationActivationsWithOptions(Bson fieldNamesBson, com.mongodb.client.model.IndexOptions indexOptions);
+    protected abstract boolean initMongoCollectionSampleStatusBuckets(String collectionName);
+    protected abstract boolean createMongoIndexSampleStatusBuckets(Bson fieldNamesBson);
 
     protected static ConfigurationManager configMgr() {
         return ConfigurationManager.getInstance();
@@ -134,7 +138,8 @@ public abstract class MongoClientBase {
                 SerializedDataColumnDocument.class,
                 PvMetadataDocument.class,
                 ConfigurationDocument.class,
-                ConfigurationActivationDocument.class
+                ConfigurationActivationDocument.class,
+                SampleStatusBucketDocument.class
         ).build();
 
         //        CodecProvider pojoCodecProvider = PojoCodecProvider.builder().automatic(true).build();
@@ -311,6 +316,25 @@ public abstract class MongoClientBase {
         return true;
     }
 
+    private boolean createMongoIndexesSampleStatusBuckets() {
+        // compound index for the primary sort/lookup order (pvName, domain, layer, firstTimeNanos);
+        // lastTimeNanos is a residual filter in the overlap predicate. The span fields are plain
+        // epoch-nanos scalars so the overlap test is a plain indexed range comparison rather than
+        // the seconds/nanos $or construction that defeats index bounds on the buckets collection.
+        createMongoIndexSampleStatusBuckets(Indexes.ascending(
+                BsonConstants.BSON_KEY_SAMPLE_STATUS_PV_NAME,
+                BsonConstants.BSON_KEY_SAMPLE_STATUS_DOMAIN,
+                BsonConstants.BSON_KEY_SAMPLE_STATUS_LAYER,
+                BsonConstants.BSON_KEY_SAMPLE_STATUS_FIRST_TIME_NANOS));
+        // second index led by (domain, layer) so empty-pvNames wildcard queries and deletes
+        // (e.g. layer retirement) don't require a full collection scan
+        createMongoIndexSampleStatusBuckets(Indexes.ascending(
+                BsonConstants.BSON_KEY_SAMPLE_STATUS_DOMAIN,
+                BsonConstants.BSON_KEY_SAMPLE_STATUS_LAYER,
+                BsonConstants.BSON_KEY_SAMPLE_STATUS_FIRST_TIME_NANOS));
+        return true;
+    }
+
     public static String getMongoConnectString() {
         // Allow a full connection string override to support replica sets, TLS, options, etc.
         String uriOverride = configMgr().getConfigString(CFG_KEY_DB_URI, DEFAULT_DB_URI);
@@ -367,6 +391,10 @@ public abstract class MongoClientBase {
 
     protected String getCollectionNameConfigurationActivations() {
         return COLLECTION_NAME_CONFIGURATION_ACTIVATIONS;
+    }
+
+    protected String getCollectionNameSampleStatusBuckets() {
+        return COLLECTION_NAME_SAMPLE_STATUS_BUCKETS;
     }
 
     public boolean init() {
@@ -433,6 +461,10 @@ public abstract class MongoClientBase {
         // initialize configurationActivations collection
         initMongoCollectionConfigurationActivations(getCollectionNameConfigurationActivations());
         createMongoIndexesConfigurationActivations();
+
+        // initialize sampleStatusBuckets collection
+        initMongoCollectionSampleStatusBuckets(getCollectionNameSampleStatusBuckets());
+        createMongoIndexesSampleStatusBuckets();
 
         return true;
     }

--- a/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoSyncClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/mongo/MongoSyncClient.java
@@ -17,6 +17,7 @@ import com.ospreydcs.dp.service.common.bson.dataset.DataSetDocument;
 import com.ospreydcs.dp.service.common.bson.configuration.ConfigurationActivationDocument;
 import com.ospreydcs.dp.service.common.bson.configuration.ConfigurationDocument;
 import com.ospreydcs.dp.service.common.bson.pvmetadata.PvMetadataDocument;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusBucketDocument;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bson.Document;
@@ -44,6 +45,7 @@ public class MongoSyncClient extends MongoClientBase {
     protected MongoCollection<PvMetadataDocument> mongoCollectionPvMetadata = null;
     protected MongoCollection<ConfigurationDocument> mongoCollectionConfigurations = null;
     protected MongoCollection<ConfigurationActivationDocument> mongoCollectionConfigurationActivations = null;
+    protected MongoCollection<SampleStatusBucketDocument> mongoCollectionSampleStatusBuckets = null;
 
     @Override
     protected boolean initMongoClient(String connectString) {
@@ -205,6 +207,18 @@ public class MongoSyncClient extends MongoClientBase {
     @Override
     protected boolean createMongoIndexConfigurationActivationsWithOptions(Bson fieldNamesBson, com.mongodb.client.model.IndexOptions indexOptions) {
         mongoCollectionConfigurationActivations.createIndex(fieldNamesBson, indexOptions);
+        return true;
+    }
+
+    @Override
+    protected boolean initMongoCollectionSampleStatusBuckets(String collectionName) {
+        mongoCollectionSampleStatusBuckets = mongoDatabase.getCollection(collectionName, SampleStatusBucketDocument.class);
+        return true;
+    }
+
+    @Override
+    protected boolean createMongoIndexSampleStatusBuckets(Bson fieldNamesBson) {
+        mongoCollectionSampleStatusBuckets.createIndex(fieldNamesBson);
         return true;
     }
 

--- a/src/main/java/com/ospreydcs/dp/service/common/utility/TabularDataUtility.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/utility/TabularDataUtility.java
@@ -31,6 +31,29 @@ public class TabularDataUtility {
     public static record RetentionInterval(
             long beginSeconds, long beginNanos, long endSeconds, long endNanos) {}
 
+    /**
+     * Per-sample status filter for Query API V2 {@code querySamples} with a
+     * {@code sampleStatusSelector}: {@code matchingTimestampsByPv} holds, per PV, the epoch-nanos
+     * timestamps of statuses matching the selector. A sample is "labeled" only by a status at its
+     * exact timestamp (nanosecond equality). INCLUDE mode retains a sample iff labeled; EXCLUDE
+     * mode drops it iff labeled.
+     *
+     * <p>Composes with the fragment {@link RetentionInterval} test by intersection: both must pass
+     * for a sample to be retained, so a status attached to a sample outside the retrieval
+     * fragments has no effect. Like RetentionInterval, this is a local value type so the shared
+     * utility does not depend on Query API V2 model classes.
+     */
+    public static record SampleStatusFilter(
+            boolean includeMode, Map<String, Set<Long>> matchingTimestampsByPv) {
+
+        public boolean retains(String pvName, long second, long nano) {
+            final Set<Long> matchingTimestamps = matchingTimestampsByPv.get(pvName);
+            final boolean labeled = matchingTimestamps != null
+                    && matchingTimestamps.contains(second * 1_000_000_000L + nano);
+            return labeled == includeMode;
+        }
+    }
+
     public static TimestampDataMapSizeStats addBucketsToTable(
             TimestampDataMap tableValueMap,
             MongoCursor<BucketDocument> cursor,
@@ -69,6 +92,25 @@ public class TabularDataUtility {
             Integer sizeLimit, // if null, no limit is applied
             List<RetentionInterval> retentionIntervals
     ) throws DpException {
+        return addBucketsToTable(
+                tableValueMap, cursor, previousDataSize, sizeLimit, retentionIntervals, null);
+    }
+
+    /**
+     * Full form adding an optional per-sample {@link SampleStatusFilter} (null = no status
+     * filtering). A sample must pass both the fragment retention test and the status test — the
+     * selectors compose by intersection. A filtered-out sample is simply never inserted, so it
+     * surfaces as a missing value (unset DataValue) where other PVs keep the row, and a timestamp
+     * at which every PV is filtered out is omitted from the result entirely.
+     */
+    public static TimestampDataMapSizeStats addBucketsToTable(
+            TimestampDataMap tableValueMap,
+            MongoCursor<BucketDocument> cursor,
+            int previousDataSize,
+            Integer sizeLimit, // if null, no limit is applied
+            List<RetentionInterval> retentionIntervals,
+            SampleStatusFilter statusFilter // if null, no status filtering is applied
+    ) throws DpException {
 
         int currentDataSize = previousDataSize;
         while (cursor.hasNext()) {
@@ -81,7 +123,7 @@ public class TabularDataUtility {
             // normally also registered under the same name inside addColumnsToTable below; this keeps
             // the slot even if a bucket's PV name and its column name ever diverge.
             tableValueMap.getColumnIndex(bucket.getPvName());
-            int bucketDataSize = addBucketToTable(bucket, tableValueMap, retentionIntervals);
+            int bucketDataSize = addBucketToTable(bucket, tableValueMap, retentionIntervals, statusFilter);
             currentDataSize = currentDataSize + bucketDataSize;
             // Size accounting is per-BUCKET, not per-timestamp: a whole bucket is added to the table
             // before the limit is checked, so currentDataSize can overshoot sizeLimit by up to one
@@ -107,7 +149,8 @@ public class TabularDataUtility {
     private static int addBucketToTable(
             BucketDocument bucket,
             TimestampDataMap tableValueMap,
-            List<RetentionInterval> retentionIntervals
+            List<RetentionInterval> retentionIntervals,
+            SampleStatusFilter statusFilter
     ) throws DpException {
 
         final DataTimestamps bucketDataTimestamps = bucket.getDataTimestamps().toDataTimestamps();
@@ -133,7 +176,8 @@ public class TabularDataUtility {
                 bucketDataTimestamps,
                 List.of(bucketColumn),
                 tableValueMap,
-                retentionIntervals);
+                retentionIntervals,
+                statusFilter);
     }
 
     /**
@@ -168,14 +212,16 @@ public class TabularDataUtility {
                 dataTimestamps,
                 dataColumns,
                 tableValueMap,
-                List.of(new RetentionInterval(beginSeconds, beginNanos, endSeconds, endNanos)));
+                List.of(new RetentionInterval(beginSeconds, beginNanos, endSeconds, endNanos)),
+                null);
     }
 
     private static int addColumnsToTable(
             DataTimestamps dataTimestamps,
             List<DataColumn> dataColumns,
             TimestampDataMap tableValueMap,
-            List<RetentionInterval> retentionIntervals
+            List<RetentionInterval> retentionIntervals,
+            SampleStatusFilter statusFilter
     ) throws DpException {
 
         int dataValueSize = 0;
@@ -211,6 +257,14 @@ public class TabularDataUtility {
 
             // add next value for each column to tableValueMap
             for (DataColumn dataColumn : dataColumns) {
+
+                // per-sample status filter (per-PV, so evaluated inside the column loop, unlike the
+                // column-independent interval test above): a filtered-out sample is never inserted,
+                // becoming a missing value at this (PV, timestamp) position
+                if (statusFilter != null && !statusFilter.retains(dataColumn.getName(), second, nano)) {
+                    continue;
+                }
+
                 final DataValue dataValue = dataColumn.getDataValues(valueIndex);
                 final int columnIndex = tableValueMap.getColumnIndex(dataColumn.getName());
 

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/QueryV2Resolver.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/QueryV2Resolver.java
@@ -7,11 +7,13 @@ import com.ospreydcs.dp.grpc.v1.query.ExecutionOptions;
 import com.ospreydcs.dp.grpc.v1.query.PvSelector;
 import com.ospreydcs.dp.grpc.v1.query.QuerySpec;
 import com.ospreydcs.dp.grpc.v1.query.ResultRepresentation;
+import com.ospreydcs.dp.grpc.v1.query.SampleStatusSelector;
 import com.ospreydcs.dp.service.common.bson.BsonConstants;
 import com.ospreydcs.dp.service.common.mongo.MongoQueryFilterBuilder;
 import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
 import com.ospreydcs.dp.service.query.handler.model.ResolutionResult;
 import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedStatusFilter;
 import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
 import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
 import com.ospreydcs.dp.service.query.handler.paging.PageToken;
@@ -22,6 +24,7 @@ import org.bson.conversions.Bson;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.PatternSyntaxException;
 
@@ -153,11 +156,37 @@ public class QueryV2Resolver {
         }
         final List<TimeInterval> intervals = resolvedIntervals.intervals;
 
+        // ---- sampleStatusSelector: validate + method gating ----
+        // Bucket-oriented methods return storage buckets whole and cannot represent per-sample
+        // filtering, so the selector is supported by querySamples/querySamplesStream only.
+        ResolvedStatusFilter statusFilter = null;
+        if (querySpec.hasSampleStatusSelector()) {
+            if (mode == ResolvedQuery.ResultMode.BUCKET) {
+                return ResolutionResult.reject(
+                        "bucket-oriented methods do not support per-sample status filtering; remove "
+                                + "sampleStatusSelector or use querySamples/querySamplesStream");
+            }
+            final SampleStatusSelector selector = querySpec.getSampleStatusSelector();
+            if (selector.getDomain().isBlank()) {
+                return ResolutionResult.reject("sampleStatusSelector.domain must be specified");
+            }
+            if (selector.getMode() != SampleStatusSelector.Mode.MODE_INCLUDE_MATCHING
+                    && selector.getMode() != SampleStatusSelector.Mode.MODE_EXCLUDE_MATCHING) {
+                return ResolutionResult.reject("sampleStatusSelector.mode must be specified");
+            }
+            statusFilter = new ResolvedStatusFilter(
+                    selector.getDomain(),
+                    List.copyOf(selector.getLayersList()),
+                    Set.copyOf(selector.getStatusCodesList()),
+                    selector.getMode() == SampleStatusSelector.Mode.MODE_INCLUDE_MATCHING);
+        }
+
         final boolean useSerialized = resultRepresentation.getUseSerializedColumns();
         final boolean excludeMetadata = resultRepresentation.getExcludeColumnMetadata();
 
         final ResolvedQuery resolved = new ResolvedQuery(
-                pvNames, intervals, pageSize, pageStart, useSerialized, excludeMetadata, mode, streaming);
+                pvNames, intervals, pageSize, pageStart, useSerialized, excludeMetadata, mode, streaming,
+                statusFilter);
         return ResolutionResult.of(resolved);
     }
 

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/model/ResolvedQuery.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/model/ResolvedQuery.java
@@ -26,6 +26,7 @@ public final class ResolvedQuery {
     private final boolean excludeColumnMetadata;
     private final ResultMode mode;
     private final boolean streaming;
+    private final ResolvedStatusFilter statusFilter; // null when no sampleStatusSelector
 
     public ResolvedQuery(
             List<String> pvNames,
@@ -36,6 +37,20 @@ public final class ResolvedQuery {
             boolean excludeColumnMetadata,
             ResultMode mode,
             boolean streaming) {
+        this(pvNames, retrievalIntervals, pageSize, pageStart, useSerializedColumns,
+                excludeColumnMetadata, mode, streaming, null);
+    }
+
+    public ResolvedQuery(
+            List<String> pvNames,
+            List<TimeInterval> retrievalIntervals,
+            int pageSize,
+            KeysetPosition pageStart,
+            boolean useSerializedColumns,
+            boolean excludeColumnMetadata,
+            ResultMode mode,
+            boolean streaming,
+            ResolvedStatusFilter statusFilter) {
         this.pvNames = Collections.unmodifiableList(pvNames);
         this.retrievalIntervals = Collections.unmodifiableList(retrievalIntervals);
         this.pageSize = pageSize;
@@ -44,6 +59,7 @@ public final class ResolvedQuery {
         this.excludeColumnMetadata = excludeColumnMetadata;
         this.mode = mode;
         this.streaming = streaming;
+        this.statusFilter = statusFilter;
     }
 
     /** Sorted-ascending list of resolved PV names; drives Q9 column order/presence. */
@@ -79,6 +95,11 @@ public final class ResolvedQuery {
 
     public boolean isStreaming() {
         return streaming;
+    }
+
+    /** Resolved sampleStatusSelector, or {@code null} when the request carried none. */
+    public ResolvedStatusFilter getStatusFilter() {
+        return statusFilter;
     }
 
     /**

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/model/ResolvedStatusFilter.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/model/ResolvedStatusFilter.java
@@ -1,0 +1,27 @@
+package com.ospreydcs.dp.service.query.handler.model;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Internal (non-proto) resolved form of a validated {@code QuerySpec.sampleStatusSelector}: the
+ * required domain, the layer wildcard list (empty = all layers in the domain), the status-code
+ * match set (empty = any code, i.e. "labeled at all"), and the mode (INCLUDE keeps only samples
+ * with a matching status; EXCLUDE drops them).
+ *
+ * <p>Carried on {@link ResolvedQuery} for the sample-oriented methods only — the resolver rejects
+ * a bucket-oriented request with the selector set, since whole storage buckets cannot represent
+ * per-sample filtering.
+ */
+public record ResolvedStatusFilter(
+        String domain,
+        List<String> layers,
+        Set<Integer> statusCodes,
+        boolean includeMode
+) {
+
+    /** True when the given status code matches the selector (empty statusCodes = any code). */
+    public boolean matchesCode(int statusCode) {
+        return statusCodes.isEmpty() || statusCodes.contains(statusCode);
+    }
+}

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoQueryClientInterface.java
@@ -7,12 +7,15 @@ import com.ospreydcs.dp.service.common.bson.ProviderDocument;
 import com.ospreydcs.dp.service.common.bson.ProviderMetadataQueryResultDocument;
 import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
 import com.ospreydcs.dp.service.common.bson.dataset.DataBlockDocument;
+import com.ospreydcs.dp.service.common.exception.DpException;
 import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
 import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
 import org.bson.conversions.Bson;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public interface MongoQueryClientInterface {
 
@@ -119,6 +122,21 @@ public interface MongoQueryClientInterface {
      */
     MongoCursor<BucketDocument> executeQuerySamplesV2(
             ResolvedQuery resolvedQuery, long windowBeginSecs, long windowBeginNanos);
+
+    /**
+     * Resolves the query's sampleStatusSelector to the per-PV sets of epoch-nanos timestamps whose
+     * statuses match it, over the same clamped page window the sample retrieval uses. Queries the
+     * sampleStatusBuckets collection for the resolved PVs and the selector's (domain, layers) with
+     * the standard span-overlap predicate, expands the matching documents, and keeps a timestamp
+     * when its status code is in the selector's statusCodes (empty = any code). PVs with no
+     * matching statuses are absent from the map. The map is the assembly-time join input: memory
+     * is bounded by the number of labeled samples in the window. Returns an empty map when the
+     * clamped window is empty, or null on database error.
+     *
+     * @throws DpException when a stored sample status document is malformed
+     */
+    Map<String, Set<Long>> resolveSampleStatusTimestamps(
+            ResolvedQuery resolvedQuery, long windowBeginSecs, long windowBeginNanos) throws DpException;
 
     MongoCursor<ProviderDocument> executeQueryProviders(QueryProvidersRequest request);
 

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/client/MongoSyncQueryClient.java
@@ -14,10 +14,14 @@ import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
 import com.ospreydcs.dp.service.common.bson.configuration.ConfigurationActivationDocument;
 import com.ospreydcs.dp.service.common.bson.dataset.DataBlockDocument;
 import com.ospreydcs.dp.service.common.bson.pvmetadata.PvMetadataDocument;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusBucketDocument;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusDocumentUtility;
+import com.ospreydcs.dp.service.common.exception.DpException;
 import com.ospreydcs.dp.service.common.mongo.MongoQueryFilterBuilder;
 import com.ospreydcs.dp.service.common.mongo.MongoSyncClient;
 import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
 import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedStatusFilter;
 import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -28,8 +32,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -453,6 +459,88 @@ public class MongoSyncQueryClient extends MongoSyncClient implements MongoQueryC
             logger.error("executeQuerySamplesV2 database error: {}", ex.getMessage(), ex);
             return null;
         }
+    }
+
+    /**
+     * Saturating epoch-nanos conversion for filter bounds: an out-of-range instant clamps to the
+     * long extreme instead of overflowing, which is correct for a comparison bound.
+     */
+    private static long saturatedEpochNanos(long seconds, long nanos) {
+        try {
+            return Math.addExact(Math.multiplyExact(seconds, 1_000_000_000L), nanos);
+        } catch (ArithmeticException ex) {
+            return seconds < 0 ? Long.MIN_VALUE : Long.MAX_VALUE;
+        }
+    }
+
+    @Override
+    public Map<String, Set<Long>> resolveSampleStatusTimestamps(
+            ResolvedQuery resolvedQuery, long windowBeginSecs, long windowBeginNanos) throws DpException {
+
+        final ResolvedStatusFilter statusFilter = resolvedQuery.getStatusFilter();
+        if (statusFilter == null) {
+            return Map.of();
+        }
+
+        // Bound the fetch by the same clamped page window the sample retrieval uses (#207): a
+        // status can only affect samples inside some clamped fragment. The bounds here are the
+        // window extremes [first fragment begin, last fragment end) — statuses in the gaps between
+        // fragments are harmless to include (their samples are dropped by the fragment retention
+        // test regardless of mode), so per-fragment precision is not required for correctness.
+        final List<TimeInterval> clampedFragments = TimeInterval.clampToWindowBegin(
+                resolvedQuery.getRetrievalIntervals(), windowBeginSecs, windowBeginNanos);
+        if (clampedFragments.isEmpty()) {
+            return Map.of();
+        }
+        final TimeInterval firstFragment = clampedFragments.get(0);
+        final TimeInterval lastFragment = clampedFragments.get(clampedFragments.size() - 1);
+        final long windowBeginTotalNanos =
+                saturatedEpochNanos(firstFragment.getBeginSeconds(), firstFragment.getBeginNanos());
+        final long windowEndTotalNanos =
+                saturatedEpochNanos(lastFragment.getEndSeconds(), lastFragment.getEndNanos());
+
+        // Span-overlap predicate on the epoch-nanos scalars. Note: status documents have no
+        // maximum span (sparse labeling over an arbitrarily wide range is first-class), so no
+        // #197-style firstTime lower bound may ever be added here.
+        final List<Bson> filters = new ArrayList<>();
+        filters.add(in(BsonConstants.BSON_KEY_SAMPLE_STATUS_PV_NAME, resolvedQuery.getPvNames()));
+        filters.add(eq(BsonConstants.BSON_KEY_SAMPLE_STATUS_DOMAIN, statusFilter.domain()));
+        if (!statusFilter.layers().isEmpty()) {
+            filters.add(in(BsonConstants.BSON_KEY_SAMPLE_STATUS_LAYER, statusFilter.layers()));
+        }
+        filters.add(lt(BsonConstants.BSON_KEY_SAMPLE_STATUS_FIRST_TIME_NANOS, windowEndTotalNanos));
+        filters.add(gte(BsonConstants.BSON_KEY_SAMPLE_STATUS_LAST_TIME_NANOS, windowBeginTotalNanos));
+
+        final Map<String, Set<Long>> matchingTimestampsByPv = new HashMap<>();
+        try (MongoCursor<SampleStatusBucketDocument> cursor =
+                     mongoCollectionSampleStatusBuckets.find(and(filters)).cursor()) {
+            while (cursor.hasNext()) {
+                final SampleStatusBucketDocument document = cursor.next();
+                for (SampleStatusDocumentUtility.StatusPoint point :
+                        SampleStatusDocumentUtility.expandDocument(document)) {
+                    // keep only in-window matching timestamps: memory stays bounded by the number
+                    // of labeled samples in the window
+                    if (point.timestampNanos() < windowBeginTotalNanos
+                            || point.timestampNanos() >= windowEndTotalNanos) {
+                        continue;
+                    }
+                    if (statusFilter.matchesCode(point.statusCode())) {
+                        matchingTimestampsByPv
+                                .computeIfAbsent(document.getPvName(), k -> new HashSet<>())
+                                .add(point.timestampNanos());
+                    }
+                }
+            }
+        } catch (DpException ex) {
+            // malformed stored document: must surface as a reportable error, never be read as
+            // "no statuses" (in EXCLUDE mode that would silently return filtered-out samples)
+            throw ex;
+        } catch (Exception ex) {
+            logger.error("resolveSampleStatusTimestamps database error: {}", ex.getMessage(), ex);
+            return null;
+        }
+
+        return matchingTimestampsByPv;
     }
 
     /**

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQuerySamplesDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/AbstractQuerySamplesDispatcher.java
@@ -6,15 +6,18 @@ import com.ospreydcs.dp.grpc.v1.common.SerializedDataColumn;
 import com.ospreydcs.dp.grpc.v1.common.Timestamp;
 import com.ospreydcs.dp.grpc.v1.common.TimestampList;
 import com.ospreydcs.dp.grpc.v1.query.ColumnTable;
+import com.ospreydcs.dp.service.common.exception.DpException;
 import com.ospreydcs.dp.service.common.model.TimestampDataMap;
 import com.ospreydcs.dp.service.common.utility.TabularDataUtility;
 import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
 import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
 import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
+import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Shared base for the Query API V2 sample dispatchers (unary {@link QuerySamplesUnaryDispatcher} and
@@ -78,6 +81,36 @@ public abstract class AbstractQuerySamplesDispatcher extends QueryV2Dispatcher {
                     fragment.getEndSeconds(), fragment.getEndNanos()));
         }
         return intervals;
+    }
+
+    /**
+     * Resolves the query's sampleStatusSelector to a {@link TabularDataUtility.SampleStatusFilter}
+     * for assembly-time per-sample filtering, or {@code null} when the request carries no selector.
+     * The per-PV matching-timestamp sets come from the sampleStatusBuckets collection over the same
+     * clamped page window the bucket retrieval uses, so the join input covers exactly the samples
+     * that can appear on this page. Composition with the configurationSelector is by intersection:
+     * this filter and the fragment retention test are both applied in the same per-sample retention
+     * decision.
+     *
+     * @throws DpException on a database error or malformed stored status document — never silently
+     *     degraded to "no statuses", which in EXCLUDE mode would return filtered-out samples
+     */
+    protected static TabularDataUtility.SampleStatusFilter statusRetentionFilter(
+            ResolvedQuery resolvedQuery,
+            MongoQueryClientInterface mongoClient,
+            long windowBeginSecs,
+            long windowBeginNanos) throws DpException {
+
+        if (resolvedQuery.getStatusFilter() == null) {
+            return null;
+        }
+        final Map<String, Set<Long>> matchingTimestampsByPv =
+                mongoClient.resolveSampleStatusTimestamps(resolvedQuery, windowBeginSecs, windowBeginNanos);
+        if (matchingTimestampsByPv == null) {
+            throw new DpException("sample status selector resolution failed (database error)");
+        }
+        return new TabularDataUtility.SampleStatusFilter(
+                resolvedQuery.getStatusFilter().includeMode(), matchingTimestampsByPv);
     }
 
     /**

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesStreamDispatcher.java
@@ -74,12 +74,17 @@ public class QuerySamplesStreamDispatcher extends AbstractQuerySamplesDispatcher
         final TimestampDataMap tableValueMap = seededTable(resolvedQuery);
 
         try (cursor) {
+            // Resolve the sampleStatusSelector (null when absent) to per-PV matching-timestamp sets
+            // for the assembly-time join; composes with the fragment trim by intersection.
+            final TabularDataUtility.SampleStatusFilter statusFilter =
+                    statusRetentionFilter(resolvedQuery, mongoClient, windowBegin[0], windowBegin[1]);
             // Assemble the full window once. No sizeLimit: streaming materializes the whole table
             // (memory-bounded, per the class note); the byte budget bounds each emitted chunk, below.
             // Trimming uses every resolved fragment rather than a collapsed window (#207).
             TabularDataUtility.addBucketsToTable(
                     tableValueMap, cursor, 0, null,
-                    retentionIntervals(resolvedQuery, windowBegin[0], windowBegin[1]));
+                    retentionIntervals(resolvedQuery, windowBegin[0], windowBegin[1]),
+                    statusFilter);
         } catch (NonScalarColumnException e) {
             final String msg = "querySamples supports scalar PVs only: PV '" + e.getPvName()
                     + "' has non-scalar column type " + e.getColumnType() + "; use queryBuckets";

--- a/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesUnaryDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/query/handler/mongo/dispatch/QuerySamplesUnaryDispatcher.java
@@ -84,6 +84,10 @@ public class QuerySamplesUnaryDispatcher extends AbstractQuerySamplesDispatcher 
 
         final boolean byteBudgetHit;
         try (cursor) {
+            // Resolve the sampleStatusSelector (null when absent) to per-PV matching-timestamp sets
+            // for the assembly-time join; composes with the fragment trim by intersection.
+            final TabularDataUtility.SampleStatusFilter statusFilter =
+                    statusRetentionFilter(resolvedQuery, mongoClient, windowBeginSecs, windowBeginNanos);
             // Trim against every resolved fragment, not the collapsed window (#207): the database
             // filters fragments only per-bucket, so a bucket spanning a gap arrives with its in-gap
             // samples intact.
@@ -92,7 +96,8 @@ public class QuerySamplesUnaryDispatcher extends AbstractQuerySamplesDispatcher 
                     cursor,
                     0,
                     (int) Math.min(Integer.MAX_VALUE, byteBudget),
-                    retentionIntervals(resolvedQuery, windowBeginSecs, windowBeginNanos));
+                    retentionIntervals(resolvedQuery, windowBeginSecs, windowBeginNanos),
+                    statusFilter);
             byteBudgetHit = sizeStats.sizeLimitExceeded();
         } catch (NonScalarColumnException e) {
             // Q4: scalar-only. Translate the neutral shared exception into querySamples guidance.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -160,6 +160,19 @@ AnnotationHandler:
   # This parameter might take some tuning on deployments to get the best performance.
   numWorkers: ${DP_ANNOTATION_HANDLER_NUM_WORKERS:7}
 
+  # AnnotationHandler.sampleStatusQueryDefaultPageSize: Default page size (SampleStatusBuckets per
+  # response) for querySampleStatuses / querySampleStatusesStream when the request's limit is 0/unset.
+  sampleStatusQueryDefaultPageSize: ${DP_ANNOTATION_HANDLER_SAMPLE_STATUS_QUERY_DEFAULT_PAGE_SIZE:10000}
+
+  # AnnotationHandler.sampleStatusQueryMaxPageSize: Maximum page size for querySampleStatuses /
+  # querySampleStatusesStream. A larger requested limit is silently clamped to this value.
+  sampleStatusQueryMaxPageSize: ${DP_ANNOTATION_HANDLER_SAMPLE_STATUS_QUERY_MAX_PAGE_SIZE:100000}
+
+  # AnnotationHandler.sampleStatusSaveMaxStatuses: Maximum total individual sample statuses
+  # (timestamps x columns, summed over frames) accepted in one saveSampleStatuses request.
+  # Oversized requests are rejected.
+  sampleStatusSaveMaxStatuses: ${DP_ANNOTATION_HANDLER_SAMPLE_STATUS_SAVE_MAX_STATUSES:1000000}
+
 # Export: Settings for the export mechanism.
 Export:
 

--- a/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/GrpcIntegrationAnnotationServiceWrapper.java
+++ b/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/GrpcIntegrationAnnotationServiceWrapper.java
@@ -1566,4 +1566,143 @@ public class GrpcIntegrationAnnotationServiceWrapper extends GrpcIntegrationServ
         assertTrue(responseObserver.getErrorMessage().contains("not yet implemented"));
     }
 
+    // =========================================================================
+    // Sample Status helpers
+    // =========================================================================
+
+    public long sendAndVerifySaveSampleStatuses(
+            SaveSampleStatusesRequest request,
+            boolean expectReject,
+            String expectedRejectMessage
+    ) {
+        final DpAnnotationServiceGrpc.DpAnnotationServiceStub asyncStub = DpAnnotationServiceGrpc.newStub(channel);
+        final AnnotationTestBase.SaveSampleStatusesResponseObserver responseObserver =
+                new AnnotationTestBase.SaveSampleStatusesResponseObserver();
+
+        new Thread(() -> asyncStub.saveSampleStatuses(request, responseObserver)).start();
+        responseObserver.await();
+
+        if (expectReject) {
+            assertTrue(responseObserver.isError());
+            assertTrue(
+                    "expected message containing '" + expectedRejectMessage + "' but was: "
+                            + responseObserver.getErrorMessage(),
+                    responseObserver.getErrorMessage().contains(expectedRejectMessage));
+            assertNull(responseObserver.getSavedCount());
+            return -1;
+        }
+
+        assertFalse(responseObserver.getErrorMessage(), responseObserver.isError());
+        final Long savedCount = responseObserver.getSavedCount();
+        assertNotNull(savedCount);
+        return savedCount;
+    }
+
+    public AnnotationTestBase.QuerySampleStatusesResponseObserver sendAndVerifyQuerySampleStatuses(
+            QuerySampleStatusesRequest request,
+            boolean expectReject,
+            String expectedRejectMessage,
+            int expectedBucketCount
+    ) {
+        final DpAnnotationServiceGrpc.DpAnnotationServiceStub asyncStub = DpAnnotationServiceGrpc.newStub(channel);
+        final AnnotationTestBase.QuerySampleStatusesResponseObserver responseObserver =
+                new AnnotationTestBase.QuerySampleStatusesResponseObserver();
+
+        new Thread(() -> asyncStub.querySampleStatuses(request, responseObserver)).start();
+        responseObserver.await();
+
+        if (expectReject) {
+            assertTrue(responseObserver.isError());
+            assertTrue(
+                    "expected message containing '" + expectedRejectMessage + "' but was: "
+                            + responseObserver.getErrorMessage(),
+                    responseObserver.getErrorMessage().contains(expectedRejectMessage));
+            return null;
+        }
+
+        assertFalse(responseObserver.getErrorMessage(), responseObserver.isError());
+        assertEquals(expectedBucketCount, responseObserver.getSampleStatusBuckets().size());
+        return responseObserver;
+    }
+
+    public AnnotationTestBase.QuerySampleStatusesStreamResponseObserver sendAndVerifyQuerySampleStatusesStream(
+            QuerySampleStatusesRequest request,
+            boolean expectReject,
+            String expectedRejectMessage,
+            int expectedBucketCount
+    ) {
+        final DpAnnotationServiceGrpc.DpAnnotationServiceStub asyncStub = DpAnnotationServiceGrpc.newStub(channel);
+        final AnnotationTestBase.QuerySampleStatusesStreamResponseObserver responseObserver =
+                new AnnotationTestBase.QuerySampleStatusesStreamResponseObserver();
+
+        new Thread(() -> asyncStub.querySampleStatusesStream(request, responseObserver)).start();
+        responseObserver.await();
+
+        if (expectReject) {
+            assertTrue(responseObserver.isError());
+            assertTrue(
+                    "expected message containing '" + expectedRejectMessage + "' but was: "
+                            + responseObserver.getErrorMessage(),
+                    responseObserver.getErrorMessage().contains(expectedRejectMessage));
+            return null;
+        }
+
+        assertFalse(responseObserver.getErrorMessage(), responseObserver.isError());
+        assertEquals(expectedBucketCount, responseObserver.getSampleStatusBuckets().size());
+        // streaming is fire-and-consume: nextPageToken must be empty on every streamed message
+        assertFalse(responseObserver.nonEmptyNextPageTokenSeen());
+        return responseObserver;
+    }
+
+    public long sendAndVerifyDeleteSampleStatuses(
+            DeleteSampleStatusesRequest request,
+            boolean expectReject,
+            String expectedRejectMessage
+    ) {
+        final DpAnnotationServiceGrpc.DpAnnotationServiceStub asyncStub = DpAnnotationServiceGrpc.newStub(channel);
+        final AnnotationTestBase.DeleteSampleStatusesResponseObserver responseObserver =
+                new AnnotationTestBase.DeleteSampleStatusesResponseObserver();
+
+        new Thread(() -> asyncStub.deleteSampleStatuses(request, responseObserver)).start();
+        responseObserver.await();
+
+        if (expectReject) {
+            assertTrue(responseObserver.isError());
+            assertTrue(
+                    "expected message containing '" + expectedRejectMessage + "' but was: "
+                            + responseObserver.getErrorMessage(),
+                    responseObserver.getErrorMessage().contains(expectedRejectMessage));
+            assertNull(responseObserver.getDeletedCount());
+            return -1;
+        }
+
+        assertFalse(responseObserver.getErrorMessage(), responseObserver.isError());
+        final Long deletedCount = responseObserver.getDeletedCount();
+        assertNotNull(deletedCount);
+        return deletedCount;
+    }
+
+    public void sendAndVerifySaveSampleStatusDomainStub() {
+        final SaveSampleStatusDomainRequest request =
+                SaveSampleStatusDomainRequest.newBuilder().setDomainName("data_quality").build();
+        final DpAnnotationServiceGrpc.DpAnnotationServiceStub asyncStub = DpAnnotationServiceGrpc.newStub(channel);
+        final AnnotationTestBase.SaveSampleStatusDomainResponseObserver responseObserver =
+                new AnnotationTestBase.SaveSampleStatusDomainResponseObserver();
+        new Thread(() -> asyncStub.saveSampleStatusDomain(request, responseObserver)).start();
+        responseObserver.await();
+        assertTrue(responseObserver.isError());
+        assertTrue(responseObserver.getErrorMessage().contains("not yet implemented"));
+    }
+
+    public void sendAndVerifyQuerySampleStatusDomainsStub() {
+        final QuerySampleStatusDomainsRequest request = QuerySampleStatusDomainsRequest.newBuilder().build();
+        final DpAnnotationServiceGrpc.DpAnnotationServiceStub asyncStub = DpAnnotationServiceGrpc.newStub(channel);
+        final AnnotationTestBase.QuerySampleStatusDomainsResponseObserver responseObserver =
+                new AnnotationTestBase.QuerySampleStatusDomainsResponseObserver();
+        new Thread(() -> asyncStub.querySampleStatusDomains(request, responseObserver)).start();
+        responseObserver.await();
+        assertTrue(responseObserver.isError());
+        assertTrue(responseObserver.getErrorMessage().contains("not yet implemented"));
+    }
+
 }

--- a/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/SampleStatusClientIT.java
+++ b/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/SampleStatusClientIT.java
@@ -1,0 +1,244 @@
+package com.ospreydcs.dp.service.integration.annotation;
+
+import com.ospreydcs.dp.client.AnnotationClient;
+import com.ospreydcs.dp.client.result.DeleteSampleStatusesApiResult;
+import com.ospreydcs.dp.client.result.QuerySampleStatusesApiResult;
+import com.ospreydcs.dp.client.result.SaveSampleStatusesApiResult;
+import com.ospreydcs.dp.grpc.v1.annotation.DeleteSampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusBucket;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusColumn;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusFrame;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.service.common.protobuf.DataTimestampsUtility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Provides integration test coverage for the Sample Status API support in the
+ * com.ospreydcs.dp.client convenience layer, exercising AnnotationClient against a running
+ * annotation service.  Server-side behavior is covered separately by SampleStatusIT; these tests
+ * cover the client wrapper — request building from the params records, the success payloads
+ * (savedCount, buckets + nextPageToken, deletedCount), the streaming accumulation, and the
+ * surfacing of server rejections through ApiResultBase.resultStatus.
+ */
+public class SampleStatusClientIT extends AnnotationIntegrationTestIntermediate {
+
+    private static final String DOMAIN = "data_quality";
+    private static final String LAYER = "ml_model_v1";
+    private static final String PV_1 = "TEST:PV:001";
+    private static final String PV_2 = "TEST:PV:002";
+
+    private static final long START_SECONDS = 1_700_000_000L;
+    private static final long PERIOD = 100_000_000L; // 100ms
+
+    private AnnotationClient annotationClient;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        annotationClient = new AnnotationClient(annotationServiceWrapper.getAnnotationChannel());
+    }
+
+    @After
+    public void tearDown() {
+        annotationClient = null;
+        super.tearDown();
+    }
+
+    // ------------------- helpers ---------------------------
+
+    private static Timestamp timestamp(long seconds, long nanos) {
+        return Timestamp.newBuilder().setEpochSeconds(seconds).setNanoseconds(nanos).build();
+    }
+
+    private static SampleStatusFrame clockFrame(String pvName, int count, int statusCode) {
+        final SampleStatusColumn.Builder column = SampleStatusColumn.newBuilder().setPvName(pvName);
+        for (int i = 0; i < count; i++) {
+            column.addStatusCodes(statusCode);
+        }
+        return SampleStatusFrame.newBuilder()
+                .setDomain(DOMAIN)
+                .setLayer(LAYER)
+                .setDataTimestamps(DataTimestampsUtility.dataTimestampsWithSamplingClock(
+                        START_SECONDS, 0, PERIOD, count))
+                .addStatusColumns(column)
+                .build();
+    }
+
+    private AnnotationClient.QuerySampleStatusesParams queryParams(int limit, String pageToken) {
+        return new AnnotationClient.QuerySampleStatusesParams(
+                timestamp(START_SECONDS, 0), timestamp(START_SECONDS + 100, 0),
+                null, List.of(DOMAIN), List.of(LAYER), limit, pageToken);
+    }
+
+    // =========================================================================
+    // request builder tests
+    // =========================================================================
+
+    @Test
+    public void testBuildQueryRequestOmitsUnsuppliedOptionalFields() {
+        final QuerySampleStatusesRequest request = AnnotationClient.buildQuerySampleStatusesRequest(
+                new AnnotationClient.QuerySampleStatusesParams(
+                        timestamp(START_SECONDS, 0), timestamp(START_SECONDS + 10, 0),
+                        null, null, null, 0, null));
+        assertTrue(request.hasTimeRange());
+        assertEquals(0, request.getPvNamesCount());
+        assertEquals(0, request.getDomainsCount());
+        assertEquals(0, request.getLayersCount());
+        assertEquals(0, request.getLimit());
+        assertEquals("", request.getPageToken());
+    }
+
+    @Test
+    public void testBuildDeleteRequestPopulatesSuppliedFields() {
+        final DeleteSampleStatusesRequest request = AnnotationClient.buildDeleteSampleStatusesRequest(
+                new AnnotationClient.DeleteSampleStatusesParams(
+                        timestamp(START_SECONDS, 0), timestamp(START_SECONDS + 10, 0),
+                        List.of(PV_1), DOMAIN, LAYER));
+        assertTrue(request.hasTimeRange());
+        assertEquals(List.of(PV_1), request.getPvNamesList());
+        assertEquals(DOMAIN, request.getDomain());
+        assertEquals(LAYER, request.getLayer());
+    }
+
+    // =========================================================================
+    // round-trip tests
+    // =========================================================================
+
+    @Test
+    public void testSaveQueryDeleteRoundTrip() {
+        // save: 10 statuses across one PV
+        final SaveSampleStatusesApiResult saveResult = annotationClient.saveSampleStatuses(
+                List.of(clockFrame(PV_1, 10, 1)), "client-source", "client-user");
+        assertFalse(saveResult.resultStatus.msg, saveResult.isError());
+        assertEquals(10, saveResult.savedCount);
+
+        // query: one bucket back, carrying the provenance and PV inside the status column
+        final QuerySampleStatusesApiResult queryResult =
+                annotationClient.querySampleStatuses(queryParams(0, null));
+        assertFalse(queryResult.resultStatus.msg, queryResult.isError());
+        assertEquals(1, queryResult.sampleStatusBuckets.size());
+        final SampleStatusBucket bucket = queryResult.sampleStatusBuckets.get(0);
+        assertEquals(PV_1, bucket.getStatusColumn().getPvName());
+        assertEquals(10, bucket.getStatusColumn().getStatusCodesCount());
+        assertEquals("client-source", bucket.getSource());
+        assertEquals("client-user", bucket.getModifiedBy());
+        assertTrue(bucket.hasUpdatedTime());
+        assertEquals("", queryResult.nextPageToken);
+
+        // delete: exact range removes half the statuses
+        final DeleteSampleStatusesApiResult deleteResult = annotationClient.deleteSampleStatuses(
+                new AnnotationClient.DeleteSampleStatusesParams(
+                        timestamp(START_SECONDS, 0),
+                        timestamp(START_SECONDS, 5 * PERIOD),
+                        List.of(PV_1), DOMAIN, LAYER));
+        assertFalse(deleteResult.resultStatus.msg, deleteResult.isError());
+        assertEquals(5, deleteResult.deletedCount);
+
+        // remaining statuses still queryable
+        final QuerySampleStatusesApiResult afterDelete =
+                annotationClient.querySampleStatuses(queryParams(0, null));
+        assertFalse(afterDelete.isError());
+        assertEquals(1, afterDelete.sampleStatusBuckets.size());
+        assertEquals(5, afterDelete.sampleStatusBuckets.get(0).getStatusColumn().getStatusCodesCount());
+    }
+
+    @Test
+    public void testQueryPaginationThroughClient() {
+        annotationClient.saveSampleStatuses(
+                List.of(clockFrame(PV_1, 3, 1), clockFrame(PV_2, 3, 2)), null, null);
+
+        // page 1 of 2
+        final QuerySampleStatusesApiResult page1 =
+                annotationClient.querySampleStatuses(queryParams(1, null));
+        assertFalse(page1.isError());
+        assertEquals(1, page1.sampleStatusBuckets.size());
+        assertFalse(page1.nextPageToken.isEmpty());
+
+        // page 2 resumes from the token and is the last page
+        final QuerySampleStatusesApiResult page2 =
+                annotationClient.querySampleStatuses(queryParams(1, page1.nextPageToken));
+        assertFalse(page2.isError());
+        assertEquals(1, page2.sampleStatusBuckets.size());
+        assertTrue(page2.nextPageToken.isEmpty());
+
+        assertEquals(PV_1, page1.sampleStatusBuckets.get(0).getStatusColumn().getPvName());
+        assertEquals(PV_2, page2.sampleStatusBuckets.get(0).getStatusColumn().getPvName());
+    }
+
+    @Test
+    public void testQueryStreamAccumulatesAllChunks() {
+        annotationClient.saveSampleStatuses(
+                List.of(clockFrame(PV_1, 3, 1), clockFrame(PV_2, 3, 2)), null, null);
+
+        // chunk size 1 forces one message per bucket; the wrapper accumulates them all
+        final QuerySampleStatusesApiResult streamResult =
+                annotationClient.querySampleStatusesStream(queryParams(1, null));
+        assertFalse(streamResult.resultStatus.msg, streamResult.isError());
+        assertEquals(2, streamResult.sampleStatusBuckets.size());
+        assertEquals("", streamResult.nextPageToken);
+    }
+
+    @Test
+    public void testQueryStreamEmptyResultIsSuccess() {
+        final QuerySampleStatusesApiResult streamResult =
+                annotationClient.querySampleStatusesStream(queryParams(0, null));
+        assertFalse(streamResult.isError());
+        assertTrue(streamResult.sampleStatusBuckets.isEmpty());
+    }
+
+    // =========================================================================
+    // rejection surfacing tests
+    // =========================================================================
+
+    @Test
+    public void testSaveRejectSurfacedThroughResult() {
+        final SaveSampleStatusesApiResult result =
+                annotationClient.saveSampleStatuses(List.of(), null, null);
+        assertTrue(result.isError());
+        assertTrue(result.isReject());
+        assertTrue(result.resultStatus.msg.contains("at least one SampleStatusFrame"));
+        assertEquals(0, result.savedCount);
+    }
+
+    @Test
+    public void testQueryRejectSurfacedThroughResult() {
+        // begin == end fails validation
+        final QuerySampleStatusesApiResult result = annotationClient.querySampleStatuses(
+                new AnnotationClient.QuerySampleStatusesParams(
+                        timestamp(START_SECONDS, 0), timestamp(START_SECONDS, 0),
+                        null, null, null, 0, null));
+        assertTrue(result.isError());
+        assertTrue(result.isReject());
+        assertTrue(result.resultStatus.msg.contains("beginTime must be before endTime"));
+        assertNull(result.sampleStatusBuckets);
+    }
+
+    @Test
+    public void testQueryStreamRejectSurfacedThroughResult() {
+        // a non-empty pageToken is rejected on the streaming method
+        final QuerySampleStatusesApiResult result = annotationClient.querySampleStatusesStream(
+                queryParams(0, "some-token"));
+        assertTrue(result.isError());
+        assertTrue(result.isReject());
+        assertTrue(result.resultStatus.msg.contains("pageToken must be empty"));
+    }
+
+    @Test
+    public void testDeleteRejectSurfacedThroughResult() {
+        final DeleteSampleStatusesApiResult result = annotationClient.deleteSampleStatuses(
+                new AnnotationClient.DeleteSampleStatusesParams(
+                        timestamp(START_SECONDS, 0), timestamp(START_SECONDS + 10, 0),
+                        null, null, LAYER));
+        assertTrue(result.isError());
+        assertTrue(result.isReject());
+        assertTrue(result.resultStatus.msg.contains("domain must be specified"));
+        assertEquals(0, result.deletedCount);
+    }
+}

--- a/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/SampleStatusIT.java
+++ b/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/SampleStatusIT.java
@@ -1,0 +1,672 @@
+package com.ospreydcs.dp.service.integration.annotation;
+
+import com.ospreydcs.dp.grpc.v1.annotation.DeleteSampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.SaveSampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.common.DataTimestamps;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusBucket;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusColumn;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusFrame;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.service.annotation.AnnotationTestBase;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusBucketDocument;
+import com.ospreydcs.dp.service.common.protobuf.DataTimestampsUtility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for the Sample Status API: saveSampleStatuses (carve-and-insert upsert),
+ * querySampleStatuses (keyset paging), querySampleStatusesStream (fire-and-consume chunking),
+ * deleteSampleStatuses (exact at the sample axis), and the deferred domain-registry stubs.
+ */
+public class SampleStatusIT extends AnnotationIntegrationTestIntermediate {
+
+    private static final String DOMAIN = "data_quality";
+    private static final String DOMAIN_OTHER = "ml_anomaly";
+    private static final String LAYER = "ml_model_v1";
+    private static final String LAYER_OTHER = "operator_override";
+    private static final String PV_1 = "TEST:PV:001";
+    private static final String PV_2 = "TEST:PV:002";
+
+    private static final long START_SECONDS = 1_700_000_000L;
+    private static final long SECOND_NANOS = 1_000_000_000L;
+    private static final long PERIOD = 100_000_000L; // 100ms
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        super.tearDown();
+    }
+
+    // ------------------- helpers ---------------------------
+
+    private static Timestamp timestamp(long seconds, long nanos) {
+        return Timestamp.newBuilder().setEpochSeconds(seconds).setNanoseconds(nanos).build();
+    }
+
+    /** Epoch nanos of the i'th tick of the standard test clock (start + i * PERIOD). */
+    private static long tickNanos(int i) {
+        return START_SECONDS * SECOND_NANOS + i * PERIOD;
+    }
+
+    private static Timestamp tick(int i) {
+        return timestamp(tickNanos(i) / SECOND_NANOS, tickNanos(i) % SECOND_NANOS);
+    }
+
+    private static DataTimestamps clockAxis(int count) {
+        return DataTimestampsUtility.dataTimestampsWithSamplingClock(START_SECONDS, 0, PERIOD, count);
+    }
+
+    private static DataTimestamps listAxis(Timestamp... timestamps) {
+        return DataTimestampsUtility.dataTimestampsWithTimestampList(List.of(timestamps));
+    }
+
+    private static List<Integer> codes(int value, int count) {
+        return Collections.nCopies(count, value);
+    }
+
+    private static SampleStatusFrame frame(
+            String domain, String layer, DataTimestamps axis, SampleStatusColumn... columns) {
+        return AnnotationTestBase.buildSampleStatusFrame(domain, layer, axis, List.of(columns));
+    }
+
+    private static SampleStatusColumn column(String pvName, List<Integer> statusCodes) {
+        return AnnotationTestBase.buildSampleStatusColumn(pvName, statusCodes, null, null);
+    }
+
+    private long save(SampleStatusFrame... frames) {
+        final SaveSampleStatusesRequest request =
+                AnnotationTestBase.buildSaveSampleStatusesRequest(List.of(frames), "source-1", "user-1");
+        return annotationServiceWrapper.sendAndVerifySaveSampleStatuses(request, false, null);
+    }
+
+    private QuerySampleStatusesRequest queryRequest(
+            Timestamp beginTime, Timestamp endTime,
+            List<String> pvNames, List<String> domains, List<String> layers,
+            int limit, String pageToken) {
+        return AnnotationTestBase.buildQuerySampleStatusesRequest(
+                beginTime, endTime, pvNames, domains, layers, limit, pageToken);
+    }
+
+    /** Collects the epoch-nanos timestamps of every status in the given buckets. */
+    private static Set<Long> statusTimestamps(List<SampleStatusBucket> buckets) {
+        final Set<Long> result = new TreeSet<>();
+        for (SampleStatusBucket bucket : buckets) {
+            final DataTimestampsUtility.DataTimestampsIterator iterator =
+                    DataTimestampsUtility.dataTimestampsIterator(bucket.getDataTimestamps());
+            while (iterator.hasNext()) {
+                final Timestamp timestamp = iterator.next();
+                result.add(timestamp.getEpochSeconds() * SECOND_NANOS + timestamp.getNanoseconds());
+            }
+        }
+        return result;
+    }
+
+    // =========================================================================
+    // saveSampleStatuses tests
+    // =========================================================================
+
+    @Test
+    public void testSaveDenseClockMultiplePvs() {
+        // dense save: SamplingClock axis, two PVs -> one document per PV, savedCount = count x PVs
+        final long savedCount = save(frame(DOMAIN, LAYER, clockAxis(10),
+                column(PV_1, codes(1, 10)), column(PV_2, codes(2, 10))));
+        assertEquals(20, savedCount);
+
+        final List<SampleStatusBucketDocument> pv1Documents =
+                mongoClient.findSampleStatusBuckets(PV_1, DOMAIN, LAYER);
+        assertEquals(1, pv1Documents.size());
+        final SampleStatusBucketDocument document = pv1Documents.get(0);
+        assertEquals(codes(1, 10), document.getStatusCodes());
+        assertEquals(tickNanos(0), document.getFirstTimeNanos());
+        assertEquals(tickNanos(9), document.getLastTimeNanos());
+        assertEquals("source-1", document.getSource());
+        assertEquals("user-1", document.getModifiedBy());
+        assertNotNull(document.getUpdatedTime());
+        assertNull(document.getConfidence());
+        assertNull(document.getReasons());
+
+        assertEquals(1, mongoClient.findSampleStatusBuckets(PV_2, DOMAIN, LAYER).size());
+    }
+
+    @Test
+    public void testSaveSparseTimestampList() {
+        // sparse labeling: 3 suspect points; nothing is stored for unlabeled samples
+        final long savedCount = save(frame(DOMAIN, LAYER, listAxis(tick(1), tick(5), tick(9)),
+                column(PV_1, List.of(4, 4, 4))));
+        assertEquals(3, savedCount);
+
+        final List<SampleStatusBucketDocument> documents =
+                mongoClient.findSampleStatusBuckets(PV_1, DOMAIN, LAYER);
+        assertEquals(1, documents.size());
+        assertEquals(3, documents.get(0).getStatusCodes().size());
+        assertEquals(tickNanos(1), documents.get(0).getFirstTimeNanos());
+        assertEquals(tickNanos(9), documents.get(0).getLastTimeNanos());
+    }
+
+    @Test
+    public void testSaveUpsertIdenticalTimestampsIncomingWins() {
+        save(frame(DOMAIN, LAYER, clockAxis(5), column(PV_1, codes(1, 5))));
+
+        final List<SampleStatusBucketDocument> firstDocuments =
+                mongoClient.findSampleStatusBuckets(PV_1, DOMAIN, LAYER);
+        assertEquals(1, firstDocuments.size());
+
+        // re-save at identical timestamps with different codes and provenance: incoming wins whole
+        final SampleStatusColumn columnWithCompanions = AnnotationTestBase.buildSampleStatusColumn(
+                PV_1, codes(2, 5), List.of(0.9f, 0.9f, 0.9f, 0.9f, 0.9f), List.of("a", "b", "c", "d", "e"));
+        final SaveSampleStatusesRequest request = AnnotationTestBase.buildSaveSampleStatusesRequest(
+                List.of(frame(DOMAIN, LAYER, clockAxis(5), columnWithCompanions)), "source-2", "user-2");
+        assertEquals(5, annotationServiceWrapper.sendAndVerifySaveSampleStatuses(request, false, null));
+
+        final List<SampleStatusBucketDocument> documents =
+                mongoClient.findSampleStatusBuckets(PV_1, DOMAIN, LAYER);
+        assertEquals(1, documents.size());
+        final SampleStatusBucketDocument document = documents.get(0);
+        assertEquals(codes(2, 5), document.getStatusCodes());
+        assertEquals(5, document.getConfidence().size());
+        assertEquals("source-2", document.getSource());
+        assertEquals("user-2", document.getModifiedBy());
+    }
+
+    @Test
+    public void testSaveFullReplaceClearsCompanions() {
+        // first save carries confidence and reasons
+        save(frame(DOMAIN, LAYER, clockAxis(3), AnnotationTestBase.buildSampleStatusColumn(
+                PV_1, codes(1, 3), List.of(0.5f, 0.6f, 0.7f), List.of("x", "y", "z"))));
+        assertNotNull(mongoClient.findSampleStatusBuckets(PV_1, DOMAIN, LAYER).get(0).getConfidence());
+
+        // re-saving the same keys with empty companions clears the stored values (full replace)
+        save(frame(DOMAIN, LAYER, clockAxis(3), column(PV_1, codes(1, 3))));
+
+        final List<SampleStatusBucketDocument> documents =
+                mongoClient.findSampleStatusBuckets(PV_1, DOMAIN, LAYER);
+        assertEquals(1, documents.size());
+        assertNull(documents.get(0).getConfidence());
+        assertNull(documents.get(0).getReasons());
+    }
+
+    @Test
+    public void testSaveCrossFrameDuplicateKeyLaterFrameWins() {
+        // same identity keys in two frames of one request: later frame wins, savedCount counts both
+        final long savedCount = save(
+                frame(DOMAIN, LAYER, clockAxis(4), column(PV_1, codes(1, 4))),
+                frame(DOMAIN, LAYER, clockAxis(4), column(PV_1, codes(2, 4))));
+        assertEquals(8, savedCount);
+
+        final List<SampleStatusBucketDocument> documents =
+                mongoClient.findSampleStatusBuckets(PV_1, DOMAIN, LAYER);
+        assertEquals(1, documents.size());
+        assertEquals(codes(2, 4), documents.get(0).getStatusCodes());
+    }
+
+    @Test
+    public void testSaveInterleavedListLeavesClockDocumentUntouched() {
+        // clock document plus list points between its ticks: no identity collision, so the
+        // original document is untouched (provenance intact) and the two documents coexist
+        save(frame(DOMAIN, LAYER, clockAxis(3), column(PV_1, codes(1, 3))));
+
+        final Timestamp betweenTicks1 = timestamp(START_SECONDS, PERIOD / 2);
+        final Timestamp betweenTicks2 = timestamp(START_SECONDS, PERIOD + PERIOD / 2);
+        final SaveSampleStatusesRequest secondRequest = AnnotationTestBase.buildSaveSampleStatusesRequest(
+                List.of(frame(DOMAIN, LAYER, listAxis(betweenTicks1, betweenTicks2),
+                        column(PV_1, List.of(9, 9)))),
+                "source-2", "user-2");
+        assertEquals(2, annotationServiceWrapper.sendAndVerifySaveSampleStatuses(secondRequest, false, null));
+
+        final List<SampleStatusBucketDocument> documents =
+                mongoClient.findSampleStatusBuckets(PV_1, DOMAIN, LAYER);
+        assertEquals(2, documents.size());
+        // first document (by firstTimeNanos) is the original clock document, provenance untouched
+        assertEquals("source-1", documents.get(0).getSource());
+        assertEquals(codes(1, 3), documents.get(0).getStatusCodes());
+        assertEquals("source-2", documents.get(1).getSource());
+
+        // query returns the union of all five statuses
+        final AnnotationTestBase.QuerySampleStatusesResponseObserver observer =
+                annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                        queryRequest(tick(0), tick(10), List.of(PV_1), null, null, 0, null),
+                        false, null, 2);
+        assertEquals(5, statusTimestamps(observer.getSampleStatusBuckets()).size());
+    }
+
+    @Test
+    public void testSavePartialOverlapCarvesCollidingTimestamps() {
+        // overwrite one interior tick of an existing clock document: the colliding sample is
+        // carved out of the original, which takes the incoming provenance; a new document holds
+        // the incoming status
+        save(frame(DOMAIN, LAYER, clockAxis(5), column(PV_1, codes(1, 5))));
+
+        final SaveSampleStatusesRequest overwriteRequest = AnnotationTestBase.buildSaveSampleStatusesRequest(
+                List.of(frame(DOMAIN, LAYER, listAxis(tick(2)), column(PV_1, List.of(99)))),
+                "source-2", "user-2");
+        assertEquals(1, annotationServiceWrapper.sendAndVerifySaveSampleStatuses(overwriteRequest, false, null));
+
+        final List<SampleStatusBucketDocument> documents =
+                mongoClient.findSampleStatusBuckets(PV_1, DOMAIN, LAYER);
+        assertEquals(2, documents.size());
+
+        // carved document: 4 surviving samples, rewritten with the incoming save's provenance
+        final SampleStatusBucketDocument carvedDocument = documents.get(0);
+        assertEquals(4, carvedDocument.getStatusCodes().size());
+        assertEquals("source-2", carvedDocument.getSource());
+        assertEquals("user-2", carvedDocument.getModifiedBy());
+
+        // total statuses across documents: 4 + 1, with code 99 at tick 2
+        final AnnotationTestBase.QuerySampleStatusesResponseObserver observer =
+                annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                        queryRequest(tick(0), tick(10), List.of(PV_1), null, null, 0, null),
+                        false, null, 2);
+        assertEquals(5, statusTimestamps(observer.getSampleStatusBuckets()).size());
+        boolean foundOverwrite = false;
+        for (SampleStatusBucket bucket : observer.getSampleStatusBuckets()) {
+            if (bucket.getStatusColumn().getStatusCodesList().equals(List.of(99))) {
+                foundOverwrite = true;
+            }
+        }
+        assertTrue(foundOverwrite);
+    }
+
+    @Test
+    public void testSaveRejectEmptyFrames() {
+        annotationServiceWrapper.sendAndVerifySaveSampleStatuses(
+                AnnotationTestBase.buildSaveSampleStatusesRequest(List.of(), null, null),
+                true, "at least one SampleStatusFrame");
+    }
+
+    @Test
+    public void testSaveRejectDuplicatePvInFrame() {
+        annotationServiceWrapper.sendAndVerifySaveSampleStatuses(
+                AnnotationTestBase.buildSaveSampleStatusesRequest(
+                        List.of(frame(DOMAIN, LAYER, clockAxis(2),
+                                column(PV_1, codes(1, 2)), column(PV_1, codes(2, 2)))),
+                        null, null),
+                true, "more than one statusColumn for PV");
+    }
+
+    @Test
+    public void testSaveRejectStatusCodesLengthMismatch() {
+        annotationServiceWrapper.sendAndVerifySaveSampleStatuses(
+                AnnotationTestBase.buildSaveSampleStatusesRequest(
+                        List.of(frame(DOMAIN, LAYER, clockAxis(3), column(PV_1, codes(1, 2)))),
+                        null, null),
+                true, "statusCodes.length mismatch");
+    }
+
+    @Test
+    public void testSaveRejectZeroPeriodClock() {
+        final DataTimestamps axis =
+                DataTimestampsUtility.dataTimestampsWithSamplingClock(START_SECONDS, 0, 0, 2);
+        annotationServiceWrapper.sendAndVerifySaveSampleStatuses(
+                AnnotationTestBase.buildSaveSampleStatusesRequest(
+                        List.of(frame(DOMAIN, LAYER, axis, column(PV_1, codes(1, 2)))),
+                        null, null),
+                true, "periodNanos must be > 0");
+    }
+
+    @Test
+    public void testSaveRejectNonIncreasingTimestampList() {
+        annotationServiceWrapper.sendAndVerifySaveSampleStatuses(
+                AnnotationTestBase.buildSaveSampleStatusesRequest(
+                        List.of(frame(DOMAIN, LAYER, listAxis(tick(2), tick(1)),
+                                column(PV_1, codes(1, 2)))),
+                        null, null),
+                true, "not strictly increasing");
+    }
+
+    @Test
+    public void testSaveRejectionPersistsNothing() {
+        // second frame is invalid: the whole request is rejected and the first frame's valid
+        // statuses are not persisted
+        annotationServiceWrapper.sendAndVerifySaveSampleStatuses(
+                AnnotationTestBase.buildSaveSampleStatusesRequest(
+                        List.of(
+                                frame(DOMAIN, LAYER, clockAxis(2), column(PV_1, codes(1, 2))),
+                                frame("", LAYER, clockAxis(2), column(PV_2, codes(1, 2)))),
+                        null, null),
+                true, "domain must be specified");
+        assertTrue(mongoClient.findSampleStatusBucketsNoRetry(PV_1, DOMAIN, LAYER).isEmpty());
+    }
+
+    // =========================================================================
+    // querySampleStatuses tests
+    // =========================================================================
+
+    @Test
+    public void testQueryOverlapEdgesAndWholeBuckets() {
+        // one document with samples at ticks 0..9
+        save(frame(DOMAIN, LAYER, clockAxis(10), column(PV_1, codes(1, 10))));
+
+        // begin exactly at the document's last sample time: included (lastTime >= beginTime)
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(tick(9), tick(20), List.of(PV_1), null, null, 0, null),
+                false, null, 1);
+
+        // begin one nano past the last sample time: excluded
+        final Timestamp justPastLast = timestamp(START_SECONDS, 9 * PERIOD + 1);
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(justPastLast, tick(20), List.of(PV_1), null, null, 0, null),
+                false, null, 0);
+
+        // end exactly at the document's first sample time: excluded (firstTime < endTime, half-open)
+        final Timestamp wayBefore = timestamp(START_SECONDS - 100, 0);
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(wayBefore, tick(0), List.of(PV_1), null, null, 0, null),
+                false, null, 0);
+
+        // end one nano past the first sample time: included
+        final Timestamp justPastFirst = timestamp(START_SECONDS, 1);
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(wayBefore, justPastFirst, List.of(PV_1), null, null, 0, null),
+                false, null, 1);
+
+        // boundary bucket is returned WHOLE: a query covering one interior tick returns all 10 statuses
+        final AnnotationTestBase.QuerySampleStatusesResponseObserver observer =
+                annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                        queryRequest(tick(4), tick(5), List.of(PV_1), null, null, 0, null),
+                        false, null, 1);
+        assertEquals(10, observer.getSampleStatusBuckets().get(0).getStatusColumn().getStatusCodesCount());
+    }
+
+    @Test
+    public void testQueryEmptyPvNamesWildcardEnumeratesLabeledPvs() {
+        save(frame(DOMAIN, LAYER, clockAxis(2),
+                column(PV_1, codes(1, 2)), column(PV_2, codes(2, 2))));
+        save(frame(DOMAIN, LAYER_OTHER, clockAxis(2), column(PV_1, codes(3, 2))));
+
+        // empty pvNames matches all PVs the (domain, layer) has labeled
+        final AnnotationTestBase.QuerySampleStatusesResponseObserver observer =
+                annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                        queryRequest(tick(0), tick(10), null, List.of(DOMAIN), List.of(LAYER), 0, null),
+                        false, null, 2);
+        final Set<String> labeledPvs = new TreeSet<>();
+        for (SampleStatusBucket bucket : observer.getSampleStatusBuckets()) {
+            labeledPvs.add(bucket.getStatusColumn().getPvName());
+        }
+        assertEquals(Set.of(PV_1, PV_2), labeledPvs);
+    }
+
+    @Test
+    public void testQueryFilterCombinations() {
+        save(frame(DOMAIN, LAYER, clockAxis(2), column(PV_1, codes(1, 2)), column(PV_2, codes(1, 2))));
+        save(frame(DOMAIN, LAYER_OTHER, clockAxis(2), column(PV_1, codes(2, 2))));
+        save(frame(DOMAIN_OTHER, LAYER, clockAxis(2), column(PV_1, codes(3, 2))));
+
+        // no filters: everything in range
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(tick(0), tick(10), null, null, null, 0, null), false, null, 4);
+
+        // AND across fields: pvName AND domain AND layer
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(tick(0), tick(10), List.of(PV_1), List.of(DOMAIN), List.of(LAYER), 0, null),
+                false, null, 1);
+
+        // OR within a field: both layers of DOMAIN for PV_1
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(tick(0), tick(10), List.of(PV_1), List.of(DOMAIN),
+                        List.of(LAYER, LAYER_OTHER), 0, null),
+                false, null, 2);
+
+        // domain filter alone
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(tick(0), tick(10), null, List.of(DOMAIN_OTHER), null, 0, null),
+                false, null, 1);
+
+        // non-matching pvName
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(tick(0), tick(10), List.of("TEST:PV:NOPE"), null, null, 0, null),
+                false, null, 0);
+    }
+
+    @Test
+    public void testQueryPaginationKeysetTokens() {
+        // five buckets in deterministic order: PV_1 has three disjoint documents (different time
+        // spans), PV_2 has two; result order is (pvName, domain, layer, bucket start time)
+        save(frame(DOMAIN, LAYER, listAxis(tick(0), tick(1)), column(PV_1, codes(1, 2)), column(PV_2, codes(1, 2))));
+        save(frame(DOMAIN, LAYER, listAxis(tick(10), tick(11)), column(PV_1, codes(2, 2)), column(PV_2, codes(2, 2))));
+        save(frame(DOMAIN, LAYER, listAxis(tick(20), tick(21)), column(PV_1, codes(3, 2))));
+
+        final List<SampleStatusBucket> allBuckets = new ArrayList<>();
+
+        // page 1
+        AnnotationTestBase.QuerySampleStatusesResponseObserver observer =
+                annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                        queryRequest(tick(0), tick(30), null, null, null, 2, null), false, null, 2);
+        assertFalse(observer.getNextPageToken().isEmpty());
+        allBuckets.addAll(observer.getSampleStatusBuckets());
+
+        // page 2, resuming from the token
+        observer = annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(tick(0), tick(30), null, null, null, 2, observer.getNextPageToken()),
+                false, null, 2);
+        assertFalse(observer.getNextPageToken().isEmpty());
+        allBuckets.addAll(observer.getSampleStatusBuckets());
+
+        // page 3: last page has one bucket and an empty token
+        observer = annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(tick(0), tick(30), null, null, null, 2, observer.getNextPageToken()),
+                false, null, 1);
+        assertTrue(observer.getNextPageToken().isEmpty());
+        allBuckets.addAll(observer.getSampleStatusBuckets());
+
+        // all five buckets seen exactly once (no bucket split or repeated across pages), in
+        // (pvName, domain, layer, bucket start time) order
+        assertEquals(5, allBuckets.size());
+        assertEquals(PV_1, allBuckets.get(0).getStatusColumn().getPvName());
+        assertEquals(List.of(1, 1), allBuckets.get(0).getStatusColumn().getStatusCodesList());
+        assertEquals(List.of(2, 2), allBuckets.get(1).getStatusColumn().getStatusCodesList());
+        assertEquals(List.of(3, 3), allBuckets.get(2).getStatusColumn().getStatusCodesList());
+        assertEquals(PV_2, allBuckets.get(3).getStatusColumn().getPvName());
+        assertEquals(List.of(1, 1), allBuckets.get(3).getStatusColumn().getStatusCodesList());
+        assertEquals(List.of(2, 2), allBuckets.get(4).getStatusColumn().getStatusCodesList());
+    }
+
+    @Test
+    public void testQueryRejectInvalidPageToken() {
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(tick(0), tick(10), null, null, null, 0, "bogus-token"),
+                true, "not a valid page token", 0);
+    }
+
+    @Test
+    public void testQueryRejectMissingTimeRange() {
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(null, null, null, null, null, 0, null),
+                true, "timeRange must be provided", 0);
+    }
+
+    @Test
+    public void testQueryRejectBeginNotBeforeEnd() {
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(tick(5), tick(5), null, null, null, 0, null),
+                true, "beginTime must be before endTime", 0);
+    }
+
+    @Test
+    public void testQueryNoMatchIsEmptySuccess() {
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                queryRequest(tick(0), tick(10), null, null, null, 0, null), false, null, 0);
+    }
+
+    // =========================================================================
+    // querySampleStatusesStream tests
+    // =========================================================================
+
+    @Test
+    public void testQueryStreamChunksByLimit() {
+        save(frame(DOMAIN, LAYER, listAxis(tick(0)), column(PV_1, List.of(1)), column(PV_2, List.of(1))));
+        save(frame(DOMAIN, LAYER, listAxis(tick(10)), column(PV_1, List.of(2)), column(PV_2, List.of(2))));
+        save(frame(DOMAIN, LAYER, listAxis(tick(20)), column(PV_1, List.of(3))));
+
+        // five buckets streamed in chunks of two: sizes [2, 2, 1], every nextPageToken empty
+        // (asserted inside the wrapper)
+        final AnnotationTestBase.QuerySampleStatusesStreamResponseObserver observer =
+                annotationServiceWrapper.sendAndVerifyQuerySampleStatusesStream(
+                        queryRequest(tick(0), tick(30), null, null, null, 2, null), false, null, 5);
+        assertEquals(List.of(2, 2, 1), observer.getChunkSizes());
+    }
+
+    @Test
+    public void testQueryStreamEmptyResultIsSingleEmptyMessage() {
+        final AnnotationTestBase.QuerySampleStatusesStreamResponseObserver observer =
+                annotationServiceWrapper.sendAndVerifyQuerySampleStatusesStream(
+                        queryRequest(tick(0), tick(10), null, null, null, 0, null), false, null, 0);
+        assertEquals(List.of(0), observer.getChunkSizes());
+    }
+
+    @Test
+    public void testQueryStreamRejectNonEmptyPageToken() {
+        // build a real token so the rejection is specifically about streaming, not parseability
+        save(frame(DOMAIN, LAYER, listAxis(tick(0)), column(PV_1, List.of(1))));
+        save(frame(DOMAIN, LAYER, listAxis(tick(10)), column(PV_1, List.of(2))));
+        final AnnotationTestBase.QuerySampleStatusesResponseObserver unaryObserver =
+                annotationServiceWrapper.sendAndVerifyQuerySampleStatuses(
+                        queryRequest(tick(0), tick(30), null, null, null, 1, null), false, null, 1);
+        final String realToken = unaryObserver.getNextPageToken();
+        assertFalse(realToken.isEmpty());
+
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatusesStream(
+                queryRequest(tick(0), tick(30), null, null, null, 1, realToken),
+                true, "pageToken must be empty", 0);
+    }
+
+    // =========================================================================
+    // deleteSampleStatuses tests
+    // =========================================================================
+
+    private DeleteSampleStatusesRequest deleteRequest(
+            Timestamp beginTime, Timestamp endTime, List<String> pvNames, String domain, String layer) {
+        return AnnotationTestBase.buildDeleteSampleStatusesRequest(beginTime, endTime, pvNames, domain, layer);
+    }
+
+    @Test
+    public void testDeleteBoundaryTrimNotWholeDocument() {
+        // deleting [tick 0, tick 3) from a 10-tick document trims it, not deletes it whole
+        save(frame(DOMAIN, LAYER, clockAxis(10), column(PV_1, codes(1, 10))));
+
+        final long deletedCount = annotationServiceWrapper.sendAndVerifyDeleteSampleStatuses(
+                deleteRequest(tick(0), tick(3), List.of(PV_1), DOMAIN, LAYER), false, null);
+        assertEquals(3, deletedCount);
+
+        final List<SampleStatusBucketDocument> documents =
+                mongoClient.findSampleStatusBuckets(PV_1, DOMAIN, LAYER);
+        assertEquals(1, documents.size());
+        assertEquals(7, documents.get(0).getStatusCodes().size());
+        assertEquals(tickNanos(3), documents.get(0).getFirstTimeNanos());
+        assertEquals(tickNanos(9), documents.get(0).getLastTimeNanos());
+    }
+
+    @Test
+    public void testDeleteInteriorRangeSplitsDocumentInTwo() {
+        // deleting an interior range [tick 3, tick 7) splits the clock document in two
+        save(frame(DOMAIN, LAYER, clockAxis(10), column(PV_1, codes(1, 10))));
+
+        final long deletedCount = annotationServiceWrapper.sendAndVerifyDeleteSampleStatuses(
+                deleteRequest(tick(3), tick(7), List.of(PV_1), DOMAIN, LAYER), false, null);
+        assertEquals(4, deletedCount);
+
+        final List<SampleStatusBucketDocument> documents =
+                mongoClient.findSampleStatusBuckets(PV_1, DOMAIN, LAYER);
+        assertEquals(2, documents.size());
+        assertEquals(tickNanos(0), documents.get(0).getFirstTimeNanos());
+        assertEquals(tickNanos(2), documents.get(0).getLastTimeNanos());
+        assertEquals(tickNanos(7), documents.get(1).getFirstTimeNanos());
+        assertEquals(tickNanos(9), documents.get(1).getLastTimeNanos());
+
+        // deletion does not refresh provenance: survivors keep the original save's identity
+        assertEquals("source-1", documents.get(0).getSource());
+        assertEquals("user-1", documents.get(0).getModifiedBy());
+    }
+
+    @Test
+    public void testDeleteDocumentFullyInsideRangeRemoved() {
+        save(frame(DOMAIN, LAYER, clockAxis(5), column(PV_1, codes(1, 5))));
+
+        final long deletedCount = annotationServiceWrapper.sendAndVerifyDeleteSampleStatuses(
+                deleteRequest(tick(0), tick(10), List.of(PV_1), DOMAIN, LAYER), false, null);
+        assertEquals(5, deletedCount);
+        assertTrue(mongoClient.findSampleStatusBucketsNoRetry(PV_1, DOMAIN, LAYER).isEmpty());
+    }
+
+    @Test
+    public void testDeleteEmptyPvNamesWildcardScopedToDomainLayer() {
+        save(frame(DOMAIN, LAYER, clockAxis(3), column(PV_1, codes(1, 3)), column(PV_2, codes(1, 3))));
+        save(frame(DOMAIN, LAYER_OTHER, clockAxis(3), column(PV_1, codes(2, 3))));
+
+        // empty pvNames deletes the (domain, layer)'s statuses for ALL PVs in the range
+        final long deletedCount = annotationServiceWrapper.sendAndVerifyDeleteSampleStatuses(
+                deleteRequest(tick(0), tick(10), null, DOMAIN, LAYER), false, null);
+        assertEquals(6, deletedCount);
+        assertTrue(mongoClient.findSampleStatusBucketsNoRetry(PV_1, DOMAIN, LAYER).isEmpty());
+        assertTrue(mongoClient.findSampleStatusBucketsNoRetry(PV_2, DOMAIN, LAYER).isEmpty());
+
+        // the other layer is untouched: deletes are scoped to a single producer stream
+        assertEquals(1, mongoClient.findSampleStatusBuckets(PV_1, DOMAIN, LAYER_OTHER).size());
+    }
+
+    @Test
+    public void testDeleteCountsStatusesNotDocuments() {
+        // two documents for the PV: counts accumulate individual statuses across documents
+        save(frame(DOMAIN, LAYER, listAxis(tick(0), tick(1)), column(PV_1, codes(1, 2))));
+        save(frame(DOMAIN, LAYER, listAxis(tick(10), tick(11), tick(12)), column(PV_1, codes(2, 3))));
+
+        final long deletedCount = annotationServiceWrapper.sendAndVerifyDeleteSampleStatuses(
+                deleteRequest(tick(0), tick(20), List.of(PV_1), DOMAIN, LAYER), false, null);
+        assertEquals(5, deletedCount);
+    }
+
+    @Test
+    public void testDeleteNoMatchIsSuccessWithZeroCount() {
+        final long deletedCount = annotationServiceWrapper.sendAndVerifyDeleteSampleStatuses(
+                deleteRequest(tick(0), tick(10), List.of(PV_1), DOMAIN, LAYER), false, null);
+        assertEquals(0, deletedCount);
+    }
+
+    @Test
+    public void testDeleteRejectMissingDomain() {
+        annotationServiceWrapper.sendAndVerifyDeleteSampleStatuses(
+                deleteRequest(tick(0), tick(10), null, null, LAYER),
+                true, "domain must be specified");
+    }
+
+    @Test
+    public void testDeleteRejectMissingLayer() {
+        annotationServiceWrapper.sendAndVerifyDeleteSampleStatuses(
+                deleteRequest(tick(0), tick(10), null, DOMAIN, null),
+                true, "layer must be specified");
+    }
+
+    @Test
+    public void testDeleteRejectMissingTimeRange() {
+        annotationServiceWrapper.sendAndVerifyDeleteSampleStatuses(
+                deleteRequest(null, null, null, DOMAIN, LAYER),
+                true, "timeRange must be provided");
+    }
+
+    // =========================================================================
+    // deferred domain-registry stubs
+    // =========================================================================
+
+    @Test
+    public void testSaveSampleStatusDomainStub() {
+        annotationServiceWrapper.sendAndVerifySaveSampleStatusDomainStub();
+    }
+
+    @Test
+    public void testQuerySampleStatusDomainsStub() {
+        annotationServiceWrapper.sendAndVerifyQuerySampleStatusDomainsStub();
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/annotation/AnnotationTestBase.java
+++ b/src/test/java/com/ospreydcs/dp/service/annotation/AnnotationTestBase.java
@@ -2116,4 +2116,287 @@ public class AnnotationTestBase {
         return GetActiveConfigurationsRequest.newBuilder().setTimestamp(timestamp).build();
     }
 
+    // =========================================================================
+    // Sample Status response observers and request builders
+    // =========================================================================
+
+    public static class SaveSampleStatusesResponseObserver implements StreamObserver<SaveSampleStatusesResponse> {
+
+        private final CountDownLatch finishLatch = new CountDownLatch(1);
+        private final AtomicBoolean isError = new AtomicBoolean(false);
+        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<Long> savedCountList = Collections.synchronizedList(new ArrayList<>());
+
+        public void await() {
+            try { finishLatch.await(1, TimeUnit.MINUTES); }
+            catch (InterruptedException e) { isError.set(true); errorMessageList.add("await interrupted"); }
+        }
+        public boolean isError() { return isError.get(); }
+        public String getErrorMessage() { return errorMessageList.isEmpty() ? "" : errorMessageList.get(0); }
+        public Long getSavedCount() { return savedCountList.isEmpty() ? null : savedCountList.get(0); }
+
+        @Override
+        public void onNext(SaveSampleStatusesResponse response) {
+            new Thread(() -> {
+                if (response.hasExceptionalResult()) {
+                    isError.set(true);
+                    errorMessageList.add(response.getExceptionalResult().getMessage());
+                    finishLatch.countDown();
+                    return;
+                }
+                assertTrue(response.hasSaveSampleStatusesResult());
+                savedCountList.add(response.getSaveSampleStatusesResult().getSavedCount());
+                finishLatch.countDown();
+            }).start();
+        }
+        @Override public void onError(Throwable t) {
+            new Thread(() -> {
+                isError.set(true); errorMessageList.add("onError: " + Status.fromThrowable(t)); finishLatch.countDown();
+            }).start();
+        }
+        @Override public void onCompleted() {}
+    }
+
+    public static class QuerySampleStatusesResponseObserver implements StreamObserver<QuerySampleStatusesResponse> {
+
+        private final CountDownLatch finishLatch = new CountDownLatch(1);
+        private final AtomicBoolean isError = new AtomicBoolean(false);
+        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<com.ospreydcs.dp.grpc.v1.common.SampleStatusBucket> bucketList =
+                Collections.synchronizedList(new ArrayList<>());
+        private String nextPageToken = "";
+
+        public void await() {
+            try { finishLatch.await(1, TimeUnit.MINUTES); }
+            catch (InterruptedException e) { isError.set(true); errorMessageList.add("await interrupted"); }
+        }
+        public boolean isError() { return isError.get(); }
+        public String getErrorMessage() { return errorMessageList.isEmpty() ? "" : errorMessageList.get(0); }
+        public List<com.ospreydcs.dp.grpc.v1.common.SampleStatusBucket> getSampleStatusBuckets() { return bucketList; }
+        public String getNextPageToken() { return nextPageToken; }
+
+        @Override
+        public void onNext(QuerySampleStatusesResponse response) {
+            new Thread(() -> {
+                if (response.hasExceptionalResult()) {
+                    isError.set(true);
+                    errorMessageList.add(response.getExceptionalResult().getMessage());
+                    finishLatch.countDown();
+                    return;
+                }
+                assertTrue(response.hasQuerySampleStatusesResult());
+                bucketList.addAll(response.getQuerySampleStatusesResult().getSampleStatusBucketsList());
+                nextPageToken = response.getQuerySampleStatusesResult().getNextPageToken();
+                finishLatch.countDown();
+            }).start();
+        }
+        @Override public void onError(Throwable t) {
+            new Thread(() -> {
+                isError.set(true); errorMessageList.add("onError: " + Status.fromThrowable(t)); finishLatch.countDown();
+            }).start();
+        }
+        @Override public void onCompleted() {}
+    }
+
+    /**
+     * Observer for the server-streaming querySampleStatusesStream(): accumulates buckets across
+     * all streamed messages, records the per-message chunk sizes, and tracks whether any streamed
+     * message carried a non-empty nextPageToken (the contract requires all of them empty).
+     * Messages are processed inline (gRPC delivers them serially); the latch counts down at
+     * stream completion or error.
+     */
+    public static class QuerySampleStatusesStreamResponseObserver
+            implements StreamObserver<QuerySampleStatusesResponse> {
+
+        private final CountDownLatch finishLatch = new CountDownLatch(1);
+        private final AtomicBoolean isError = new AtomicBoolean(false);
+        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<com.ospreydcs.dp.grpc.v1.common.SampleStatusBucket> bucketList =
+                Collections.synchronizedList(new ArrayList<>());
+        private final List<Integer> chunkSizeList = Collections.synchronizedList(new ArrayList<>());
+        private final AtomicBoolean nonEmptyNextPageTokenSeen = new AtomicBoolean(false);
+
+        public void await() {
+            try { finishLatch.await(1, TimeUnit.MINUTES); }
+            catch (InterruptedException e) { isError.set(true); errorMessageList.add("await interrupted"); }
+        }
+        public boolean isError() { return isError.get(); }
+        public String getErrorMessage() { return errorMessageList.isEmpty() ? "" : errorMessageList.get(0); }
+        public List<com.ospreydcs.dp.grpc.v1.common.SampleStatusBucket> getSampleStatusBuckets() { return bucketList; }
+        public List<Integer> getChunkSizes() { return chunkSizeList; }
+        public boolean nonEmptyNextPageTokenSeen() { return nonEmptyNextPageTokenSeen.get(); }
+
+        @Override
+        public void onNext(QuerySampleStatusesResponse response) {
+            if (response.hasExceptionalResult()) {
+                isError.set(true);
+                errorMessageList.add(response.getExceptionalResult().getMessage());
+                return;
+            }
+            assertTrue(response.hasQuerySampleStatusesResult());
+            final QuerySampleStatusesResponse.QuerySampleStatusesResult result =
+                    response.getQuerySampleStatusesResult();
+            bucketList.addAll(result.getSampleStatusBucketsList());
+            chunkSizeList.add(result.getSampleStatusBucketsCount());
+            if (!result.getNextPageToken().isEmpty()) {
+                nonEmptyNextPageTokenSeen.set(true);
+            }
+        }
+        @Override public void onError(Throwable t) {
+            isError.set(true); errorMessageList.add("onError: " + Status.fromThrowable(t)); finishLatch.countDown();
+        }
+        @Override public void onCompleted() {
+            finishLatch.countDown();
+        }
+    }
+
+    public static class DeleteSampleStatusesResponseObserver implements StreamObserver<DeleteSampleStatusesResponse> {
+
+        private final CountDownLatch finishLatch = new CountDownLatch(1);
+        private final AtomicBoolean isError = new AtomicBoolean(false);
+        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<Long> deletedCountList = Collections.synchronizedList(new ArrayList<>());
+
+        public void await() {
+            try { finishLatch.await(1, TimeUnit.MINUTES); }
+            catch (InterruptedException e) { isError.set(true); errorMessageList.add("await interrupted"); }
+        }
+        public boolean isError() { return isError.get(); }
+        public String getErrorMessage() { return errorMessageList.isEmpty() ? "" : errorMessageList.get(0); }
+        public Long getDeletedCount() { return deletedCountList.isEmpty() ? null : deletedCountList.get(0); }
+
+        @Override
+        public void onNext(DeleteSampleStatusesResponse response) {
+            new Thread(() -> {
+                if (response.hasExceptionalResult()) {
+                    isError.set(true);
+                    errorMessageList.add(response.getExceptionalResult().getMessage());
+                    finishLatch.countDown();
+                    return;
+                }
+                assertTrue(response.hasDeleteSampleStatusesResult());
+                deletedCountList.add(response.getDeleteSampleStatusesResult().getDeletedCount());
+                finishLatch.countDown();
+            }).start();
+        }
+        @Override public void onError(Throwable t) {
+            new Thread(() -> {
+                isError.set(true); errorMessageList.add("onError: " + Status.fromThrowable(t)); finishLatch.countDown();
+            }).start();
+        }
+        @Override public void onCompleted() {}
+    }
+
+    public static class SaveSampleStatusDomainResponseObserver
+            implements StreamObserver<SaveSampleStatusDomainResponse> {
+        private final CountDownLatch finishLatch = new CountDownLatch(1);
+        private final AtomicBoolean isError = new AtomicBoolean(false);
+        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        public void await() {
+            try { finishLatch.await(1, TimeUnit.MINUTES); }
+            catch (InterruptedException e) { isError.set(true); errorMessageList.add("await interrupted"); }
+        }
+        public boolean isError() { return isError.get(); }
+        public String getErrorMessage() { return errorMessageList.isEmpty() ? "" : errorMessageList.get(0); }
+        @Override public void onNext(SaveSampleStatusDomainResponse response) {
+            if (response.hasExceptionalResult()) { isError.set(true); errorMessageList.add(response.getExceptionalResult().getMessage()); }
+            finishLatch.countDown();
+        }
+        @Override public void onError(Throwable t) { isError.set(true); errorMessageList.add("onError: " + Status.fromThrowable(t)); finishLatch.countDown(); }
+        @Override public void onCompleted() {}
+    }
+
+    public static class QuerySampleStatusDomainsResponseObserver
+            implements StreamObserver<QuerySampleStatusDomainsResponse> {
+        private final CountDownLatch finishLatch = new CountDownLatch(1);
+        private final AtomicBoolean isError = new AtomicBoolean(false);
+        private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        public void await() {
+            try { finishLatch.await(1, TimeUnit.MINUTES); }
+            catch (InterruptedException e) { isError.set(true); errorMessageList.add("await interrupted"); }
+        }
+        public boolean isError() { return isError.get(); }
+        public String getErrorMessage() { return errorMessageList.isEmpty() ? "" : errorMessageList.get(0); }
+        @Override public void onNext(QuerySampleStatusDomainsResponse response) {
+            if (response.hasExceptionalResult()) { isError.set(true); errorMessageList.add(response.getExceptionalResult().getMessage()); }
+            finishLatch.countDown();
+        }
+        @Override public void onError(Throwable t) { isError.set(true); errorMessageList.add("onError: " + Status.fromThrowable(t)); finishLatch.countDown(); }
+        @Override public void onCompleted() {}
+    }
+
+    public static com.ospreydcs.dp.grpc.v1.common.SampleStatusColumn buildSampleStatusColumn(
+            String pvName, List<Integer> statusCodes, List<Float> confidence, List<String> reasons) {
+        final com.ospreydcs.dp.grpc.v1.common.SampleStatusColumn.Builder builder =
+                com.ospreydcs.dp.grpc.v1.common.SampleStatusColumn.newBuilder();
+        if (pvName != null) builder.setPvName(pvName);
+        if (statusCodes != null) builder.addAllStatusCodes(statusCodes);
+        if (confidence != null) builder.addAllConfidence(confidence);
+        if (reasons != null) builder.addAllReasons(reasons);
+        return builder.build();
+    }
+
+    public static com.ospreydcs.dp.grpc.v1.common.SampleStatusFrame buildSampleStatusFrame(
+            String domain,
+            String layer,
+            com.ospreydcs.dp.grpc.v1.common.DataTimestamps dataTimestamps,
+            List<com.ospreydcs.dp.grpc.v1.common.SampleStatusColumn> statusColumns) {
+        final com.ospreydcs.dp.grpc.v1.common.SampleStatusFrame.Builder builder =
+                com.ospreydcs.dp.grpc.v1.common.SampleStatusFrame.newBuilder();
+        if (domain != null) builder.setDomain(domain);
+        if (layer != null) builder.setLayer(layer);
+        if (dataTimestamps != null) builder.setDataTimestamps(dataTimestamps);
+        if (statusColumns != null) builder.addAllStatusColumns(statusColumns);
+        return builder.build();
+    }
+
+    public static SaveSampleStatusesRequest buildSaveSampleStatusesRequest(
+            List<com.ospreydcs.dp.grpc.v1.common.SampleStatusFrame> frames, String source, String modifiedBy) {
+        final SaveSampleStatusesRequest.Builder builder = SaveSampleStatusesRequest.newBuilder();
+        if (frames != null) builder.addAllFrames(frames);
+        if (source != null) builder.setSource(source);
+        if (modifiedBy != null) builder.setModifiedBy(modifiedBy);
+        return builder.build();
+    }
+
+    public static QuerySampleStatusesRequest buildQuerySampleStatusesRequest(
+            Timestamp beginTime,
+            Timestamp endTime,
+            List<String> pvNames,
+            List<String> domains,
+            List<String> layers,
+            int limit,
+            String pageToken) {
+        final QuerySampleStatusesRequest.Builder builder = QuerySampleStatusesRequest.newBuilder();
+        if (beginTime != null || endTime != null) {
+            final com.ospreydcs.dp.grpc.v1.common.TimeRange.Builder timeRangeBuilder =
+                    com.ospreydcs.dp.grpc.v1.common.TimeRange.newBuilder();
+            if (beginTime != null) timeRangeBuilder.setBeginTime(beginTime);
+            if (endTime != null) timeRangeBuilder.setEndTime(endTime);
+            builder.setTimeRange(timeRangeBuilder);
+        }
+        if (pvNames != null) builder.addAllPvNames(pvNames);
+        if (domains != null) builder.addAllDomains(domains);
+        if (layers != null) builder.addAllLayers(layers);
+        if (limit > 0) builder.setLimit(limit);
+        if (pageToken != null && !pageToken.isBlank()) builder.setPageToken(pageToken);
+        return builder.build();
+    }
+
+    public static DeleteSampleStatusesRequest buildDeleteSampleStatusesRequest(
+            Timestamp beginTime, Timestamp endTime, List<String> pvNames, String domain, String layer) {
+        final DeleteSampleStatusesRequest.Builder builder = DeleteSampleStatusesRequest.newBuilder();
+        if (beginTime != null || endTime != null) {
+            final com.ospreydcs.dp.grpc.v1.common.TimeRange.Builder timeRangeBuilder =
+                    com.ospreydcs.dp.grpc.v1.common.TimeRange.newBuilder();
+            if (beginTime != null) timeRangeBuilder.setBeginTime(beginTime);
+            if (endTime != null) timeRangeBuilder.setEndTime(endTime);
+            builder.setTimeRange(timeRangeBuilder);
+        }
+        if (pvNames != null) builder.addAllPvNames(pvNames);
+        if (domain != null) builder.setDomain(domain);
+        if (layer != null) builder.setLayer(layer);
+        return builder.build();
+    }
+
 }

--- a/src/test/java/com/ospreydcs/dp/service/annotation/handler/SampleStatusValidationUtilityTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/annotation/handler/SampleStatusValidationUtilityTest.java
@@ -380,4 +380,114 @@ public class SampleStatusValidationUtilityTest {
                 deleteRequestBuilder().setLayer("").build());
         assertRejected(status, "layer must be specified");
     }
+
+    // ------------------- epoch-nanos overflow ---------------------------
+    //
+    // Every Sample Status timestamp is converted to a signed 64-bit epoch-nanos scalar by the
+    // storage and query paths (firstTimeNanos/lastTimeNanos, the overlap predicates, the keyset
+    // paging token). An epochSeconds above MAX_EPOCH_SECONDS (~year 2262) wraps negative, which
+    // would write a document no later overlap query can find, or build a time range matching the
+    // wrong set -- a silent wrong answer rather than an error. These cover all four call sites of
+    // validateTimestamp: TimestampList entries, SamplingClock startTime, and TimeRange
+    // begin/end on both query and delete.
+
+    /** First epochSeconds whose epoch-nanos conversion overflows a signed 64-bit long. */
+    private static final long OVERFLOW_SECONDS = Long.MAX_VALUE / 1_000_000_000L + 1;
+
+    /** Largest epochSeconds that still converts without overflow. */
+    private static final long MAX_SAFE_SECONDS = Long.MAX_VALUE / 1_000_000_000L;
+
+    @Test
+    public void testOverflowSecondsActuallyWrapsNegative() {
+        // guards the premise of the tests below: this is the arithmetic the storage path performs
+        assertTrue(OVERFLOW_SECONDS * 1_000_000_000L < 0);
+        assertTrue(MAX_SAFE_SECONDS * 1_000_000_000L > 0);
+    }
+
+    @Test
+    public void testSaveOverflowingTimestampListEntryRejected() {
+        final DataTimestamps axis = DataTimestampsUtility.dataTimestampsWithTimestampList(List.of(
+                timestamp(OVERFLOW_SECONDS, 0)));
+        final SampleStatusFrame frame = frameBuilder(1).setDataTimestamps(axis).build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "exceeds representable epoch-nanos range");
+    }
+
+    @Test
+    public void testSaveOverflowingLaterTimestampListEntryRejected() {
+        // the overflow is in the second entry: the axis is still strictly increasing, so only the
+        // range check catches it
+        final DataTimestamps axis = DataTimestampsUtility.dataTimestampsWithTimestampList(List.of(
+                timestamp(START_SECONDS, 0), timestamp(OVERFLOW_SECONDS, 0)));
+        final SampleStatusFrame frame = frameBuilder(2).setDataTimestamps(axis).build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "exceeds representable epoch-nanos range");
+    }
+
+    @Test
+    public void testSaveMaxSafeTimestampListEntryAccepted() {
+        final DataTimestamps axis = DataTimestampsUtility.dataTimestampsWithTimestampList(List.of(
+                timestamp(MAX_SAFE_SECONDS, 0)));
+        final SampleStatusFrame frame = frameBuilder(1).setDataTimestamps(axis).build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertFalse("boundary value must remain acceptable: " + status.msg, status.isError);
+    }
+
+    @Test
+    public void testSaveOverflowingClockStartTimeRejected() {
+        final DataTimestamps axis = DataTimestampsUtility.dataTimestampsWithSamplingClock(
+                OVERFLOW_SECONDS, 0, PERIOD, 2);
+        final SampleStatusFrame frame = frameBuilder(2).setDataTimestamps(axis).build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "exceeds representable epoch-nanos range");
+    }
+
+    @Test
+    public void testSaveClockAxisRunningPastRangeRejected() {
+        // startTime is representable, but start + (count-1) * period is not: the end-of-axis
+        // check in the SamplingClock branch is what catches this one
+        final DataTimestamps axis = DataTimestampsUtility.dataTimestampsWithSamplingClock(
+                MAX_SAFE_SECONDS, 0, Long.MAX_VALUE / 2, 3);
+        final SampleStatusFrame frame = frameBuilder(3).setDataTimestamps(axis).build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "time axis exceeds representable range");
+    }
+
+    @Test
+    public void testQueryOverflowingBeginTimeRejected() {
+        final ResultStatus status = SampleStatusValidationUtility.validateQuerySampleStatusesRequest(
+                queryRequest(TimeRange.newBuilder()
+                        .setBeginTime(timestamp(OVERFLOW_SECONDS, 0))
+                        .setEndTime(timestamp(OVERFLOW_SECONDS + 60, 0))
+                        .build()));
+        assertRejected(status, "exceeds representable epoch-nanos range");
+    }
+
+    @Test
+    public void testQueryOverflowingEndTimeRejected() {
+        final ResultStatus status = SampleStatusValidationUtility.validateQuerySampleStatusesRequest(
+                queryRequest(TimeRange.newBuilder()
+                        .setBeginTime(timestamp(START_SECONDS, 0))
+                        .setEndTime(timestamp(OVERFLOW_SECONDS, 0))
+                        .build()));
+        assertRejected(status, "exceeds representable epoch-nanos range");
+    }
+
+    @Test
+    public void testDeleteOverflowingEndTimeRejected() {
+        // an unguarded wrap here makes lt(firstTimeNanos, endNanos) match the wrong set, so the
+        // delete silently removes something other than what was asked for
+        final ResultStatus status = SampleStatusValidationUtility.validateDeleteSampleStatusesRequest(
+                deleteRequestBuilder()
+                        .setTimeRange(TimeRange.newBuilder()
+                                .setBeginTime(timestamp(START_SECONDS, 0))
+                                .setEndTime(timestamp(OVERFLOW_SECONDS, 0)))
+                        .build());
+        assertRejected(status, "exceeds representable epoch-nanos range");
+    }
 }

--- a/src/test/java/com/ospreydcs/dp/service/annotation/handler/SampleStatusValidationUtilityTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/annotation/handler/SampleStatusValidationUtilityTest.java
@@ -1,0 +1,383 @@
+package com.ospreydcs.dp.service.annotation.handler;
+
+import com.ospreydcs.dp.grpc.v1.annotation.DeleteSampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.QuerySampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.annotation.SaveSampleStatusesRequest;
+import com.ospreydcs.dp.grpc.v1.common.DataTimestamps;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusColumn;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusFrame;
+import com.ospreydcs.dp.grpc.v1.common.TimeRange;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.service.common.model.ResultStatus;
+import com.ospreydcs.dp.service.common.protobuf.DataTimestampsUtility;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class SampleStatusValidationUtilityTest {
+
+    private static final long MAX_STATUSES = 1_000_000L;
+    private static final long START_SECONDS = 1_700_000_000L;
+    private static final long PERIOD = 100_000_000L;
+
+    private static Timestamp timestamp(long seconds, long nanos) {
+        return Timestamp.newBuilder().setEpochSeconds(seconds).setNanoseconds(nanos).build();
+    }
+
+    private static DataTimestamps clockAxis(int count) {
+        return DataTimestampsUtility.dataTimestampsWithSamplingClock(START_SECONDS, 0, PERIOD, count);
+    }
+
+    private static SampleStatusColumn column(String pvName, int count) {
+        final SampleStatusColumn.Builder builder = SampleStatusColumn.newBuilder().setPvName(pvName);
+        for (int i = 0; i < count; i++) {
+            builder.addStatusCodes(i);
+        }
+        return builder.build();
+    }
+
+    private static SaveSampleStatusesRequest saveRequest(SampleStatusFrame... frames) {
+        return SaveSampleStatusesRequest.newBuilder().addAllFrames(List.of(frames)).build();
+    }
+
+    private static SampleStatusFrame.Builder frameBuilder(int count) {
+        return SampleStatusFrame.newBuilder()
+                .setDomain("data_quality")
+                .setLayer("layer_a")
+                .setDataTimestamps(clockAxis(count))
+                .addStatusColumns(column("pv_01", count));
+    }
+
+    private static void assertRejected(ResultStatus status, String expectedFragment) {
+        assertTrue(status.isError);
+        assertTrue("expected message containing '" + expectedFragment + "' but was: " + status.msg,
+                status.msg.contains(expectedFragment));
+    }
+
+    // ------------------- saveSampleStatuses ---------------------------
+
+    @Test
+    public void testSaveValidRequestAccepted() {
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frameBuilder(3).build()), MAX_STATUSES);
+        assertFalse(status.isError);
+    }
+
+    @Test
+    public void testSaveEmptyFramesRejected() {
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                SaveSampleStatusesRequest.newBuilder().build(), MAX_STATUSES);
+        assertRejected(status, "at least one SampleStatusFrame");
+    }
+
+    @Test
+    public void testSaveBlankDomainRejected() {
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frameBuilder(2).setDomain("").build()), MAX_STATUSES);
+        assertRejected(status, "domain must be specified");
+    }
+
+    @Test
+    public void testSaveBlankLayerRejected() {
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frameBuilder(2).setLayer(" ").build()), MAX_STATUSES);
+        assertRejected(status, "layer must be specified");
+    }
+
+    @Test
+    public void testSaveMissingDataTimestampsRejected() {
+        final SampleStatusFrame frame = SampleStatusFrame.newBuilder()
+                .setDomain("data_quality")
+                .setLayer("layer_a")
+                .addStatusColumns(column("pv_01", 2))
+                .build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "dataTimestamps must be provided");
+    }
+
+    @Test
+    public void testSaveNoStatusColumnsRejected() {
+        final SampleStatusFrame frame = SampleStatusFrame.newBuilder()
+                .setDomain("data_quality")
+                .setLayer("layer_a")
+                .setDataTimestamps(clockAxis(2))
+                .build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "at least one statusColumn");
+    }
+
+    @Test
+    public void testSaveBlankPvNameRejected() {
+        final SampleStatusFrame frame = frameBuilder(2)
+                .clearStatusColumns()
+                .addStatusColumns(column("", 2))
+                .build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "pvName must be specified");
+    }
+
+    @Test
+    public void testSaveDuplicatePvInFrameRejected() {
+        final SampleStatusFrame frame = frameBuilder(2)
+                .addStatusColumns(column("pv_01", 2))
+                .build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "more than one statusColumn for PV");
+    }
+
+    @Test
+    public void testSaveStatusCodesLengthMismatchRejected() {
+        final SampleStatusFrame frame = frameBuilder(3)
+                .clearStatusColumns()
+                .addStatusColumns(column("pv_01", 2))
+                .build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "statusCodes.length mismatch");
+    }
+
+    @Test
+    public void testSaveConfidenceLengthMismatchRejected() {
+        final SampleStatusColumn badColumn = SampleStatusColumn.newBuilder()
+                .setPvName("pv_01")
+                .addAllStatusCodes(List.of(1, 2, 3))
+                .addAllConfidence(List.of(0.5f))
+                .build();
+        final SampleStatusFrame frame = frameBuilder(3)
+                .clearStatusColumns()
+                .addStatusColumns(badColumn)
+                .build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "confidence must be empty or contain");
+    }
+
+    @Test
+    public void testSaveReasonsLengthMismatchRejected() {
+        final SampleStatusColumn badColumn = SampleStatusColumn.newBuilder()
+                .setPvName("pv_01")
+                .addAllStatusCodes(List.of(1, 2, 3))
+                .addAllReasons(List.of("a", "b"))
+                .build();
+        final SampleStatusFrame frame = frameBuilder(3)
+                .clearStatusColumns()
+                .addStatusColumns(badColumn)
+                .build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "reasons must be empty or contain");
+    }
+
+    @Test
+    public void testSaveFullLengthCompanionsAccepted() {
+        final SampleStatusColumn goodColumn = SampleStatusColumn.newBuilder()
+                .setPvName("pv_01")
+                .addAllStatusCodes(List.of(1, 2))
+                .addAllConfidence(List.of(0.5f, 0.6f))
+                .addAllReasons(List.of("", "spike"))
+                .build();
+        final SampleStatusFrame frame = frameBuilder(2)
+                .clearStatusColumns()
+                .addStatusColumns(goodColumn)
+                .build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertFalse(status.isError);
+    }
+
+    @Test
+    public void testSaveClockCountZeroRejected() {
+        final DataTimestamps axis =
+                DataTimestampsUtility.dataTimestampsWithSamplingClock(START_SECONDS, 0, PERIOD, 0);
+        final SampleStatusFrame frame = frameBuilder(0).setDataTimestamps(axis).build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "count must be >= 1");
+    }
+
+    @Test
+    public void testSaveClockPeriodZeroRejected() {
+        // periodNanos = 0 would collapse identity keys
+        final DataTimestamps axis =
+                DataTimestampsUtility.dataTimestampsWithSamplingClock(START_SECONDS, 0, 0, 3);
+        final SampleStatusFrame frame = frameBuilder(3).setDataTimestamps(axis).build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "periodNanos must be > 0");
+    }
+
+    @Test
+    public void testSaveEmptyTimestampListRejected() {
+        final DataTimestamps axis = DataTimestampsUtility.dataTimestampsWithTimestampList(List.of());
+        final SampleStatusFrame frame = frameBuilder(0).setDataTimestamps(axis).build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "timestamps cannot be empty");
+    }
+
+    @Test
+    public void testSaveNonIncreasingTimestampListRejected() {
+        final DataTimestamps axis = DataTimestampsUtility.dataTimestampsWithTimestampList(List.of(
+                timestamp(START_SECONDS, 100), timestamp(START_SECONDS, 50)));
+        final SampleStatusFrame frame = frameBuilder(2).setDataTimestamps(axis).build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "not strictly increasing");
+    }
+
+    @Test
+    public void testSaveDuplicateTimestampListEntriesRejected() {
+        // equal timestamps would collapse identity keys within the frame: strictly increasing required
+        final DataTimestamps axis = DataTimestampsUtility.dataTimestampsWithTimestampList(List.of(
+                timestamp(START_SECONDS, 100), timestamp(START_SECONDS, 100)));
+        final SampleStatusFrame frame = frameBuilder(2).setDataTimestamps(axis).build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "not strictly increasing");
+    }
+
+    @Test
+    public void testSaveInvalidTimestampNanosRejected() {
+        final DataTimestamps axis = DataTimestampsUtility.dataTimestampsWithTimestampList(List.of(
+                timestamp(START_SECONDS, 1_000_000_000L)));
+        final SampleStatusFrame frame = frameBuilder(1).setDataTimestamps(axis).build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "has invalid values");
+    }
+
+    @Test
+    public void testSaveMissingClockStartTimeRejected() {
+        final DataTimestamps axis = DataTimestamps.newBuilder()
+                .setSamplingClock(com.ospreydcs.dp.grpc.v1.common.SamplingClock.newBuilder()
+                        .setPeriodNanos(PERIOD)
+                        .setCount(2))
+                .build();
+        final SampleStatusFrame frame = frameBuilder(2).setDataTimestamps(axis).build();
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frame), MAX_STATUSES);
+        assertRejected(status, "startTime must be provided");
+    }
+
+    @Test
+    public void testSaveBatchCapExceededRejected() {
+        // 10 timestamps x 1 column = 10 statuses; cap of 9 rejects
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frameBuilder(10).build()), 9);
+        assertRejected(status, "exceeds maximum statuses per request");
+    }
+
+    @Test
+    public void testSaveMultipleValidFramesAccepted() {
+        final ResultStatus status = SampleStatusValidationUtility.validateSaveSampleStatusesRequest(
+                saveRequest(frameBuilder(3).build(), frameBuilder(2).setLayer("layer_b").build()),
+                MAX_STATUSES);
+        assertFalse(status.isError);
+    }
+
+    // ------------------- querySampleStatuses ---------------------------
+
+    private static QuerySampleStatusesRequest queryRequest(TimeRange timeRange) {
+        final QuerySampleStatusesRequest.Builder builder = QuerySampleStatusesRequest.newBuilder();
+        if (timeRange != null) {
+            builder.setTimeRange(timeRange);
+        }
+        return builder.build();
+    }
+
+    @Test
+    public void testQueryValidRequestAccepted() {
+        final ResultStatus status = SampleStatusValidationUtility.validateQuerySampleStatusesRequest(
+                queryRequest(TimeRange.newBuilder()
+                        .setBeginTime(timestamp(START_SECONDS, 0))
+                        .setEndTime(timestamp(START_SECONDS + 60, 0))
+                        .build()));
+        assertFalse(status.isError);
+    }
+
+    @Test
+    public void testQueryMissingTimeRangeRejected() {
+        final ResultStatus status =
+                SampleStatusValidationUtility.validateQuerySampleStatusesRequest(queryRequest(null));
+        assertRejected(status, "timeRange must be provided");
+    }
+
+    @Test
+    public void testQueryMissingBeginTimeRejected() {
+        final ResultStatus status = SampleStatusValidationUtility.validateQuerySampleStatusesRequest(
+                queryRequest(TimeRange.newBuilder().setEndTime(timestamp(START_SECONDS, 0)).build()));
+        assertRejected(status, "beginTime must be provided");
+    }
+
+    @Test
+    public void testQueryMissingEndTimeRejected() {
+        final ResultStatus status = SampleStatusValidationUtility.validateQuerySampleStatusesRequest(
+                queryRequest(TimeRange.newBuilder().setBeginTime(timestamp(START_SECONDS, 0)).build()));
+        assertRejected(status, "endTime must be provided");
+    }
+
+    @Test
+    public void testQueryBeginEqualsEndRejected() {
+        final ResultStatus status = SampleStatusValidationUtility.validateQuerySampleStatusesRequest(
+                queryRequest(TimeRange.newBuilder()
+                        .setBeginTime(timestamp(START_SECONDS, 500))
+                        .setEndTime(timestamp(START_SECONDS, 500))
+                        .build()));
+        assertRejected(status, "beginTime must be before endTime");
+    }
+
+    @Test
+    public void testQueryBeginAfterEndRejected() {
+        final ResultStatus status = SampleStatusValidationUtility.validateQuerySampleStatusesRequest(
+                queryRequest(TimeRange.newBuilder()
+                        .setBeginTime(timestamp(START_SECONDS + 60, 0))
+                        .setEndTime(timestamp(START_SECONDS, 0))
+                        .build()));
+        assertRejected(status, "beginTime must be before endTime");
+    }
+
+    // ------------------- deleteSampleStatuses ---------------------------
+
+    private static DeleteSampleStatusesRequest.Builder deleteRequestBuilder() {
+        return DeleteSampleStatusesRequest.newBuilder()
+                .setTimeRange(TimeRange.newBuilder()
+                        .setBeginTime(timestamp(START_SECONDS, 0))
+                        .setEndTime(timestamp(START_SECONDS + 60, 0)))
+                .setDomain("data_quality")
+                .setLayer("layer_a");
+    }
+
+    @Test
+    public void testDeleteValidRequestAccepted() {
+        final ResultStatus status = SampleStatusValidationUtility.validateDeleteSampleStatusesRequest(
+                deleteRequestBuilder().build());
+        assertFalse(status.isError);
+    }
+
+    @Test
+    public void testDeleteMissingTimeRangeRejected() {
+        final ResultStatus status = SampleStatusValidationUtility.validateDeleteSampleStatusesRequest(
+                deleteRequestBuilder().clearTimeRange().build());
+        assertRejected(status, "timeRange must be provided");
+    }
+
+    @Test
+    public void testDeleteBlankDomainRejected() {
+        final ResultStatus status = SampleStatusValidationUtility.validateDeleteSampleStatusesRequest(
+                deleteRequestBuilder().setDomain("").build());
+        assertRejected(status, "domain must be specified");
+    }
+
+    @Test
+    public void testDeleteBlankLayerRejected() {
+        final ResultStatus status = SampleStatusValidationUtility.validateDeleteSampleStatusesRequest(
+                deleteRequestBuilder().setLayer("").build());
+        assertRejected(status, "layer must be specified");
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/annotation/handler/model/SampleStatusPageTokenTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/annotation/handler/model/SampleStatusPageTokenTest.java
@@ -1,0 +1,56 @@
+package com.ospreydcs.dp.service.annotation.handler.model;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.Assert.*;
+
+public class SampleStatusPageTokenTest {
+
+    @Test
+    public void testEncodeDecodeRoundTrip() {
+        final SampleStatusPageToken token =
+                new SampleStatusPageToken("pv_01", "data_quality", "layer_a", 1_700_000_000_123_456_789L);
+        assertEquals(token, SampleStatusPageToken.decode(token.encode()));
+    }
+
+    @Test
+    public void testRoundTripWithAwkwardStrings() {
+        // names containing JSON/delimiter characters must survive the codec
+        final SampleStatusPageToken token = new SampleStatusPageToken(
+                "pv\"with|quotes", "domain{brace}", "layer:colon,comma", 42L);
+        assertEquals(token, SampleStatusPageToken.decode(token.encode()));
+    }
+
+    @Test
+    public void testSmallFirstTimeNanosRoundTrip() {
+        // small longs may serialize as plain JSON ints; the decoder must still read them as long
+        final SampleStatusPageToken token = new SampleStatusPageToken("pv", "d", "l", 7L);
+        assertEquals(token, SampleStatusPageToken.decode(token.encode()));
+    }
+
+    @Test
+    public void testDecodeGarbageReturnsNull() {
+        assertNull(SampleStatusPageToken.decode("not-base64!@#"));
+        assertNull(SampleStatusPageToken.decode(""));
+        assertNull(SampleStatusPageToken.decode(
+                Base64.getEncoder().encodeToString("not json".getBytes(StandardCharsets.UTF_8))));
+    }
+
+    @Test
+    public void testDecodeMissingFieldReturnsNull() {
+        final String tokenMissingField = Base64.getEncoder().encodeToString(
+                "{\"pvName\": \"pv\", \"domain\": \"d\"}".getBytes(StandardCharsets.UTF_8));
+        assertNull(SampleStatusPageToken.decode(tokenMissingField));
+    }
+
+    @Test
+    public void testDecodeForeignSkipOffsetTokenReturnsNull() {
+        // a pvMetadata-style Base64 skip-offset token must be rejected, not misread
+        final String skipOffsetToken =
+                Base64.getEncoder().encodeToString("100".getBytes(StandardCharsets.UTF_8));
+        assertNull(SampleStatusPageToken.decode(skipOffsetToken));
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/common/bson/samplestatus/SampleStatusDocumentUtilityTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/bson/samplestatus/SampleStatusDocumentUtilityTest.java
@@ -1,0 +1,325 @@
+package com.ospreydcs.dp.service.common.bson.samplestatus;
+
+import com.ospreydcs.dp.grpc.v1.common.DataTimestamps;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusColumn;
+import com.ospreydcs.dp.grpc.v1.common.Timestamp;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusDocumentUtility.RemovalResult;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusDocumentUtility.StatusPoint;
+import com.ospreydcs.dp.service.common.exception.DpException;
+import com.ospreydcs.dp.service.common.protobuf.DataTimestampsUtility;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class SampleStatusDocumentUtilityTest {
+
+    private static final long SECOND_NANOS = 1_000_000_000L;
+    private static final long START_SECONDS = 1_700_000_000L;
+    private static final long START_NANOS_EPOCH = START_SECONDS * SECOND_NANOS;
+    private static final long PERIOD = 100_000_000L; // 100ms
+
+    private static DataTimestamps clockAxis(long startSeconds, long startNanos, long periodNanos, int count) {
+        return DataTimestampsUtility.dataTimestampsWithSamplingClock(startSeconds, startNanos, periodNanos, count);
+    }
+
+    private static DataTimestamps listAxis(long... epochNanos) {
+        final List<Timestamp> timestamps = new ArrayList<>();
+        for (long nanos : epochNanos) {
+            timestamps.add(SampleStatusDocumentUtility.timestampFromNanos(nanos));
+        }
+        return DataTimestampsUtility.dataTimestampsWithTimestampList(timestamps);
+    }
+
+    private static SampleStatusBucketDocument document(
+            DataTimestamps axis, List<Integer> codes, List<Float> confidence, List<String> reasons) {
+        final SampleStatusColumn.Builder column = SampleStatusColumn.newBuilder()
+                .setPvName("pv_01")
+                .addAllStatusCodes(codes);
+        if (confidence != null) {
+            column.addAllConfidence(confidence);
+        }
+        if (reasons != null) {
+            column.addAllReasons(reasons);
+        }
+        return SampleStatusBucketDocument.fromSampleStatusColumn(
+                "data_quality", "layer_a", axis, column.build(), "source-1", "user-1", Instant.now());
+    }
+
+    // ------------------- timestampNanosList / timestampFromNanos ---------------------------
+
+    @Test
+    public void testTimestampNanosListSamplingClock() {
+        final List<Long> nanos = SampleStatusDocumentUtility.timestampNanosList(
+                clockAxis(START_SECONDS, 0, PERIOD, 5));
+        assertEquals(5, nanos.size());
+        assertEquals(START_NANOS_EPOCH, (long) nanos.get(0));
+        assertEquals(START_NANOS_EPOCH + 4 * PERIOD, (long) nanos.get(4));
+    }
+
+    @Test
+    public void testTimestampNanosListTimestampList() {
+        final List<Long> nanos = SampleStatusDocumentUtility.timestampNanosList(
+                listAxis(START_NANOS_EPOCH, START_NANOS_EPOCH + 7, START_NANOS_EPOCH + SECOND_NANOS));
+        assertEquals(List.of(START_NANOS_EPOCH, START_NANOS_EPOCH + 7, START_NANOS_EPOCH + SECOND_NANOS), nanos);
+    }
+
+    @Test
+    public void testTimestampFromNanosRoundTrip() {
+        final long nanos = START_NANOS_EPOCH + 123_456_789L;
+        final Timestamp timestamp = SampleStatusDocumentUtility.timestampFromNanos(nanos);
+        assertEquals(START_SECONDS, timestamp.getEpochSeconds());
+        assertEquals(123_456_789L, timestamp.getNanoseconds());
+        assertEquals(nanos, SampleStatusDocumentUtility.timestampNanos(timestamp));
+    }
+
+    // ------------------- expandDocument ---------------------------
+
+    @Test
+    public void testExpandDocumentWithCompanions() throws DpException {
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 3),
+                List.of(1, 2, 3),
+                List.of(0.1f, 0.2f, 0.3f),
+                List.of("a", "", "c"));
+        final List<StatusPoint> points = SampleStatusDocumentUtility.expandDocument(document);
+        assertEquals(3, points.size());
+        assertEquals(START_NANOS_EPOCH + PERIOD, points.get(1).timestampNanos());
+        assertEquals(2, points.get(1).statusCode());
+        assertEquals(0.2f, points.get(1).confidence(), 0.0f);
+        assertEquals("", points.get(1).reason());
+    }
+
+    @Test
+    public void testExpandDocumentWithoutCompanions() throws DpException {
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 2), List.of(7, 8), null, null);
+        final List<StatusPoint> points = SampleStatusDocumentUtility.expandDocument(document);
+        assertNull(points.get(0).confidence());
+        assertNull(points.get(0).reason());
+    }
+
+    @Test
+    public void testExpandDocumentMismatchedStatusCodesThrows() {
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 3), List.of(1, 2, 3), null, null);
+        document.setStatusCodes(List.of(1, 2)); // corrupt: 2 codes for 3 timestamps
+        assertThrows(DpException.class, () -> SampleStatusDocumentUtility.expandDocument(document));
+    }
+
+    @Test
+    public void testExpandDocumentMissingDataTimestampsThrows() {
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 2), List.of(1, 2), null, null);
+        document.setDataTimestamps(null);
+        assertThrows(DpException.class, () -> SampleStatusDocumentUtility.expandDocument(document));
+    }
+
+    // ------------------- buildDataTimestamps ---------------------------
+
+    @Test
+    public void testBuildDataTimestampsEvenlySpacedYieldsClock() {
+        final List<StatusPoint> points = List.of(
+                new StatusPoint(START_NANOS_EPOCH, 1, null, null),
+                new StatusPoint(START_NANOS_EPOCH + PERIOD, 2, null, null),
+                new StatusPoint(START_NANOS_EPOCH + 2 * PERIOD, 3, null, null));
+        final DataTimestamps axis = SampleStatusDocumentUtility.buildDataTimestamps(points);
+        assertTrue(axis.hasSamplingClock());
+        assertEquals(PERIOD, axis.getSamplingClock().getPeriodNanos());
+        assertEquals(3, axis.getSamplingClock().getCount());
+        assertEquals(START_SECONDS, axis.getSamplingClock().getStartTime().getEpochSeconds());
+    }
+
+    @Test
+    public void testBuildDataTimestampsIrregularYieldsList() {
+        final List<StatusPoint> points = List.of(
+                new StatusPoint(START_NANOS_EPOCH, 1, null, null),
+                new StatusPoint(START_NANOS_EPOCH + PERIOD, 2, null, null),
+                new StatusPoint(START_NANOS_EPOCH + 3 * PERIOD, 3, null, null));
+        final DataTimestamps axis = SampleStatusDocumentUtility.buildDataTimestamps(points);
+        assertTrue(axis.hasTimestampList());
+        assertEquals(3, axis.getTimestampList().getTimestampsCount());
+    }
+
+    @Test
+    public void testBuildDataTimestampsSinglePointYieldsList() {
+        final DataTimestamps axis = SampleStatusDocumentUtility.buildDataTimestamps(
+                List.of(new StatusPoint(START_NANOS_EPOCH, 1, null, null)));
+        assertTrue(axis.hasTimestampList());
+        assertEquals(1, axis.getTimestampList().getTimestampsCount());
+    }
+
+    // ------------------- removeTimestamps (save-path carve) ---------------------------
+
+    @Test
+    public void testRemoveTimestampsNoCollisionUntouched() throws DpException {
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 3), List.of(1, 2, 3), null, null);
+        // timestamps interleaved between the clock ticks: no exact collision
+        final RemovalResult result = SampleStatusDocumentUtility.removeTimestamps(
+                document, Set.of(START_NANOS_EPOCH + 1, START_NANOS_EPOCH + PERIOD + 1));
+        assertEquals(0, result.removedCount());
+        assertTrue(result.replacementDocuments().isEmpty());
+    }
+
+    @Test
+    public void testRemoveTimestampsAllCollideNoReplacement() throws DpException {
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 3), List.of(1, 2, 3), null, null);
+        final RemovalResult result = SampleStatusDocumentUtility.removeTimestamps(
+                document, Set.of(START_NANOS_EPOCH, START_NANOS_EPOCH + PERIOD, START_NANOS_EPOCH + 2 * PERIOD));
+        assertEquals(3, result.removedCount());
+        assertTrue(result.replacementDocuments().isEmpty());
+    }
+
+    @Test
+    public void testRemoveTimestampsPrefixSurvivorsStayClock() throws DpException {
+        // removing the first two ticks of a 5-tick clock leaves an evenly spaced run
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 5), List.of(1, 2, 3, 4, 5), null, null);
+        final RemovalResult result = SampleStatusDocumentUtility.removeTimestamps(
+                document, Set.of(START_NANOS_EPOCH, START_NANOS_EPOCH + PERIOD));
+        assertEquals(2, result.removedCount());
+        assertEquals(1, result.replacementDocuments().size());
+
+        final SampleStatusBucketDocument replacement = result.replacementDocuments().get(0);
+        assertEquals(List.of(3, 4, 5), replacement.getStatusCodes());
+        assertEquals(START_NANOS_EPOCH + 2 * PERIOD, replacement.getFirstTimeNanos());
+        assertEquals(START_NANOS_EPOCH + 4 * PERIOD, replacement.getLastTimeNanos());
+        final DataTimestamps axis = replacement.getDataTimestamps().toDataTimestamps();
+        assertTrue(axis.hasSamplingClock());
+        assertEquals(3, axis.getSamplingClock().getCount());
+    }
+
+    @Test
+    public void testRemoveTimestampsInteriorSurvivorsBecomeList() throws DpException {
+        // carving an interior tick leaves an unevenly spaced run: single TimestampList replacement
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 4), List.of(1, 2, 3, 4), null, null);
+        final RemovalResult result = SampleStatusDocumentUtility.removeTimestamps(
+                document, Set.of(START_NANOS_EPOCH + PERIOD));
+        assertEquals(1, result.removedCount());
+        assertEquals(1, result.replacementDocuments().size());
+
+        final SampleStatusBucketDocument replacement = result.replacementDocuments().get(0);
+        assertEquals(List.of(1, 3, 4), replacement.getStatusCodes());
+        assertTrue(replacement.getDataTimestamps().toDataTimestamps().hasTimestampList());
+    }
+
+    @Test
+    public void testRemoveTimestampsPreservesCompanions() throws DpException {
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 3),
+                List.of(1, 2, 3),
+                List.of(0.1f, 0.2f, 0.3f),
+                List.of("a", "b", "c"));
+        final RemovalResult result = SampleStatusDocumentUtility.removeTimestamps(
+                document, Set.of(START_NANOS_EPOCH + PERIOD));
+        final SampleStatusBucketDocument replacement = result.replacementDocuments().get(0);
+        assertEquals(List.of(0.1f, 0.3f), replacement.getConfidence());
+        assertEquals(List.of("a", "c"), replacement.getReasons());
+    }
+
+    @Test
+    public void testRemoveTimestampsAbsentCompanionsStayAbsent() throws DpException {
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 3), List.of(1, 2, 3), null, null);
+        final RemovalResult result = SampleStatusDocumentUtility.removeTimestamps(
+                document, Set.of(START_NANOS_EPOCH));
+        final SampleStatusBucketDocument replacement = result.replacementDocuments().get(0);
+        assertNull(replacement.getConfidence());
+        assertNull(replacement.getReasons());
+    }
+
+    @Test
+    public void testRemoveTimestampsPreservesIdentityAndProvenance() throws DpException {
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 2), List.of(1, 2), null, null);
+        final RemovalResult result = SampleStatusDocumentUtility.removeTimestamps(
+                document, Set.of(START_NANOS_EPOCH));
+        final SampleStatusBucketDocument replacement = result.replacementDocuments().get(0);
+        assertEquals("pv_01", replacement.getPvName());
+        assertEquals("data_quality", replacement.getDomain());
+        assertEquals("layer_a", replacement.getLayer());
+        assertEquals("source-1", replacement.getSource());
+        assertEquals("user-1", replacement.getModifiedBy());
+        assertEquals(document.getUpdatedTime(), replacement.getUpdatedTime());
+        assertNull(replacement.getId()); // new document, id assigned on insert
+    }
+
+    // ------------------- removeRange (delete path) ---------------------------
+
+    @Test
+    public void testRemoveRangeFullyInsideRemovesAll() throws DpException {
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 3), List.of(1, 2, 3), null, null);
+        final RemovalResult result = SampleStatusDocumentUtility.removeRange(
+                document, START_NANOS_EPOCH, START_NANOS_EPOCH + 3 * PERIOD);
+        assertEquals(3, result.removedCount());
+        assertTrue(result.replacementDocuments().isEmpty());
+    }
+
+    @Test
+    public void testRemoveRangeBoundaryTrimYieldsShorterClock() throws DpException {
+        // deleting [start, start+2*period) trims the first two ticks; survivors stay a clock
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 5), List.of(1, 2, 3, 4, 5), null, null);
+        final RemovalResult result = SampleStatusDocumentUtility.removeRange(
+                document, START_NANOS_EPOCH, START_NANOS_EPOCH + 2 * PERIOD);
+        assertEquals(2, result.removedCount());
+        assertEquals(1, result.replacementDocuments().size());
+        final DataTimestamps axis = result.replacementDocuments().get(0).getDataTimestamps().toDataTimestamps();
+        assertTrue(axis.hasSamplingClock());
+        assertEquals(3, axis.getSamplingClock().getCount());
+        assertEquals(List.of(3, 4, 5), result.replacementDocuments().get(0).getStatusCodes());
+    }
+
+    @Test
+    public void testRemoveRangeInteriorSplitsClockInTwo() throws DpException {
+        // deleting an interior range splits the clock document into two clock documents
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 6), List.of(1, 2, 3, 4, 5, 6), null, null);
+        final RemovalResult result = SampleStatusDocumentUtility.removeRange(
+                document, START_NANOS_EPOCH + 2 * PERIOD, START_NANOS_EPOCH + 4 * PERIOD);
+        assertEquals(2, result.removedCount());
+        assertEquals(2, result.replacementDocuments().size());
+
+        final SampleStatusBucketDocument before = result.replacementDocuments().get(0);
+        assertEquals(List.of(1, 2), before.getStatusCodes());
+        assertTrue(before.getDataTimestamps().toDataTimestamps().hasSamplingClock());
+        assertEquals(START_NANOS_EPOCH + PERIOD, before.getLastTimeNanos());
+
+        final SampleStatusBucketDocument after = result.replacementDocuments().get(1);
+        assertEquals(List.of(5, 6), after.getStatusCodes());
+        assertTrue(after.getDataTimestamps().toDataTimestamps().hasSamplingClock());
+        assertEquals(START_NANOS_EPOCH + 4 * PERIOD, after.getFirstTimeNanos());
+    }
+
+    @Test
+    public void testRemoveRangeHalfOpenBoundaries() throws DpException {
+        // [begin, end): a sample exactly at begin is removed, a sample exactly at end survives
+        final SampleStatusBucketDocument document = document(
+                clockAxis(START_SECONDS, 0, PERIOD, 3), List.of(1, 2, 3), null, null);
+        final RemovalResult result = SampleStatusDocumentUtility.removeRange(
+                document, START_NANOS_EPOCH + PERIOD, START_NANOS_EPOCH + 2 * PERIOD);
+        assertEquals(1, result.removedCount());
+        assertEquals(2, result.replacementDocuments().size());
+        assertEquals(List.of(1), result.replacementDocuments().get(0).getStatusCodes());
+        assertEquals(List.of(3), result.replacementDocuments().get(1).getStatusCodes());
+    }
+
+    @Test
+    public void testRemoveRangeSpanOverlapButNoSampleInRangeUntouched() throws DpException {
+        // sparse list document spanning the range with no sample inside it
+        final SampleStatusBucketDocument document = document(
+                listAxis(START_NANOS_EPOCH, START_NANOS_EPOCH + 10 * PERIOD), List.of(1, 2), null, null);
+        final RemovalResult result = SampleStatusDocumentUtility.removeRange(
+                document, START_NANOS_EPOCH + 2 * PERIOD, START_NANOS_EPOCH + 3 * PERIOD);
+        assertEquals(0, result.removedCount());
+        assertTrue(result.replacementDocuments().isEmpty());
+    }
+}

--- a/src/test/java/com/ospreydcs/dp/service/common/mongo/MongoTestClient.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/mongo/MongoTestClient.java
@@ -12,6 +12,7 @@ import com.ospreydcs.dp.service.common.bson.dataset.DataSetDocument;
 import com.ospreydcs.dp.service.common.bson.configuration.ConfigurationActivationDocument;
 import com.ospreydcs.dp.service.common.bson.configuration.ConfigurationDocument;
 import com.ospreydcs.dp.service.common.bson.pvmetadata.PvMetadataDocument;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusBucketDocument;
 import com.ospreydcs.dp.service.query.handler.mongo.client.MongoSyncQueryClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -290,6 +291,40 @@ public class MongoTestClient extends MongoSyncClient {
             }
         }
         return null;
+    }
+
+    /**
+     * Returns all sampleStatusBuckets documents for the given identity prefix, ordered by
+     * firstTimeNanos. Follows the retry-loop pattern (worker-thread insertion): retries until at
+     * least one matching document appears, returning an empty list if none ever does — callers
+     * expecting zero documents should use findSampleStatusBucketsNoRetry().
+     */
+    public List<SampleStatusBucketDocument> findSampleStatusBuckets(String pvName, String domain, String layer) {
+        for (int retryCount = 0 ; retryCount < MONGO_FIND_RETRY_COUNT ; ++retryCount){
+            final List<SampleStatusBucketDocument> matchingDocuments =
+                    findSampleStatusBucketsNoRetry(pvName, domain, layer);
+            if (matchingDocuments.size() > 0) {
+                return matchingDocuments;
+            } else {
+                try {
+                    logger.info("findSampleStatusBuckets pvName: " + pvName + " retrying");
+                    Thread.sleep(MONGO_FIND_RETRY_INTERVAL_MILLIS);
+                } catch (InterruptedException ex) {
+                    // ignore and just retry
+                }
+            }
+        }
+        return new ArrayList<>();
+    }
+
+    public List<SampleStatusBucketDocument> findSampleStatusBucketsNoRetry(
+            String pvName, String domain, String layer) {
+        final List<SampleStatusBucketDocument> matchingDocuments = new ArrayList<>();
+        mongoCollectionSampleStatusBuckets.find(and(
+                        eq("pvName", pvName), eq("domain", domain), eq("layer", layer)))
+                .sort(com.mongodb.client.model.Sorts.ascending("firstTimeNanos"))
+                .into(matchingDocuments);
+        return matchingDocuments;
     }
 
 }

--- a/src/test/java/com/ospreydcs/dp/service/common/utility/TabularDataUtilityTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/common/utility/TabularDataUtilityTest.java
@@ -54,10 +54,11 @@ public class TabularDataUtilityTest {
             List<TabularDataUtility.RetentionInterval> intervals) throws Exception {
 
         final Method method = TabularDataUtility.class.getDeclaredMethod(
-                "addColumnsToTable", DataTimestamps.class, List.class, TimestampDataMap.class, List.class);
+                "addColumnsToTable", DataTimestamps.class, List.class, TimestampDataMap.class, List.class,
+                TabularDataUtility.SampleStatusFilter.class);
         method.setAccessible(true);
         try {
-            method.invoke(null, dataTimestamps, dataColumns, tableValueMap, intervals);
+            method.invoke(null, dataTimestamps, dataColumns, tableValueMap, intervals, null);
         } catch (InvocationTargetException e) {
             throw (Exception) e.getCause();
         }

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/QueryV2ResolverTest.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/QueryV2ResolverTest.java
@@ -9,6 +9,7 @@ import com.ospreydcs.dp.grpc.v1.query.PvNameList;
 import com.ospreydcs.dp.grpc.v1.query.PvSelector;
 import com.ospreydcs.dp.grpc.v1.query.QuerySpec;
 import com.ospreydcs.dp.grpc.v1.query.ResultRepresentation;
+import com.ospreydcs.dp.grpc.v1.query.SampleStatusSelector;
 import com.ospreydcs.dp.service.common.bson.PvMetadataQueryResultDocument;
 import com.ospreydcs.dp.service.common.bson.ProviderDocument;
 import com.ospreydcs.dp.service.common.bson.ProviderMetadataQueryResultDocument;
@@ -22,6 +23,7 @@ import com.ospreydcs.dp.grpc.v1.query.QueryTableRequest;
 import com.ospreydcs.dp.service.query.handler.model.KeysetPosition;
 import com.ospreydcs.dp.service.query.handler.model.ResolutionResult;
 import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedStatusFilter;
 import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
 import com.ospreydcs.dp.service.query.handler.mongo.client.MongoQueryClientInterface;
 import com.ospreydcs.dp.service.query.handler.paging.PageToken;
@@ -62,6 +64,7 @@ public class QueryV2ResolverTest {
         @Override public MongoCursor<BucketDocument> executeQueryBucketsV2(ResolvedQuery q) { return null; }
         @Override public MongoCursor<BucketDocument> executeQueryBucketsV2Stream(ResolvedQuery q) { return null; }
         @Override public MongoCursor<BucketDocument> executeQuerySamplesV2(ResolvedQuery q, long bs, long bn) { return null; }
+        @Override public java.util.Map<String, java.util.Set<Long>> resolveSampleStatusTimestamps(ResolvedQuery q, long bs, long bn) { return java.util.Map.of(); }
         @Override public MongoCursor<ProviderDocument> executeQueryProviders(QueryProvidersRequest r) { return null; }
         @Override public MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(QueryProviderStatsRequest r) { return null; }
         @Override public MongoCursor<ProviderMetadataQueryResultDocument> executeQueryProviderStats(String id) { return null; }
@@ -334,5 +337,115 @@ public class QueryV2ResolverTest {
         assertEquals(1, rq.getRetrievalIntervals().size());
         assertEquals(new TimeInterval(10, 0, 50, 0), rq.getRetrievalIntervals().get(0));
         assertFalse(rq.isEmptyResult());
+    }
+
+    // -----------------------------------------------------------------------
+    // SampleStatusSelector validation: sample-oriented methods only; domain and
+    // mode required; layers/statusCodes are wildcards
+    // -----------------------------------------------------------------------
+
+    private static SampleStatusSelector.Builder statusSelector(SampleStatusSelector.Mode mode) {
+        return SampleStatusSelector.newBuilder().setDomain("data_quality").setMode(mode);
+    }
+
+    private ResolutionResult resolveSample(QuerySpec spec) {
+        return resolver().resolve(
+                spec, ExecutionOptions.getDefaultInstance(), ResultRepresentation.getDefaultInstance(),
+                ResolvedQuery.ResultMode.SAMPLE, false);
+    }
+
+    @Test
+    public void testStatusSelectorMissingDomainRejected() {
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(pvList("pv1"))
+                .setSampleStatusSelector(
+                        statusSelector(SampleStatusSelector.Mode.MODE_INCLUDE_MATCHING).setDomain(""))
+                .build();
+        final ResolutionResult r = resolveSample(spec);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("sampleStatusSelector.domain must be specified"));
+    }
+
+    @Test
+    public void testStatusSelectorModeUnspecifiedRejected() {
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(pvList("pv1"))
+                .setSampleStatusSelector(statusSelector(SampleStatusSelector.Mode.MODE_UNSPECIFIED))
+                .build();
+        final ResolutionResult r = resolveSample(spec);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("sampleStatusSelector.mode must be specified"));
+    }
+
+    @Test
+    public void testStatusSelectorOnBucketModeRejected() {
+        // bucket-oriented methods return storage buckets whole and cannot represent per-sample
+        // filtering: a well-formed selector still rejects in BUCKET mode
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(pvList("pv1"))
+                .setSampleStatusSelector(statusSelector(SampleStatusSelector.Mode.MODE_INCLUDE_MATCHING))
+                .build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.getDefaultInstance(), false);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("bucket-oriented methods do not support"));
+    }
+
+    @Test
+    public void testStatusSelectorOnBucketStreamModeRejected() {
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(pvList("pv1"))
+                .setSampleStatusSelector(statusSelector(SampleStatusSelector.Mode.MODE_EXCLUDE_MATCHING))
+                .build();
+        final ResolutionResult r = resolve(spec, ExecutionOptions.getDefaultInstance(), true);
+        assertTrue(r.isError());
+        assertTrue(r.getErrorStatus().msg.contains("bucket-oriented methods do not support"));
+    }
+
+    @Test
+    public void testStatusSelectorWellFormedResolves() {
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(pvList("pv1"))
+                .setSampleStatusSelector(statusSelector(SampleStatusSelector.Mode.MODE_INCLUDE_MATCHING)
+                        .addLayers("ml_model_v1")
+                        .addStatusCodes(3)
+                        .addStatusCodes(7))
+                .build();
+        final ResolutionResult r = resolveSample(spec);
+        assertFalse(r.isError());
+        final ResolvedStatusFilter filter = r.getResolvedQuery().getStatusFilter();
+        assertNotNull(filter);
+        assertEquals("data_quality", filter.domain());
+        assertEquals(List.of("ml_model_v1"), filter.layers());
+        assertTrue(filter.includeMode());
+        assertTrue(filter.matchesCode(3));
+        assertTrue(filter.matchesCode(7));
+        assertFalse(filter.matchesCode(4));
+    }
+
+    @Test
+    public void testStatusSelectorEmptyCodesMatchesAnyCode() {
+        // empty statusCodes = any code ("labeled at all"); empty layers = all layers in the domain
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(pvList("pv1"))
+                .setSampleStatusSelector(statusSelector(SampleStatusSelector.Mode.MODE_EXCLUDE_MATCHING))
+                .build();
+        final ResolutionResult r = resolveSample(spec);
+        assertFalse(r.isError());
+        final ResolvedStatusFilter filter = r.getResolvedQuery().getStatusFilter();
+        assertNotNull(filter);
+        assertTrue(filter.layers().isEmpty());
+        assertFalse(filter.includeMode());
+        assertTrue(filter.matchesCode(0));
+        assertTrue(filter.matchesCode(-42));
+    }
+
+    @Test
+    public void testNoStatusSelectorResolvesWithNullFilter() {
+        final QuerySpec spec = specWithTimeRange(0, 100)
+                .setPvSelector(pvList("pv1"))
+                .build();
+        final ResolutionResult r = resolveSample(spec);
+        assertFalse(r.isError());
+        assertNull(r.getResolvedQuery().getStatusFilter());
     }
 }

--- a/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQuerySamplesV2Test.java
+++ b/src/test/java/com/ospreydcs/dp/service/query/handler/mongo/MongoSyncQuerySamplesV2Test.java
@@ -6,6 +6,7 @@ import com.ospreydcs.dp.grpc.v1.common.DataColumn;
 import com.ospreydcs.dp.grpc.v1.common.DataTimestamps;
 import com.ospreydcs.dp.grpc.v1.common.DataValue;
 import com.ospreydcs.dp.grpc.v1.common.DoubleArrayColumn;
+import com.ospreydcs.dp.grpc.v1.common.SampleStatusColumn;
 import com.ospreydcs.dp.grpc.v1.common.SamplingClock;
 import com.ospreydcs.dp.grpc.v1.common.TimeRange;
 import com.ospreydcs.dp.grpc.v1.common.Timestamp;
@@ -21,12 +22,15 @@ import com.ospreydcs.dp.service.common.bson.DataTimestampsDocument;
 import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
 import com.ospreydcs.dp.service.common.bson.column.DataColumnDocument;
 import com.ospreydcs.dp.service.common.bson.column.DoubleArrayColumnDocument;
+import com.ospreydcs.dp.service.common.bson.samplestatus.SampleStatusBucketDocument;
 import com.ospreydcs.dp.service.common.exception.DpException;
 import com.ospreydcs.dp.service.common.mongo.MongoTestClient;
+import com.ospreydcs.dp.service.common.protobuf.DataTimestampsUtility;
 import com.ospreydcs.dp.service.common.protobuf.TimestampUtility;
 import com.ospreydcs.dp.service.query.handler.QueryV2Resolver;
 import com.ospreydcs.dp.service.query.handler.model.ResolutionResult;
 import com.ospreydcs.dp.service.query.handler.model.ResolvedQuery;
+import com.ospreydcs.dp.service.query.handler.model.ResolvedStatusFilter;
 import com.ospreydcs.dp.service.query.handler.model.TimeInterval;
 import com.ospreydcs.dp.service.query.handler.mongo.client.MongoSyncQueryClient;
 import com.ospreydcs.dp.service.query.handler.mongo.dispatch.QuerySamplesUnaryDispatcher;
@@ -36,6 +40,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -78,7 +83,19 @@ public class MongoSyncQuerySamplesV2Test extends MongoQueryHandlerTestBase {
             InsertManyResult result = mongoCollectionBuckets.insertMany(documentList);
             return result.getInsertedIds().size();
         }
+        public void insertSampleStatusBucketDocuments(List<SampleStatusBucketDocument> documentList) {
+            mongoCollectionSampleStatusBuckets.insertMany(documentList);
+        }
     }
+
+    // sampleStatusSelector fixture, on its own time base clear of the other PVs
+    private static final String PV_STATUS = "sspv";
+    private static final String PV_STATUS_2 = "sspv2";
+    private static final long STATUS_B = startSeconds + 300_000L;
+    private static final int STATUS_SECONDS = 10;
+    private static final String STATUS_DOMAIN = "dq";
+    private static final String STATUS_LAYER_1 = "l1";
+    private static final String STATUS_LAYER_2 = "l2";
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -97,8 +114,38 @@ public class MongoSyncQuerySamplesV2Test extends MongoQueryHandlerTestBase {
         // the same data stored as per-second buckets is filtered correctly by the database alone and
         // would not exercise the sample-level fragment trim.
         buckets.add(spanningBucket(PV_SPAN, SPAN_B, SPAN_SECONDS));
+        // sampleStatusSelector fixture: two 1 Hz PVs (values 0..9), statuses seeded below
+        buckets.add(spanningBucket(PV_STATUS, STATUS_B, STATUS_SECONDS));
+        buckets.add(spanningBucket(PV_STATUS_2, STATUS_B, STATUS_SECONDS));
         assertEquals(buckets.size(),
                 ((TestClientInterface) clientTestInterface).insertBucketDocuments(buckets));
+
+        // status fixture (domain dq):
+        //   l1/sspv:  offsets 2 and 5 code 7, offset 8 code 3, and a NEAR-MISS at offset 3 + 1ns
+        //             code 7 (must not label the sample at offset 3 -- matching is exact-timestamp)
+        //   l1/sspv2: offset 2 code 7
+        //   l2/sspv:  offset 6 code 7 (visible only through the layers wildcard)
+        final List<SampleStatusBucketDocument> statusDocuments = new ArrayList<>();
+        statusDocuments.add(statusDocument(PV_STATUS, STATUS_LAYER_1,
+                List.of(ts(STATUS_B + 2, 0), ts(STATUS_B + 3, 1), ts(STATUS_B + 5, 0), ts(STATUS_B + 8, 0)),
+                List.of(7, 7, 7, 3)));
+        statusDocuments.add(statusDocument(PV_STATUS_2, STATUS_LAYER_1,
+                List.of(ts(STATUS_B + 2, 0)), List.of(7)));
+        statusDocuments.add(statusDocument(PV_STATUS, STATUS_LAYER_2,
+                List.of(ts(STATUS_B + 6, 0)), List.of(7)));
+        testClient.insertSampleStatusBucketDocuments(statusDocuments);
+    }
+
+    private static SampleStatusBucketDocument statusDocument(
+            String pvName, String layer, List<Timestamp> timestamps, List<Integer> statusCodes) {
+        final SampleStatusColumn column = SampleStatusColumn.newBuilder()
+                .setPvName(pvName)
+                .addAllStatusCodes(statusCodes)
+                .build();
+        return SampleStatusBucketDocument.fromSampleStatusColumn(
+                STATUS_DOMAIN, layer,
+                DataTimestampsUtility.dataTimestampsWithTimestampList(timestamps),
+                column, "test-source", "test-user", Instant.now());
     }
 
     @AfterClass
@@ -730,5 +777,191 @@ public class MongoSyncQuerySamplesV2Test extends MongoQueryHandlerTestBase {
         }
         assertEquals("paged traversal must visit each in-fragment sample exactly once",
                 List.of(0L, 1L, 8L, 9L), collected);
+    }
+
+    // -----------------------------------------------------------------------
+    // sampleStatusSelector: per-sample filtering joined into ColumnTable assembly.
+    // Fixture: PV_STATUS/PV_STATUS_2 at 1 Hz over [STATUS_B, STATUS_B+10), values = offset;
+    // statuses per the setUp() comment.
+    // -----------------------------------------------------------------------
+
+    private static ResolvedQuery statusQuery(
+            List<String> pvNames, ResolvedStatusFilter statusFilter, List<TimeInterval> intervals) {
+        return new ResolvedQuery(
+                pvNames, intervals, DEFAULT_PAGE_SIZE, null, false, false,
+                ResolvedQuery.ResultMode.SAMPLE, false, statusFilter);
+    }
+
+    private static List<TimeInterval> wholeStatusRange() {
+        final List<TimeInterval> intervals = new ArrayList<>();
+        intervals.add(new TimeInterval(STATUS_B, 0, STATUS_B + STATUS_SECONDS, 0));
+        return intervals;
+    }
+
+    private static ResolvedStatusFilter statusFilter(boolean include, List<String> layers, Integer... codes) {
+        return new ResolvedStatusFilter(STATUS_DOMAIN, layers, java.util.Set.of(codes), include);
+    }
+
+    private ColumnTable runStatusUnary(ResolvedQuery resolvedQuery) {
+        final List<QuerySamplesResponse> responses = new ArrayList<>();
+        final StreamObserver<QuerySamplesResponse> observer = new StreamObserver<>() {
+            @Override public void onNext(QuerySamplesResponse r) { responses.add(r); }
+            @Override public void onError(Throwable t) { }
+            @Override public void onCompleted() { }
+        };
+        new QueryV2Job(resolvedQuery, new QuerySamplesUnaryDispatcher(observer, Long.MAX_VALUE),
+                clientTestInterface).execute();
+        assertEquals(1, responses.size());
+        assertTrue(responses.get(0).hasSampleQueryResult());
+        return responses.get(0).getSampleQueryResult().getColumnTable();
+    }
+
+    /** Offsets from STATUS_B of every timestamp in the table. */
+    private static List<Long> statusOffsets(ColumnTable table) {
+        final List<Long> offsets = new ArrayList<>();
+        for (Timestamp t : table.getTimestampList().getTimestampsList()) {
+            offsets.add(t.getEpochSeconds() - STATUS_B);
+        }
+        return offsets;
+    }
+
+    @Test
+    public void testStatusSelectorIncludeExactMatchOnly() {
+        // INCLUDE code 7 in l1: only offsets 2 and 5 -- offset 8 has a non-matching code, offset 6's
+        // label is in a non-selected layer, and the near-miss status at offset 3 + 1ns must NOT
+        // label the sample at offset 3 (exact nanosecond matching)
+        final ColumnTable table = runStatusUnary(statusQuery(
+                List.of(PV_STATUS), statusFilter(true, List.of(STATUS_LAYER_1), 7), wholeStatusRange()));
+        assertEquals(List.of(2L, 5L), statusOffsets(table));
+        final DataColumn column = columnByName(table, PV_STATUS);
+        assertEquals(2.0, column.getDataValues(0).getDoubleValue(), 0.0);
+        assertEquals(5.0, column.getDataValues(1).getDoubleValue(), 0.0);
+    }
+
+    @Test
+    public void testStatusSelectorIncludeEmptyCodesIsLabeledAtAll() {
+        // empty statusCodes = any code: offsets 2 and 5 (code 7) plus 8 (code 3); the near-miss
+        // still labels nothing
+        final ColumnTable table = runStatusUnary(statusQuery(
+                List.of(PV_STATUS), statusFilter(true, List.of(STATUS_LAYER_1)), wholeStatusRange()));
+        assertEquals(List.of(2L, 5L, 8L), statusOffsets(table));
+    }
+
+    @Test
+    public void testStatusSelectorEmptyLayersMatchesAllLayers() {
+        // layers wildcard: the l2 label at offset 6 now counts as well
+        final ColumnTable table = runStatusUnary(statusQuery(
+                List.of(PV_STATUS), statusFilter(true, List.of()), wholeStatusRange()));
+        assertEquals(List.of(2L, 5L, 6L, 8L), statusOffsets(table));
+    }
+
+    @Test
+    public void testStatusSelectorExcludePassesUnlabeled() {
+        // EXCLUDE any-code in l1 drops offsets 2, 5, 8; unlabeled samples pass
+        final ColumnTable table = runStatusUnary(statusQuery(
+                List.of(PV_STATUS), statusFilter(false, List.of(STATUS_LAYER_1)), wholeStatusRange()));
+        assertEquals(List.of(0L, 1L, 3L, 4L, 6L, 7L, 9L), statusOffsets(table));
+    }
+
+    @Test
+    public void testStatusSelectorMissingValueAndAllFilteredRowOmission() {
+        // EXCLUDE code 7 in l1 over both PVs: at offset 2 BOTH PVs are labeled, so the whole row is
+        // omitted; at offset 5 only PV_STATUS is labeled, so the row survives with an unset
+        // DataValue in the PV_STATUS column and a real value for PV_STATUS_2
+        final ColumnTable table = runStatusUnary(statusQuery(
+                List.of(PV_STATUS, PV_STATUS_2),
+                statusFilter(false, List.of(STATUS_LAYER_1), 7),
+                wholeStatusRange()));
+        assertEquals(List.of(0L, 1L, 3L, 4L, 5L, 6L, 7L, 8L, 9L), statusOffsets(table));
+
+        final DataColumn statusColumn = columnByName(table, PV_STATUS);
+        final DataColumn statusColumn2 = columnByName(table, PV_STATUS_2);
+        final int offset5Row = statusOffsets(table).indexOf(5L);
+        assertEquals(DataValue.ValueCase.VALUE_NOT_SET,
+                statusColumn.getDataValues(offset5Row).getValueCase());
+        assertEquals(5.0, statusColumn2.getDataValues(offset5Row).getDoubleValue(), 0.0);
+
+        // offset 8's label has code 3, which does not match code 7 -- the sample passes
+        final int offset8Row = statusOffsets(table).indexOf(8L);
+        assertEquals(8.0, statusColumn.getDataValues(offset8Row).getDoubleValue(), 0.0);
+    }
+
+    @Test
+    public void testStatusSelectorIncludeAllFilteredPvEmitsEmptyColumn() {
+        // INCLUDE code 7: PV_STATUS_2's only match is offset 2; PV_STATUS matches 2 and 5. Rows are
+        // the union {2, 5}; PV_STATUS_2 still gets its column with an unset value at offset 5
+        final ColumnTable table = runStatusUnary(statusQuery(
+                List.of(PV_STATUS, PV_STATUS_2),
+                statusFilter(true, List.of(STATUS_LAYER_1), 7),
+                wholeStatusRange()));
+        assertEquals(List.of(2L, 5L), statusOffsets(table));
+        final DataColumn statusColumn2 = columnByName(table, PV_STATUS_2);
+        assertEquals(2.0, statusColumn2.getDataValues(0).getDoubleValue(), 0.0);
+        assertEquals(DataValue.ValueCase.VALUE_NOT_SET, statusColumn2.getDataValues(1).getValueCase());
+    }
+
+    @Test
+    public void testStatusSelectorComposesWithFragmentsByIntersection() {
+        // fragments [0,4) and [6,10) with EXCLUDE code 7 in l1: the fragment restriction applies
+        // first, so the status at offset 5 (in the gap) has no effect; the status at offset 2 drops
+        // its in-fragment sample. Expected: fragment samples {0,1,2,3,6,7,8,9} minus {2}.
+        final List<TimeInterval> fragments = new ArrayList<>();
+        fragments.add(new TimeInterval(STATUS_B, 0, STATUS_B + 4, 0));
+        fragments.add(new TimeInterval(STATUS_B + 6, 0, STATUS_B + 10, 0));
+        final ColumnTable table = runStatusUnary(statusQuery(
+                List.of(PV_STATUS), statusFilter(false, List.of(STATUS_LAYER_1), 7), fragments));
+        assertEquals(List.of(0L, 1L, 3L, 6L, 7L, 8L, 9L), statusOffsets(table));
+    }
+
+    @Test
+    public void testStatusSelectorStreaming() {
+        // streaming path shares the same join: INCLUDE code 7 in l1 streams offsets 2 and 5
+        final StreamOutcome outcome = new StreamOutcome();
+        final StreamObserver<QuerySamplesResponse> observer = new StreamObserver<>() {
+            @Override public void onNext(QuerySamplesResponse r) { outcome.messages.add(r); }
+            @Override public void onError(Throwable t) { outcome.errored = true; }
+            @Override public void onCompleted() { outcome.completed = true; }
+        };
+        final ResolvedQuery resolvedQuery = new ResolvedQuery(
+                List.of(PV_STATUS), wholeStatusRange(), DEFAULT_PAGE_SIZE, null, false, false,
+                ResolvedQuery.ResultMode.SAMPLE, true,
+                statusFilter(true, List.of(STATUS_LAYER_1), 7));
+        new QueryV2Job(
+                resolvedQuery,
+                new com.ospreydcs.dp.service.query.handler.mongo.dispatch.QuerySamplesStreamDispatcher(
+                        observer, Long.MAX_VALUE),
+                clientTestInterface).execute();
+
+        assertFalse(outcome.errored);
+        assertTrue(outcome.completed);
+        final List<Long> allOffsets = new ArrayList<>();
+        for (QuerySamplesResponse r : outcome.messages) {
+            allOffsets.addAll(statusOffsets(r.getSampleQueryResult().getColumnTable()));
+        }
+        assertEquals(List.of(2L, 5L), allOffsets);
+    }
+
+    @Test
+    public void testStatusSelectorEndToEndThroughResolver() {
+        // full path: QuerySpec with a sampleStatusSelector through the resolver, then the unary
+        // dispatcher against real MongoDB
+        final QuerySpec spec = QuerySpec.newBuilder()
+                .setTimeRange(TimeRange.newBuilder()
+                        .setBeginTime(ts(STATUS_B, 0)).setEndTime(ts(STATUS_B + STATUS_SECONDS, 0)))
+                .setPvSelector(PvSelector.newBuilder()
+                        .setPvNameList(PvNameList.newBuilder().addPvNames(PV_STATUS)))
+                .setSampleStatusSelector(com.ospreydcs.dp.grpc.v1.query.SampleStatusSelector.newBuilder()
+                        .setDomain(STATUS_DOMAIN)
+                        .addLayers(STATUS_LAYER_1)
+                        .addStatusCodes(7)
+                        .setMode(com.ospreydcs.dp.grpc.v1.query.SampleStatusSelector.Mode.MODE_INCLUDE_MATCHING))
+                .build();
+        final ResolutionResult resolution = resolver().resolve(
+                spec, ExecutionOptions.getDefaultInstance(), ResultRepresentation.getDefaultInstance(),
+                ResolvedQuery.ResultMode.SAMPLE, false);
+        assertFalse(resolution.isError());
+
+        final ColumnTable table = runStatusUnary(resolution.getResolvedQuery());
+        assertEquals(List.of(2L, 5L), statusOffsets(table));
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -24,6 +24,13 @@ QueryHandler:
   queryV2MaxPageSize: ${DP_QUERY_HANDLER_QUERY_V2_MAX_PAGE_SIZE:100000}
   queryV2MaxResolvedPvCount: ${DP_QUERY_HANDLER_QUERY_V2_MAX_RESOLVED_PV_COUNT:10000}
 
+# AnnotationHandler: Annotation Service request handler settings (sample status paging/size limits).
+# Mirrors the main application.yml keys so tests exercise the same defaults; see that file for docs.
+AnnotationHandler:
+  sampleStatusQueryDefaultPageSize: ${DP_ANNOTATION_HANDLER_SAMPLE_STATUS_QUERY_DEFAULT_PAGE_SIZE:10000}
+  sampleStatusQueryMaxPageSize: ${DP_ANNOTATION_HANDLER_SAMPLE_STATUS_QUERY_MAX_PAGE_SIZE:100000}
+  sampleStatusSaveMaxStatuses: ${DP_ANNOTATION_HANDLER_SAMPLE_STATUS_SAVE_MAX_STATUSES:1000000}
+
 Level1:
   Level2:
     intValue: 60


### PR DESCRIPTION
Implements the Sample Status API service handlers per the plan in #238, against the API added in dp-grpc PR [osprey-dcs/dp-grpc#139](https://github.com/osprey-dcs/dp-grpc/pull/139) (dp-grpc issue #121). Closes #238.

## Annotation service

Implements `saveSampleStatuses`, `querySampleStatuses`, `querySampleStatusesStream` (the service's first server-streaming RPC), and `deleteSampleStatuses` following the modern CRUD pattern (`AnnotationServiceImpl` → handler → job → `MongoSyncAnnotationClient` → dispatcher); `saveSampleStatusDomain` / `querySampleStatusDomains` are deferred stubs per the `patchPvMetadata` pattern.

**Storage** is the new `sampleStatusBuckets` collection (`SampleStatusBucketDocument`), paralleling the data buckets collection, with the time span denormalized to `firstTimeNanos`/`lastTimeNanos` epoch-nanos scalars so the overlap predicate is a plain indexed range comparison rather than the seconds/nanos `$or` construction that defeats index bounds on the buckets collection (#198). Indexes on `(pvName, domain, layer, firstTimeNanos)` and `(domain, layer, firstTimeNanos)` (the latter serves empty-pvNames wildcard queries and layer-retirement deletes). Status documents deliberately have **no maximum span** — sparse labeling over an arbitrarily wide range is first-class — so no #197-style lower bound may ever be added to their overlap queries.

**Write path — carve-and-insert upsert.** The storage invariant is that no two documents ever assert the same identity key `(pvName, timestamp, domain, layer)`: exactly-colliding timestamps are carved out of existing overlapping documents (which take the incoming save's provenance and a fresh `updatedTime`), then the incoming column is inserted whole, preserving its axis representation. Documents with overlapping spans but no colliding timestamps are left untouched, provenance intact. Carves happen before the insert, so a mid-write failure can lose replaced statuses but never leaves duplicate keys (partial persistence on error is documented API behavior). This choice — versus sample-wise merging — keeps the optional confidence/reasons companion arrays homogeneous per document (no filler values), preserves compact clock representations for dense saves, and shares one heavily unit-tested removal primitive with the delete path.

**Delete is exact at the sample axis**: boundary documents are trimmed or split via the shared `removeRange()` primitive — an evenly spaced surviving run re-emits as a SamplingClock, so an interior delete splits a clock document into two clocks — and trimmed survivors keep their original provenance (deletion is not a save). Counts are individual statuses, not documents.

**Query paging is keyset**: the token encodes the last-returned `(pvName, domain, layer, firstTimeNanos)` sort position — unique under the storage invariant, and stable while documents are rewritten in place, where a skip-offset would drift. Unparseable tokens are rejected per the contract. The streaming variant pages internally and emits limit-sized chunks with empty continuation tokens; a non-empty request token is rejected.

New config keys (`AnnotationHandler` section, both application.yml files): `sampleStatusQueryDefaultPageSize` (10000), `sampleStatusQueryMaxPageSize` (100000, silent clamp), `sampleStatusSaveMaxStatuses` (1000000 per-request cap).

## Query service (V2)

`QueryV2Resolver` validates `QuerySpec.sampleStatusSelector` (required domain and mode) and **rejects it on the bucket-oriented methods** — whole storage buckets cannot represent per-sample filtering. The validated selector rides on `ResolvedQuery` as the internal `ResolvedStatusFilter`. `MongoSyncQueryClient.resolveSampleStatusTimestamps()` joins against `sampleStatusBuckets` over the same clamped page window the bucket retrieval uses (#207), producing per-PV sets of matching epoch-nanos timestamps; `TabularDataUtility.SampleStatusFilter` applies the per-sample test during ColumnTable assembly (INCLUDE keeps a sample iff labeled at its **exact** nanosecond timestamp; EXCLUDE drops it). Composition with `configurationSelector` is by intersection — both tests share one retention decision. Filtered samples are never inserted, so missing values (unset `DataValue`) and all-PVs-filtered row omission fall out of the existing representation, and the up-front column registration keeps all-filtered PVs as all-empty columns. A database error or corrupt status document surfaces as an error, never as "no statuses" (in EXCLUDE mode that would silently return filtered-out samples).

## Client layer

`AnnotationClient` wrappers for the four implemented methods: typed results (`SaveSampleStatusesApiResult`, `QuerySampleStatusesApiResult`, `DeleteSampleStatusesApiResult`), observers on the #228 `ApiResponseObserverBase`, params records with request builders, and send/convenience pairs. The streaming method gets a dedicated multi-response observer (the shared base treats a second response as a failure by design) that accumulates buckets inline and returns them as a single result.

## Tests

- **Unit (377 pass, ~75 new):** `SampleStatusDocumentUtilityTest` (expand/carve/trim/split, clock re-emission, companion preservation, half-open boundaries, malformed-document DpException), `SampleStatusValidationUtilityTest` (the full rejection matrix), `SampleStatusPageTokenTest` (round-trip incl. awkward strings; garbage/foreign tokens decode to null), `QueryV2ResolverTest` selector group, `MongoSyncQuerySamplesV2Test` selector group (exact-match with a +1 ns near-miss labeling nothing, empty-codes labeled-at-all, layer wildcards, missing-value/row-omission representation, fragment composition, streaming, resolver-to-assembly end to end).
- **Integration (45 new):** `SampleStatusIT` (35) covers the API handoff checklist — dense/sparse saves, identical-timestamp overwrite, full-replace clearing companions, cross-frame duplicate keys, interleave coexistence, partial-overlap carve, rejection cases incl. nothing-persisted-on-reject; overlap edges, whole boundary buckets, wildcard enumeration, AND/OR filters, keyset pagination round-trip, stream chunking; delete trim/split/wildcard/counting. `SampleStatusClientIT` (10) covers the client wrappers and rejection surfacing.
- **Regression:** PvMetadataIT, ConfigurationIT, AnnotationCalculationsIT, ExportDataIT, QueryV2GrpcIT, QueryTableIT, QueryDataIT all pass (104 tests).

One noted deviation from the handoff's test checklist: the "SamplingClock/TimestampList interleave merge" case is satisfied by **coexistence** rather than merging — interleaved non-colliding points become a second document and the original clock document stays untouched with its provenance intact, which the storage-is-non-normative contract permits (verified by `testSaveInterleavedListLeavesClockDocumentUntouched`).

Requires dp-grpc `main` (PR #139 merged); CI already builds dp-grpc `main` into the local Maven repo, and `dp-grpc.version` stays 1.16.0 until the rel-1.17.0 version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyMBz7pL2nncBppzH7hAPS
