### PR TITLE
dp-service #240: pass server rejection messages through to callers unmodified

### DIFF
--- a/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/AnnotationClient.java
@@ -1436,9 +1436,14 @@ public class AnnotationClient extends ServiceApiClientBase {
         public void onNext(QuerySampleStatusesResponse response) {
             if (response.hasExceptionalResult()) {
                 final ExceptionalResult exceptionalResult = response.getExceptionalResult();
-                recordFailure(
+                // the service's message is recorded verbatim for the caller; this observer's
+                // identity goes on the console line only.  See the message contract on
+                // ApiResponseObserverBase.
+                System.err.println(
                         "QuerySampleStatusesStreamResponseObserver onNext received exceptional "
-                                + "response: " + exceptionalResult.getMessage(),
+                                + "response: " + exceptionalResult.getMessage());
+                recordFailure(
+                        exceptionalResult.getMessage(),
                         ApiResultStatus.fromProto(exceptionalResult.getExceptionalResultStatus()));
                 return;
             }

--- a/src/main/java/com/ospreydcs/dp/client/ApiResponseObserverBase.java
+++ b/src/main/java/com/ospreydcs/dp/client/ApiResponseObserverBase.java
@@ -36,6 +36,17 @@ import java.util.concurrent.atomic.AtomicReference;
  * original defect, so subclasses must report failures through {@code recordFailure} rather than
  * touching the error state directly.
  *
+ * <p><strong>Message contract.</strong> A failure the client itself detected -- a duplicate
+ * response, an expired await, a response missing its result field -- is named by this observer,
+ * and its message carries {@link #observerName} so that the caller can tell which RPC produced it.
+ * A failure the <em>service</em> reported is different: the service already wrote a complete
+ * sentence for the caller to read, so its message is recorded verbatim.  Prefixing it would
+ * displace the actual explanation in {@code ApiResult.resultStatus.msg}, which for most callers is
+ * the only message they have.  The observer identity is not lost -- it is written to the console
+ * line and is available from the result's type.  {@code ApiResponseObserverBaseTest} asserts the
+ * pass-through with an exact-equality check, since a {@code contains()} assertion would pass
+ * whether or not a prefix crept back in.
+ *
  * <p><strong>Threading.</strong> {@code onNext} and {@code onError} dispatch their work onto a new
  * thread, preserving the behavior of the observers this class replaces: it keeps response handling
  * off the service handler's thread, so in-process tests exercise the same concurrency an
@@ -143,8 +154,21 @@ public abstract class ApiResponseObserverBase<T extends Message> implements Stre
      * @param apiResultStatus the status to report, or null to leave it at its current value
      */
     protected final void recordFailure(String errorMsg, ApiResultStatus apiResultStatus) {
+        recordFailure(errorMsg, apiResultStatus, true);
+    }
 
-        System.err.println(errorMsg);
+    /**
+     * Records a failure, optionally suppressing the console line.
+     *
+     * <p>{@code print} is false only for a failure whose caller has already written a more
+     * informative console line than the recorded message -- a service-supplied message, which is
+     * recorded verbatim for the caller but logged with this observer's identity attached.
+     */
+    private void recordFailure(String errorMsg, ApiResultStatus apiResultStatus, boolean print) {
+
+        if (print) {
+            System.err.println(errorMsg);
+        }
 
         if (apiResultStatus != null) {
             this.apiResultStatus.compareAndSet(ApiResultStatus.NONE, apiResultStatus);
@@ -225,10 +249,18 @@ public abstract class ApiResponseObserverBase<T extends Message> implements Stre
 
             if (hasExceptionalResult(response)) {
                 final ExceptionalResult exceptionalResult = getExceptionalResult(response);
-                recordFailure(
+                // the service wrote this message for the caller to read, so it is passed through
+                // unmodified: prefixing it with this observer's identity displaces the actual
+                // explanation in the only message a caller has.  The identity is still useful for
+                // diagnosis, so it goes on the console line instead, which is why this branch
+                // prints for itself rather than letting recordFailure do it.
+                System.err.println(
                         observerName() + " onNext received exceptional response: "
-                                + exceptionalResult.getMessage(),
-                        ApiResultStatus.fromProto(exceptionalResult.getExceptionalResultStatus()));
+                                + exceptionalResult.getMessage());
+                recordFailure(
+                        exceptionalResult.getMessage(),
+                        ApiResultStatus.fromProto(exceptionalResult.getExceptionalResultStatus()),
+                        false);
                 return;
             }
 

--- a/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
+++ b/src/main/java/com/ospreydcs/dp/client/IngestionClient.java
@@ -372,9 +372,14 @@ public class IngestionClient extends ServiceApiClientBase {
         public void onNext(IngestDataResponse response) {
 
             if (response.hasExceptionalResult()) {
-                final String errorMsg = "onNext received exceptional response: "
-                        + response.getExceptionalResult().getMessage();
-                System.err.println(errorMsg);
+                // the service's message is recorded verbatim for the caller; this observer's
+                // identity goes on the console line only.  See the message contract on
+                // ApiResponseObserverBase, which this observer cannot extend because it accepts
+                // more than one response.
+                final String errorMsg = response.getExceptionalResult().getMessage();
+                System.err.println(
+                        "IngestDataResponseObserver onNext received exceptional response: "
+                                + errorMsg);
                 apiResultStatus.compareAndSet(
                         ApiResultStatus.NONE,
                         ApiResultStatus.fromProto(response.getExceptionalResult().getExceptionalResultStatus()));

--- a/src/main/java/com/ospreydcs/dp/client/result/ApiResultStatus.java
+++ b/src/main/java/com/ospreydcs/dp/client/result/ApiResultStatus.java
@@ -72,7 +72,10 @@ public enum ApiResultStatus {
      * can present as a benign not-found and, for a caller deciding whether a save would overwrite,
      * turn into a silent clobber.  Every dispatcher must therefore set the status explicitly;
      * {@code ApiResultBaseTest.testEveryExceptionalResultSetsStatus()} guards this by scanning the
-     * service sources for a builder that omits it.
+     * service sources for a builder that omits it.  {@code
+     * ApiResultBaseTest.testEveryExceptionalResultSetsMessage()} guards the companion field the
+     * same way: the client layer records a service message verbatim, so an omitted {@code
+     * setMessage()} reaches the caller as an empty explanation.
      */
     public static ApiResultStatus fromProto(ExceptionalResult.ExceptionalResultStatus protoStatus) {
 

--- a/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/ConfigurationClientIT.java
+++ b/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/ConfigurationClientIT.java
@@ -34,9 +34,8 @@ import static org.junit.Assert.assertTrue;
  * the client wrapper — request building from the params records, the success payloads, and the
  * surfacing of server rejections through ApiResultBase.resultStatus.  Where a rejection is
  * exercised here, the assertion is about the surfacing mechanism (that the rejection arrives as
- * resultStatus.isError rather than a thrown exception, with the server's message embedded in
- * resultStatus.msg behind an "onNext received exceptional response: " prefix) and not
- * about the server-side rule that produced it.
+ * resultStatus.isError rather than a thrown exception, carrying the server's message verbatim in
+ * resultStatus.msg) and not about the server-side rule that produced it.
  */
 public class ConfigurationClientIT extends AnnotationIntegrationTestIntermediate {
 

--- a/src/test/java/com/ospreydcs/dp/client/ApiResponseObserverBaseTest.java
+++ b/src/test/java/com/ospreydcs/dp/client/ApiResponseObserverBaseTest.java
@@ -197,6 +197,65 @@ public class ApiResponseObserverBaseTest {
     }
 
     /*
+     * The service's message must reach the caller verbatim.  It was previously prefixed with the
+     * observer's class name and a gRPC lifecycle phrase, so a caller displaying
+     * ApiResult.resultStatus.msg -- the only message it has -- showed client implementation detail
+     * ahead of the server's explanation.
+     *
+     * This asserts exact equality deliberately.  Every other assertion on a client error message
+     * in this repo uses contains() against the substantive text, which passes whether or not a
+     * prefix is present, so a contains() assertion here would let the prefix creep back in
+     * unnoticed.
+     */
+    @Test
+    public void testServiceMessageIsNotPrefixed() {
+
+        final String serviceMessage =
+                "overlapping activation exists for configurationName 'beamline-a'";
+
+        final QueryClient.QueryTableResponseObserver observer =
+                new QueryClient.QueryTableResponseObserver();
+
+        observer.onNext(QueryTableResponse.newBuilder()
+                .setExceptionalResult(ExceptionalResult.newBuilder()
+                        .setExceptionalResultStatus(
+                                ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT)
+                        .setMessage(serviceMessage)
+                        .build())
+                .build());
+
+        assertReturnsPromptly("QueryTableResponseObserver.await()", observer::await);
+
+        assertTrue("an exceptional result must be reported as an error", observer.isError());
+        assertEquals(
+                "the service message must reach the caller unmodified",
+                serviceMessage,
+                observer.getErrorMessage());
+        assertEquals(ApiResultStatus.REJECT, observer.getApiResultStatus());
+    }
+
+    /*
+     * A failure the client itself detected keeps the observer name, which is the other half of the
+     * contract: stripping the prefix from service messages must not strip it from the messages
+     * this observer authors, where it identifies which RPC failed.
+     */
+    @Test
+    public void testClientDetectedFailureKeepsObserverName() {
+
+        final QueryClient.QueryProvidersResponseObserver observer =
+                new QueryClient.QueryProvidersResponseObserver();
+
+        observer.onNext(QueryProvidersResponse.newBuilder().build());
+
+        assertReturnsPromptly("QueryProvidersResponseObserver.await()", observer::await);
+
+        assertTrue(
+                "expected the observer name on a client-detected failure, got: "
+                        + observer.getErrorMessage(),
+                observer.getErrorMessage().startsWith("QueryProvidersResponseObserver"));
+    }
+
+    /*
      * A response missing the result field it is required to carry is rejected rather than stored,
      * and must release the caller.  Previously QueryProvidersResponseObserver called
      * Objects.requireNonNull here, on the onNext thread, where the resulting NPE was swallowed and

--- a/src/test/java/com/ospreydcs/dp/client/result/ApiResultBaseTest.java
+++ b/src/test/java/com/ospreydcs/dp/client/result/ApiResultBaseTest.java
@@ -138,15 +138,12 @@ public class ApiResultBaseTest {
     }
 
     /*
-     * RESULT_STATUS_REJECT is 0, the protobuf default, so an ExceptionalResult built without
-     * setExceptionalResultStatus() is indistinguishable on the wire from a deliberate reject and
-     * ApiResultStatus.fromProto() maps it to REJECT.  Callers branch on isReject() to read "target
-     * record does not exist", so such an omission can present as a benign not-found -- and for a
-     * caller deciding whether a save would overwrite, become a silent clobber.  Scan the service
-     * sources so a new dispatcher that forgets the setter fails here rather than in production.
+     * Scans the service sources for ExceptionalResult builder chains missing a required setter,
+     * returning "file:line" for each violation.  Shared by the status and message checks below,
+     * which guard the same class of defect: a field the client layer depends on that protobuf
+     * silently defaults rather than rejecting.
      */
-    @Test
-    public void testEveryExceptionalResultSetsStatus() throws IOException {
+    private static List<String> findExceptionalResultsMissing(String setter) throws IOException {
 
         final Path sourceRoot = Paths.get("src/main/java");
         assertTrue(
@@ -170,7 +167,7 @@ public class ApiResultBaseTest {
 
                 while (matcher.find()) {
                     chainCount++;
-                    if (!matcher.group().contains("setExceptionalResultStatus")) {
+                    if (!matcher.group().contains(setter)) {
                         final long line =
                                 contents.substring(0, matcher.start()).chars().filter(c -> c == '\n').count() + 1;
                         violations.add(source + ":" + line);
@@ -179,12 +176,49 @@ public class ApiResultBaseTest {
             }
         }
 
-        // guard against the regex silently matching nothing, which would make this test vacuous
+        // guard against the regex silently matching nothing, which would make the callers vacuous
         assertTrue(
                 "expected to find ExceptionalResult builders to check, found none",
                 chainCount > 0);
+
+        return violations;
+    }
+
+    /*
+     * RESULT_STATUS_REJECT is 0, the protobuf default, so an ExceptionalResult built without
+     * setExceptionalResultStatus() is indistinguishable on the wire from a deliberate reject and
+     * ApiResultStatus.fromProto() maps it to REJECT.  Callers branch on isReject() to read "target
+     * record does not exist", so such an omission can present as a benign not-found -- and for a
+     * caller deciding whether a save would overwrite, become a silent clobber.  Scan the service
+     * sources so a new dispatcher that forgets the setter fails here rather than in production.
+     */
+    @Test
+    public void testEveryExceptionalResultSetsStatus() throws IOException {
+
+        final List<String> violations =
+                findExceptionalResultsMissing("setExceptionalResultStatus");
+
         assertEquals(
                 "ExceptionalResult built without setExceptionalResultStatus() at " + violations,
+                List.of(),
+                violations);
+    }
+
+    /*
+     * The client layer records a service-supplied message verbatim (see the message contract on
+     * ApiResponseObserverBase), so an ExceptionalResult built without setMessage() reaches the
+     * caller as an empty resultStatus.msg -- a failure with no explanation at all.  Before the
+     * prefix was removed the observer name concealed this, because the caller always got at least
+     * that much text.  It no longer does, so the omission is now caller-visible and is checked
+     * here alongside the status.
+     */
+    @Test
+    public void testEveryExceptionalResultSetsMessage() throws IOException {
+
+        final List<String> violations = findExceptionalResultsMissing("setMessage");
+
+        assertEquals(
+                "ExceptionalResult built without setMessage() at " + violations,
                 List.of(),
                 violations);
     }


### PR DESCRIPTION
Fixes #240.

Server-authored rejection messages reached client API callers with the observer's class name and a gRPC lifecycle phrase glued to the front:

```
SaveConfigurationActivationResponseObserver onNext received exceptional response: overlapping activation exists for configurationName 'beamline-a' or category 'beamline'
```

Everything before `overlapping` is client implementation detail. For a caller displaying `ApiResult.resultStatus.msg` — the only message it has — it displaces the actual explanation.

## What changed

Four observers in the client layer receive an `ExceptionalResult`. Triage found they wrapped the message **three different ways**, so a caller could not strip the prefix defensively either:

| Site | Before | After |
|---|---|---|
| `ApiResponseObserverBase:250` (inherited by 16 observers) | `<ObserverName> onNext received exceptional response: <msg>` | `<msg>` |
| `IngestionClient:374` | `onNext received exceptional response: <msg>` (no class name) | `<msg>` |
| `AnnotationClient:1437` | `QuerySampleStatusesStreamResponseObserver onNext received exceptional response: <msg>` | `<msg>` |
| `IngestionStreamClient:189` | `<msg>` — already correct | unchanged |

`IngestionStreamClient`'s `SubscribeDataEventResponseObserver` already recorded the message verbatim and put its identity on the console line only, so this is applying an existing in-repo pattern to the three that diverged rather than a new design.

**The observer identity is not lost.** It stays on the stderr diagnostic at each site, and client-detected failures — a duplicate response, an expired await, a response missing its result field — keep their prefix, where naming the observer identifies which RPC failed. The contract is documented on `ApiResponseObserverBase`.

`recordFailure()` gains a private three-arg overload so a branch that has already written a more informative console line can suppress the default one. Both protected overloads are unchanged, so none of the ~20 existing call sites move.

## Guarding the field this exposes

With the prefix gone, a service that omits `setMessage()` on an `ExceptionalResult` hands the caller an **empty explanation** — previously the prefix concealed this, because the caller always got at least that much text.

`ApiResultBaseTest` already scanned the service sources for the companion omission (`setExceptionalResultStatus`, a protobuf zero-value hazard). Rather than write a second scanner, that one is parameterized by setter name and now covers `setMessage` as well. All 46 service-side builders pass; verified non-vacuous by temporarily deleting a `setMessage()` call and confirming it failed with the exact `file:line`.

## Tests

- `testServiceMessageIsNotPrefixed` — asserts **exact equality**, deliberately. Every other assertion on a client error message in this repo uses `contains()` against the substantive text and would pass whether or not a prefix crept back in, so without this the behavior regresses silently. Confirmed to fail on the pre-fix code with the prefix visible in the `ComparisonFailure`.
- `testClientDetectedFailureKeepsObserverName` — asserts the other half of the contract, so a future change can't strip the prefix where it is load-bearing.
- `testEveryExceptionalResultSetsMessage` — the source scan described above.

Full `mvn verify`: **389 unit + 232 integration across 95 suites, 0 failures** (1 pre-existing skip).

## Scope

**Out of scope, by agreement during triage:**

- **Test-base observers → #241.** `AnnotationTestBase`, `QueryTestBase` and `IngestionTestBase` construct similar messages independently and do not exercise the client layer. #241 rewrites the same observer blocks for the `await()`-timeout fix, so splitting the work would guarantee a conflict. `git diff --name-only | grep TestBase` is empty on this branch. Details posted on #241.
- **`System.err` → log4j migration.** The client observers print diagnostics to `System.err` while surrounding classes use log4j. Worth fixing under the CLAUDE.md logging convention, but folding a logging migration into a message-text change makes both harder to review.

## Reviewer notes

- `ConfigurationClientIT:38`'s Javadoc documented the prefix as the surfacing mechanism; updated to match.
- Callers must distinguish failure via `isError()` / `apiResultStatus`, never by testing the message for emptiness. That was always the right pattern and `ApiResultBase` exposes both, but it is now load-bearing rather than incidental.
- Composes with #235 and is independent of it: #235 is about the *status* attached to a failure, this is about the *message text*. Different code, either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbkpEaUpnfTXK3x5ikwwi5
