### PR TITLE
dp-service #235: classify Annotation Service business-rule failures as REJECT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,11 +181,43 @@ List<String> normalizedTags = new ArrayList<>(
 **Validation in Job.execute():** Call `dispatcher.handleValidationError(new ResultStatus(true, "message"))` and return early for each violation.
 
 **Result wrapper classes:**
-- `MongoSaveResult` — document identifier and error state
-- `MongoDeleteResult` — deleted document identifier and error state
+- `MongoSaveResult` — document identifier, plus `isError`/`isReject` state
+- `MongoDeleteResult` — deleted document identifier, plus `isError`/`isReject` state
+- `MongoCountResult` — affected-item count, plus `isError`/`isReject` state
 - `PvMetadataQueryResult` — `List<PvMetadataDocument>` and `String nextPageToken`
 - `ConfigurationQueryResult` — `List<ConfigurationDocument>` and `String nextPageToken`
 - `ConfigurationActivationQueryResult` — `List<ConfigurationActivationDocument>` and `String nextPageToken`
+
+### Reject vs. Error in the Mongo Client (issue #235)
+
+A failure detected *inside* the Mongo client must be classified, not just flagged. The three result
+wrappers above carry both `isError` and `isReject`, and the `Save*`/`Delete*` dispatchers route
+`isReject` to `sendXxxResponseReject` ahead of the `isError` branch.
+
+- **Reject** — the request violated a business rule: a referenced entity does not exist, or a
+  constraint would be broken. Retrying the identical request is pointless, and the condition is a
+  correctable mistake the caller may want to surface to a user. Build with
+  `MongoSaveResult.reject(...)` / `MongoDeleteResult.reject(...)` / `MongoCountResult.reject(...)`,
+  and log at `debug` — a client mistake is not a service error.
+- **Error** — the service failed to handle an otherwise valid request: a `MongoException`, an
+  unacknowledged write, an unexpected null id. A retry may succeed. Build with the matching
+  `error(...)` factory and log at `error` with the exception object.
+
+`isReject` implies `isError`, so callers reading only `isError` still see every failure. Adding a
+business rule on these paths without the `reject(...)` factory silently reproduces the original bug
+— the failure reads like a rejection but arrives as `RESULT_STATUS_ERROR`.
+
+**Do not classify "not found" by a helper that swallows exceptions.** `findDataSet()`/`findAnnotation()`
+return null for both "absent" and "query failed", so a Mongo outage is indistinguishable from a
+genuine not-found. `saveDataSet`/`saveAnnotation` therefore use the private `lookupDataSet()`/
+`lookupAnnotation()` variants, which throw `DpException` on query failure — otherwise a database
+outage would be reported to the caller as "your id does not exist", inverting the retry decision.
+
+The guard against regression is on the test side: the `sendAndVerify*` wrappers for the eight
+affected Save/Delete methods assert `RESULT_STATUS_REJECT` in their `expectReject` branch, and the
+observers in `AnnotationTestBase` capture `getExceptionalResultStatus()` to make that possible. Before
+this, `expectReject` asserted only `isError()` and a message substring, so the naming and the wire
+status could — and did — diverge silently.
 
 ### Pagination Pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,19 @@ observers in `AnnotationTestBase` capture `getExceptionalResultStatus()` to make
 this, `expectReject` asserted only `isError()` and a message substring, so the naming and the wire
 status could — and did — diverge silently.
 
+**Never `upsert(true)` on an `_id` filter.** An upsert filtered by natural key (pvName,
+configurationName, clientActivationId) re-creates the same logical record and is fine — that is what
+`savePvMetadata`, `saveConfiguration`, and `saveConfigurationActivation` do. An upsert filtered by
+`_id` cannot: if the document was deleted between the lookup and the write, Mongo inserts a
+*different* document under a newly generated id, having silently written data the caller never sees.
+`saveDataSet`/`saveAnnotation` therefore replace without upsert and test `getMatchedCount() == 0`,
+reporting that race as a rejection.
+
+Test `matchedCount`, not `modifiedCount`, when checking whether a `replaceOne` found its target.
+`modifiedCount` is also 0 when the replacement leaves the stored document unchanged, which is a
+successful save. (These documents carry an always-refreshed `updatedAt`, so that case does not arise
+today — but the check should not depend on that.)
+
 ### Pagination Pattern
 
 ```java

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/client/MongoSyncAnnotationClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/client/MongoSyncAnnotationClient.java
@@ -155,26 +155,34 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
 
             UpdateResult result = null;
             try {
-                final ReplaceOptions replaceOptions = new ReplaceOptions().upsert(true);
+                // No upsert: the filter is on _id, so an upsert would not re-create this document —
+                // it would insert a *different* one under a new id if the document were deleted
+                // between the lookup above and this write. Matching zero documents is the honest
+                // signal for that race, handled below.
                 final Bson idFilter = eq(BsonConstants.BSON_KEY_DATA_SET_ID, new ObjectId(existingDocumentId));
-                result = mongoCollectionDataSets.replaceOne(idFilter, dataSetDocument, replaceOptions);
+                result = mongoCollectionDataSets.replaceOne(idFilter, dataSetDocument);
             } catch (MongoException ex) {
                 final String errorMsg = "MongoException replacing DataSetDocument: " + ex.getMessage();
-                logger.error(errorMsg);
-                return new MongoSaveResult(true, errorMsg, existingDocumentId, false);
+                logger.error("saveDataSet replace error: {}", ex.getMessage(), ex);
+                return MongoSaveResult.error(errorMsg, existingDocumentId, false);
             }
 
             if (!result.wasAcknowledged()) {
                 final String errorMsg = "replaceOne not acknowledged for existing DataSetDocument id: "
                         + existingDocumentId;
                 logger.error(errorMsg);
-                return new MongoSaveResult(true, errorMsg, existingDocumentId, false);
+                return MongoSaveResult.error(errorMsg, existingDocumentId, false);
             }
 
-            if (result.getModifiedCount() != 1) {
-                final String errorMsg = "replaceOne DataSetDocument unexpected modified count: " + result.getModifiedCount();
-                logger.error(errorMsg);
-                return new MongoSaveResult(true, errorMsg, existingDocumentId, false);
+            // Test matchedCount, not modifiedCount. With the upsert removed, matching nothing is the
+            // only real failure here: the document was deleted between the lookup above and this
+            // write. modifiedCount additionally reports 0 when the stored document is unchanged by
+            // the replacement, which is a successful save, not a failure.
+            if (result.getMatchedCount() == 0) {
+                final String rejectMsg = "saveDataSet no DataSetDocument found with id: " + existingDocumentId
+                        + " (deleted concurrently)";
+                logger.debug(rejectMsg);
+                return MongoSaveResult.reject(rejectMsg, existingDocumentId, false);
             }
 
             return new MongoSaveResult(false, "", existingDocumentId, false);
@@ -359,27 +367,34 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
 
             UpdateResult result = null;
             try {
-                final ReplaceOptions replaceOptions = new ReplaceOptions().upsert(true);
-                final Bson idFilter = eq(BsonConstants.BSON_KEY_DATA_SET_ID, new ObjectId(existingDocumentId));
-                result = mongoCollectionAnnotations.replaceOne(idFilter, annotationDocument, replaceOptions);
+                // No upsert: the filter is on _id, so an upsert would not re-create this document —
+                // it would insert a *different* one under a new id if the document were deleted
+                // between the lookup above and this write. Matching zero documents is the honest
+                // signal for that race, handled below.
+                final Bson idFilter = eq(BsonConstants.BSON_KEY_ANNOTATION_ID, new ObjectId(existingDocumentId));
+                result = mongoCollectionAnnotations.replaceOne(idFilter, annotationDocument);
             } catch (MongoException ex) {
                 final String errorMsg = "MongoException replacing AnnotationDocument: " + ex.getMessage();
-                logger.error(errorMsg);
-                return new MongoSaveResult(true, errorMsg, existingDocumentId, false);
+                logger.error("saveAnnotation replace error: {}", ex.getMessage(), ex);
+                return MongoSaveResult.error(errorMsg, existingDocumentId, false);
             }
 
             if (!result.wasAcknowledged()) {
                 final String errorMsg = "replaceOne not acknowledged for existing AnnotationDocument id: "
                         + existingDocumentId;
                 logger.error(errorMsg);
-                return new MongoSaveResult(true, errorMsg, existingDocumentId, false);
+                return MongoSaveResult.error(errorMsg, existingDocumentId, false);
             }
 
-            if (result.getModifiedCount() != 1) {
-                final String errorMsg =
-                        "replaceOne AnnotationDocument unexpected modified count: " + result.getModifiedCount();
-                logger.error(errorMsg);
-                return new MongoSaveResult(true, errorMsg, existingDocumentId, false);
+            // Test matchedCount, not modifiedCount. With the upsert removed, matching nothing is the
+            // only real failure here: the document was deleted between the lookup above and this
+            // write. modifiedCount additionally reports 0 when the stored document is unchanged by
+            // the replacement, which is a successful save, not a failure.
+            if (result.getMatchedCount() == 0) {
+                final String rejectMsg = "saveAnnotation no AnnotationDocument found with id: " + existingDocumentId
+                        + " (deleted concurrently)";
+                logger.debug(rejectMsg);
+                return MongoSaveResult.reject(rejectMsg, existingDocumentId, false);
             }
 
             return new MongoSaveResult(false, "", existingDocumentId, false);

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/client/MongoSyncAnnotationClient.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/client/MongoSyncAnnotationClient.java
@@ -64,24 +64,38 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
 
     @Override
     public DataSetDocument findDataSet(String dataSetId) {
+        // Collapses "absent" and "query failed" to null. Callers that must tell the two apart —
+        // saveDataSet, which reports the former as a rejection — use lookupDataSet() instead.
+        try {
+            return lookupDataSet(dataSetId);
+        } catch (DpException ex) {
+            // already logged with its stack trace in lookupDataSet()
+            return null;
+        }
+    }
+
+    /**
+     * Looks up a DataSetDocument by id, distinguishing an absent document (null) from a failed
+     * query (DpException). {@link #findDataSet} cannot make that distinction, so a caller whose
+     * response depends on it — a missing document is a business-rule rejection, a failed query is
+     * an infrastructure error — must use this method.
+     */
+    private DataSetDocument lookupDataSet(String dataSetId) throws DpException {
         // TODO: do we need to wrap this in a retry loop?  I'm not adding it now, my reasoning is that if the caller
         // sending request has a dataSetId, it already exists in the database.
-        List<DataSetDocument> matchingDocuments = new ArrayList<>();
+        final List<DataSetDocument> matchingDocuments = new ArrayList<>();
 
         // wrap this in a try/catch because otherwise we take out the thread if mongo throws an exception
         try {
             mongoCollectionDataSets.find(
                     eq(BsonConstants.BSON_KEY_DATA_SET_ID, new ObjectId(dataSetId))).into(matchingDocuments);
         } catch (Exception ex) {
-            logger.error("findDataSet: mongo exception in find(): {}", ex.getMessage());
-            return null;
+            // log here with the trace: DpException carries only the message onward
+            logger.error("lookupDataSet: mongo exception in find(): {}", ex.getMessage(), ex);
+            throw new DpException("error querying DataSetDocument by id: " + ex.getMessage());
         }
 
-        if (matchingDocuments.size() > 0) {
-            return matchingDocuments.get(0);
-        } else {
-            return null;
-        }
+        return matchingDocuments.isEmpty() ? null : matchingDocuments.get(0);
     }
 
     @Override
@@ -92,11 +106,18 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
         // try to fetch existing document
         DataSetDocument existingDocument = null;
         if (!existingDocumentId.isBlank()) {
-            existingDocument = findDataSet(existingDocumentId);
+            try {
+                existingDocument = lookupDataSet(existingDocumentId);
+            } catch (DpException ex) {
+                final String errorMsg = "MongoException looking up DataSetDocument by id: " + ex.getMessage();
+                logger.error("saveDataSet lookup error: {}", ex.getMessage(), ex);
+                return MongoSaveResult.error(errorMsg, existingDocumentId, false);
+            }
             if (existingDocument == null) {
-                final String errorMsg = "saveDataSet no DataSetDocument found with id: " + existingDocumentId;
-                logger.error(errorMsg);
-                return new MongoSaveResult(true, errorMsg, existingDocumentId, false);
+                // the caller referenced a document that does not exist: a rejection, not an error
+                final String rejectMsg = "saveDataSet no DataSetDocument found with id: " + existingDocumentId;
+                logger.debug(rejectMsg);
+                return MongoSaveResult.reject(rejectMsg, existingDocumentId, false);
             }
         }
 
@@ -248,25 +269,37 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
 
     @Override
     public AnnotationDocument findAnnotation(String annotationId) {
+        // Collapses "absent" and "query failed" to null. Callers that must tell the two apart —
+        // saveAnnotation, which reports the former as a rejection — use lookupAnnotation() instead.
+        try {
+            return lookupAnnotation(annotationId);
+        } catch (DpException ex) {
+            // already logged with its stack trace in lookupAnnotation()
+            return null;
+        }
+     }
+
+    /**
+     * Looks up an AnnotationDocument by id, distinguishing an absent document (null) from a failed
+     * query (DpException). See {@link #lookupDataSet} for why the distinction matters.
+     */
+    private AnnotationDocument lookupAnnotation(String annotationId) throws DpException {
 
         // TODO: do we need to wrap this in a retry loop?  I'm not adding it now, my reasoning is that if the caller
         // sending request has an annotationId, it already exists in the database.
-        List<AnnotationDocument> matchingDocuments = new ArrayList<>();
+        final List<AnnotationDocument> matchingDocuments = new ArrayList<>();
 
         // wrap this in a try/catch because otherwise we take out the thread if mongo throws an exception
         try {
             mongoCollectionAnnotations.find(
                     eq(BsonConstants.BSON_KEY_ANNOTATION_ID, new ObjectId(annotationId))).into(matchingDocuments);
         } catch (Exception ex) {
-            logger.error("findAnnotation: mongo exception in find(): {}", ex.getMessage());
-            return null;
+            // log here with the trace: DpException carries only the message onward
+            logger.error("lookupAnnotation: mongo exception in find(): {}", ex.getMessage(), ex);
+            throw new DpException("error querying AnnotationDocument by id: " + ex.getMessage());
         }
 
-        if (!matchingDocuments.isEmpty()) {
-            return matchingDocuments.get(0);
-        } else {
-            return null;
-        }
+        return matchingDocuments.isEmpty() ? null : matchingDocuments.get(0);
      }
 
     @Override
@@ -277,11 +310,18 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
         // try to fetch existing document
         AnnotationDocument existingDocument = null;
         if (!existingDocumentId.isBlank()) {
-            existingDocument = findAnnotation(existingDocumentId);
+            try {
+                existingDocument = lookupAnnotation(existingDocumentId);
+            } catch (DpException ex) {
+                final String errorMsg = "MongoException looking up AnnotationDocument by id: " + ex.getMessage();
+                logger.error("saveAnnotation lookup error: {}", ex.getMessage(), ex);
+                return MongoSaveResult.error(errorMsg, existingDocumentId, false);
+            }
             if (existingDocument == null) {
-                final String errorMsg = "saveAnnotation no AnnotationDocument found with id: " + existingDocumentId;
-                logger.error(errorMsg);
-                return new MongoSaveResult(true, errorMsg, existingDocumentId, false);
+                // the caller referenced a document that does not exist: a rejection, not an error
+                final String rejectMsg = "saveAnnotation no AnnotationDocument found with id: " + existingDocumentId;
+                logger.debug(rejectMsg);
+                return MongoSaveResult.reject(rejectMsg, existingDocumentId, false);
             }
         }
 
@@ -748,10 +788,10 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
                 return new MongoSaveResult(true, errorMsg, null, false);
             }
             if (hasActivations) {
-                final String errorMsg = "cannot change category for configurationName '"
+                final String rejectMsg = "cannot change category for configurationName '"
                         + document.getConfigurationName()
                         + "': existing activations must be deleted first";
-                return new MongoSaveResult(true, errorMsg, null, false);
+                return MongoSaveResult.reject(rejectMsg, null, false);
             }
         }
         // NOTE: the activation existence check above and the subsequent replaceOne are not atomic.
@@ -923,9 +963,9 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
             return new MongoDeleteResult(true, errorMsg, null);
         }
         if (hasActivations) {
-            final String errorMsg = "cannot delete configurationName '" + configurationName
+            final String rejectMsg = "cannot delete configurationName '" + configurationName
                     + "': existing activations must be deleted first";
-            return new MongoDeleteResult(true, errorMsg, null);
+            return MongoDeleteResult.reject(rejectMsg);
         }
 
         try {
@@ -1008,7 +1048,7 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
             // look up Configuration to get internalCategory
             final ConfigurationDocument config = findConfigurationByName(document.getConfigurationName());
             if (config == null) {
-                return new MongoSaveResult(true,
+                return MongoSaveResult.reject(
                         "no Configuration found for configurationName: '" + document.getConfigurationName() + "'",
                         null, false);
             }
@@ -1031,7 +1071,7 @@ public class MongoSyncAnnotationClient extends MongoSyncClient implements MongoA
                 return new MongoSaveResult(true, errorMsg, null, false);
             }
             if (overlap) {
-                return new MongoSaveResult(true,
+                return MongoSaveResult.reject(
                         "overlapping activation exists for configurationName '"
                                 + document.getConfigurationName() + "' or category '"
                                 + document.getInternalCategory() + "'",

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/DeleteConfigurationActivationDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/DeleteConfigurationActivationDispatcher.java
@@ -26,7 +26,10 @@ public class DeleteConfigurationActivationDispatcher extends Dispatcher {
     }
 
     public void handleResult(MongoDeleteResult result) {
-        if (result.isError) {
+        if (result.isReject) {
+            // business-rule rejection detected in the mongo client, not an infrastructure failure
+            AnnotationServiceImpl.sendDeleteConfigurationActivationResponseReject(result.message, responseObserver);
+        } else if (result.isError) {
             AnnotationServiceImpl.sendDeleteConfigurationActivationResponseError(result.message, responseObserver);
         } else if (result.deletedPvName == null) {
             final String keyDescription = switch (request.getKeyCase()) {

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/DeleteConfigurationDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/DeleteConfigurationDispatcher.java
@@ -26,7 +26,10 @@ public class DeleteConfigurationDispatcher extends Dispatcher {
     }
 
     public void handleResult(MongoDeleteResult result) {
-        if (result.isError) {
+        if (result.isReject) {
+            // business-rule rejection detected in the mongo client, not an infrastructure failure
+            AnnotationServiceImpl.sendDeleteConfigurationResponseReject(result.message, responseObserver);
+        } else if (result.isError) {
             AnnotationServiceImpl.sendDeleteConfigurationResponseError(result.message, responseObserver);
         } else if (result.deletedPvName == null) {
             final String msg = "no Configuration record found for: " + request.getConfigurationName();

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/DeletePvMetadataDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/DeletePvMetadataDispatcher.java
@@ -26,7 +26,10 @@ public class DeletePvMetadataDispatcher extends Dispatcher {
     }
 
     public void handleResult(MongoDeleteResult result) {
-        if (result.isError) {
+        if (result.isReject) {
+            // business-rule rejection detected in the mongo client, not an infrastructure failure
+            AnnotationServiceImpl.sendDeletePvMetadataResponseReject(result.message, responseObserver);
+        } else if (result.isError) {
             AnnotationServiceImpl.sendDeletePvMetadataResponseError(result.message, responseObserver);
         } else if (result.deletedPvName == null) {
             final String msg = "no PvMetadata record found for: " + request.getPvNameOrAlias();

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/DeleteSampleStatusesDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/DeleteSampleStatusesDispatcher.java
@@ -30,7 +30,10 @@ public class DeleteSampleStatusesDispatcher extends Dispatcher {
     }
 
     public void handleResult(MongoCountResult result) {
-        if (result.isError) {
+        if (result.isReject) {
+            // business-rule rejection detected in the mongo client, not an infrastructure failure
+            AnnotationServiceImpl.sendDeleteSampleStatusesResponseReject(result.message, responseObserver);
+        } else if (result.isError) {
             AnnotationServiceImpl.sendDeleteSampleStatusesResponseError(result.message, responseObserver);
         } else {
             // a delete matching nothing is a success with deletedCount = 0, not an ExceptionalResult

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SaveAnnotationDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SaveAnnotationDispatcher.java
@@ -42,6 +42,13 @@ public class SaveAnnotationDispatcher extends Dispatcher {
 
     public void handleResult(MongoSaveResult result) {
 
+        // A rejection means the request violated a business rule (e.g. it referenced a document
+        // that does not exist), as opposed to the service failing to handle it.
+        if (result.isReject) {
+            AnnotationServiceImpl.sendSaveAnnotationResponseReject(result.message, responseObserver);
+            return;
+        }
+
         // Check to see if error flag is set in our result wrapper, this indicates that insertOne failed.
         if (result.isError) {
             // send error response and close response stream

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SaveConfigurationActivationDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SaveConfigurationActivationDispatcher.java
@@ -30,7 +30,10 @@ public class SaveConfigurationActivationDispatcher extends Dispatcher {
     }
 
     public void handleResult(MongoSaveResult result) {
-        if (result.isError) {
+        if (result.isReject) {
+            // business-rule rejection detected in the mongo client, not an infrastructure failure
+            AnnotationServiceImpl.sendSaveConfigurationActivationResponseReject(result.message, responseObserver);
+        } else if (result.isError) {
             AnnotationServiceImpl.sendSaveConfigurationActivationResponseError(result.message, responseObserver);
         } else {
             AnnotationServiceImpl.sendSaveConfigurationActivationResponseSuccess(result.documentId, responseObserver);

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SaveConfigurationDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SaveConfigurationDispatcher.java
@@ -30,7 +30,10 @@ public class SaveConfigurationDispatcher extends Dispatcher {
     }
 
     public void handleResult(MongoSaveResult result) {
-        if (result.isError) {
+        if (result.isReject) {
+            // business-rule rejection detected in the mongo client, not an infrastructure failure
+            AnnotationServiceImpl.sendSaveConfigurationResponseReject(result.message, responseObserver);
+        } else if (result.isError) {
             AnnotationServiceImpl.sendSaveConfigurationResponseError(result.message, responseObserver);
         } else {
             AnnotationServiceImpl.sendSaveConfigurationResponseSuccess(result.documentId, responseObserver);

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SaveDataSetDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SaveDataSetDispatcher.java
@@ -36,6 +36,13 @@ public class SaveDataSetDispatcher extends Dispatcher {
 
     public void handleResult(MongoSaveResult result) {
 
+        // A rejection means the request violated a business rule (e.g. it referenced a document
+        // that does not exist), as opposed to the service failing to handle it.
+        if (result.isReject) {
+            AnnotationServiceImpl.sendSaveDataSetResponseReject(result.message, responseObserver);
+            return;
+        }
+
         // Check to see if error flag is set in our result wrapper, this indicates that insertOne failed.
         if (result.isError) {
             // send error response and close response stream

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SavePvMetadataDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SavePvMetadataDispatcher.java
@@ -30,7 +30,10 @@ public class SavePvMetadataDispatcher extends Dispatcher {
     }
 
     public void handleResult(MongoSaveResult result) {
-        if (result.isError) {
+        if (result.isReject) {
+            // business-rule rejection detected in the mongo client, not an infrastructure failure
+            AnnotationServiceImpl.sendSavePvMetadataResponseReject(result.message, responseObserver);
+        } else if (result.isError) {
             AnnotationServiceImpl.sendSavePvMetadataResponseError(result.message, responseObserver);
         } else {
             AnnotationServiceImpl.sendSavePvMetadataResponseSuccess(result.documentId, responseObserver);

--- a/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SaveSampleStatusesDispatcher.java
+++ b/src/main/java/com/ospreydcs/dp/service/annotation/handler/mongo/dispatch/SaveSampleStatusesDispatcher.java
@@ -30,7 +30,10 @@ public class SaveSampleStatusesDispatcher extends Dispatcher {
     }
 
     public void handleResult(MongoCountResult result) {
-        if (result.isError) {
+        if (result.isReject) {
+            // business-rule rejection detected in the mongo client, not an infrastructure failure
+            AnnotationServiceImpl.sendSaveSampleStatusesResponseReject(result.message, responseObserver);
+        } else if (result.isError) {
             AnnotationServiceImpl.sendSaveSampleStatusesResponseError(result.message, responseObserver);
         } else {
             AnnotationServiceImpl.sendSaveSampleStatusesResponseSuccess(result.count, responseObserver);

--- a/src/main/java/com/ospreydcs/dp/service/common/model/MongoCountResult.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/model/MongoCountResult.java
@@ -5,16 +5,38 @@ package com.ospreydcs.dp.service.common.model;
  * sample statuses upserted by saveSampleStatuses or removed by deleteSampleStatuses. On error the
  * count reflects the items already persisted/removed before the failure (partial persistence is
  * documented behavior for those operations).
+ *
+ * <p>See {@link MongoSaveResult} for the distinction between {@link #isReject} (business-rule
+ * rejection, RESULT_STATUS_REJECT) and a plain {@link #isError} (infrastructure failure,
+ * RESULT_STATUS_ERROR). No current site returns a rejection from this type; the flag exists so a
+ * business rule added on the sample status path classifies correctly rather than reproducing the
+ * collapse described in issue #235.
  */
 public class MongoCountResult {
 
     public final boolean isError;
+    public final boolean isReject;
     public final String message;
     public final long count;
 
     public MongoCountResult(boolean isError, String message, long count) {
+        this(isError, false, message, count);
+    }
+
+    public MongoCountResult(boolean isError, boolean isReject, String message, long count) {
         this.isError = isError;
+        this.isReject = isReject;
         this.message = message;
         this.count = count;
+    }
+
+    /** Creates a result for a business-rule rejection, sent to the client as RESULT_STATUS_REJECT. */
+    public static MongoCountResult reject(String message, long count) {
+        return new MongoCountResult(true, true, message, count);
+    }
+
+    /** Creates a result for an infrastructure failure, sent to the client as RESULT_STATUS_ERROR. */
+    public static MongoCountResult error(String message, long count) {
+        return new MongoCountResult(true, false, message, count);
     }
 }

--- a/src/main/java/com/ospreydcs/dp/service/common/model/MongoDeleteResult.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/model/MongoDeleteResult.java
@@ -1,14 +1,39 @@
 package com.ospreydcs.dp.service.common.model;
 
+/**
+ * Result of a MongoDB delete operation. See {@link MongoSaveResult} for the distinction between
+ * {@link #isReject} (business-rule rejection, RESULT_STATUS_REJECT) and a plain {@link #isError}
+ * (infrastructure failure, RESULT_STATUS_ERROR).
+ *
+ * <p>Note that "no matching record" is not a failure here: the delete methods signal it with
+ * {@code isError=false} and a null {@link #deletedPvName}, and the dispatcher turns that into a
+ * rejection.
+ */
 public class MongoDeleteResult {
 
     public final boolean isError;
+    public final boolean isReject;
     public final String message;
     public final String deletedPvName;
 
     public MongoDeleteResult(boolean isError, String message, String deletedPvName) {
+        this(isError, false, message, deletedPvName);
+    }
+
+    public MongoDeleteResult(boolean isError, boolean isReject, String message, String deletedPvName) {
         this.isError = isError;
+        this.isReject = isReject;
         this.message = message;
         this.deletedPvName = deletedPvName;
+    }
+
+    /** Creates a result for a business-rule rejection, sent to the client as RESULT_STATUS_REJECT. */
+    public static MongoDeleteResult reject(String message) {
+        return new MongoDeleteResult(true, true, message, null);
+    }
+
+    /** Creates a result for an infrastructure failure, sent to the client as RESULT_STATUS_ERROR. */
+    public static MongoDeleteResult error(String message) {
+        return new MongoDeleteResult(true, false, message, null);
     }
 }

--- a/src/main/java/com/ospreydcs/dp/service/common/model/MongoSaveResult.java
+++ b/src/main/java/com/ospreydcs/dp/service/common/model/MongoSaveResult.java
@@ -1,16 +1,48 @@
 package com.ospreydcs.dp.service.common.model;
 
+/**
+ * Result of a MongoDB save operation.
+ *
+ * <p>Failures come in two kinds, and callers act on them differently. A <i>rejection</i>
+ * ({@link #isReject}) means the request violated a business rule — a referenced entity does not
+ * exist, or a constraint would be broken — so the service declined it and retrying the same
+ * request is pointless. An <i>error</i> means the service failed to handle an otherwise valid
+ * request (a MongoException, an unacknowledged write), where a retry may well succeed. The
+ * dispatchers map these to RESULT_STATUS_REJECT and RESULT_STATUS_ERROR respectively.
+ *
+ * <p>{@link #isReject} implies {@link #isError}, so call sites that only test {@code isError}
+ * continue to see every failure. Prefer the {@link #reject} and {@link #error} factories over the
+ * constructor when building a failure result.
+ */
 public class MongoSaveResult {
     
     public final Boolean isError;
+    public final boolean isReject;
     public final String message;
     public final String documentId;
     public final boolean isNewDocument;
 
     public MongoSaveResult(Boolean isError, String message, String documentId, boolean isNewDocument) {
+        this(isError, false, message, documentId, isNewDocument);
+    }
+
+    public MongoSaveResult(
+            Boolean isError, boolean isReject, String message, String documentId, boolean isNewDocument
+    ) {
         this.isError = isError;
+        this.isReject = isReject;
         this.message = message;
         this.documentId = documentId;
         this.isNewDocument = isNewDocument;
+    }
+
+    /** Creates a result for a business-rule rejection, sent to the client as RESULT_STATUS_REJECT. */
+    public static MongoSaveResult reject(String message, String documentId, boolean isNewDocument) {
+        return new MongoSaveResult(true, true, message, documentId, isNewDocument);
+    }
+
+    /** Creates a result for an infrastructure failure, sent to the client as RESULT_STATUS_ERROR. */
+    public static MongoSaveResult error(String message, String documentId, boolean isNewDocument) {
+        return new MongoSaveResult(true, false, message, documentId, isNewDocument);
     }
 }

--- a/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/ConfigurationClientIT.java
+++ b/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/ConfigurationClientIT.java
@@ -480,6 +480,10 @@ public class ConfigurationClientIT extends AnnotationIntegrationTestIntermediate
                                 null, null, null, null));
 
         assertTrue(result.resultStatus.isError);
+        // the referenced configuration not existing is a business rule, so this must be a REJECT
+        // rather than an ERROR: the test's name and the wire status have to agree (issue #235)
+        assertEquals(ApiResultStatus.REJECT, result.apiResultStatus);
+        assertTrue(result.isReject());
         assertTrue(result.resultStatus.msg,
                 result.resultStatus.msg.contains("no Configuration found for configurationName"));
         assertNull(result.clientActivationId);
@@ -605,18 +609,18 @@ public class ConfigurationClientIT extends AnnotationIntegrationTestIntermediate
     }
 
     /**
-     * Verifies that the overlap constraint failure arrives categorized as ERROR, not REJECT.
+     * Verifies that the overlap constraint failure arrives categorized as REJECT, not ERROR.
      *
      * The overlap check runs in MongoSyncAnnotationClient after the request has already passed
-     * validation, and reports through the MongoSaveResult error path, which the dispatcher sends as
-     * RESULT_STATUS_ERROR.  So although "an overlapping activation already exists" reads like a
-     * rejection of the request, it is categorized as a service error, and a caller branching on
-     * isReject() will not catch it.  This test pins that behavior: the constraint is a server-side
-     * concern, and whether it ought to be reported as a reject instead is a question about the
-     * service, not about this client status mapping.
+     * validation.  It used to report through the MongoSaveResult error path, so "an overlapping
+     * activation already exists" — which reads like a rejection of the request — reached the caller
+     * as RESULT_STATUS_ERROR and a caller branching on isReject() would not catch it.  Issue #235
+     * gave the result wrappers an isReject flag and classified this site as a business rule, so the
+     * constraint now arrives as a rejection: retrying the identical request is pointless, and the
+     * condition is a correctable mistake rather than a service failure.
      */
     @Test
-    public void testApiResultStatusErrorOnOverlapConstraint() {
+    public void testApiResultStatusRejectOnOverlapConstraint() {
 
         final SaveConfigurationApiResult configResult = annotationClient.saveConfiguration(
                 new AnnotationClient.SaveConfigurationParams(
@@ -644,8 +648,9 @@ public class ConfigurationClientIT extends AnnotationIntegrationTestIntermediate
                                 null, null, null, null));
 
         assertTrue(secondResult.resultStatus.isError);
-        assertEquals(ApiResultStatus.ERROR, secondResult.apiResultStatus);
-        assertFalse(secondResult.isReject());
+        assertEquals(ApiResultStatus.REJECT, secondResult.apiResultStatus);
+        assertTrue(secondResult.isReject());
+        assertTrue(secondResult.resultStatus.msg.contains("overlapping activation exists"));
     }
 
 }

--- a/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/ConfigurationIT.java
+++ b/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/ConfigurationIT.java
@@ -608,6 +608,57 @@ public class ConfigurationIT extends AnnotationIntegrationTestIntermediate {
                 overlap, true, "overlapping activation exists");
     }
 
+    /**
+     * The activation guard on saveConfiguration is a business rule, so a category change blocked by
+     * existing activations must reach the client as REJECT rather than ERROR (issue #235). The
+     * status assertion lives in sendAndVerifySaveConfiguration().
+     */
+    @Test
+    public void testSaveConfigurationRejectCategoryChangeWithActivations() {
+        saveConfigForActivationTests("cat-change-config", "original-cat");
+
+        // an activation makes the configuration's category immutable
+        final AnnotationTestBase.SaveConfigurationActivationParams activation =
+                new AnnotationTestBase.SaveConfigurationActivationParams(
+                        "cat-change-activation", "cat-change-config",
+                        ts(T0_SECONDS, T0_NANOS), ts(T2_SECONDS, T2_NANOS),
+                        null, null, null, null);
+        annotationServiceWrapper.sendAndVerifySaveConfigurationActivation(activation, false, null);
+        assertNotNull(mongoClient.findConfigurationActivationById("cat-change-activation"));
+
+        // re-saving with a different category must be rejected
+        final AnnotationTestBase.SaveConfigurationParams changed = new AnnotationTestBase.SaveConfigurationParams(
+                "cat-change-config", "different-cat", null, null, null, null, null);
+        annotationServiceWrapper.sendAndVerifySaveConfiguration(
+                changed, true, "existing activations must be deleted first");
+
+        // the stored category is unchanged
+        assertEquals("original-cat", mongoClient.findConfiguration("cat-change-config").getCategory());
+    }
+
+    /**
+     * As above, for the delete guard: deleting a configuration that still has activations is a
+     * business rule violation, and must arrive as REJECT rather than ERROR (issue #235).
+     */
+    @Test
+    public void testDeleteConfigurationRejectWithActivations() {
+        saveConfigForActivationTests("delete-guard-config", "delete-guard-cat");
+
+        final AnnotationTestBase.SaveConfigurationActivationParams activation =
+                new AnnotationTestBase.SaveConfigurationActivationParams(
+                        "delete-guard-activation", "delete-guard-config",
+                        ts(T0_SECONDS, T0_NANOS), ts(T2_SECONDS, T2_NANOS),
+                        null, null, null, null);
+        annotationServiceWrapper.sendAndVerifySaveConfigurationActivation(activation, false, null);
+        assertNotNull(mongoClient.findConfigurationActivationById("delete-guard-activation"));
+
+        annotationServiceWrapper.sendAndVerifyDeleteConfiguration(
+                "delete-guard-config", true, "existing activations must be deleted first");
+
+        // the configuration survives the rejected delete
+        assertNotNull(mongoClient.findConfiguration("delete-guard-config"));
+    }
+
     @Test
     public void testSaveConfigurationActivationRejectOverlapSameCategory() {
         saveConfigForActivationTests("cat-config-A", "shared-cat");

--- a/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/GrpcIntegrationAnnotationServiceWrapper.java
+++ b/src/test/integration/java/com/ospreydcs/dp/service/integration/annotation/GrpcIntegrationAnnotationServiceWrapper.java
@@ -7,6 +7,7 @@ import com.ospreydcs.dp.grpc.v1.annotation.*;
 import com.ospreydcs.dp.grpc.v1.common.CalculationsSpec;
 import com.ospreydcs.dp.grpc.v1.common.DataColumn;
 import com.ospreydcs.dp.grpc.v1.common.DataTimestamps;
+import com.ospreydcs.dp.grpc.v1.common.ExceptionalResult;
 import com.ospreydcs.dp.service.annotation.AnnotationTestBase;
 import com.ospreydcs.dp.service.annotation.handler.interfaces.AnnotationHandlerInterface;
 import com.ospreydcs.dp.service.annotation.handler.mongo.MongoAnnotationHandler;
@@ -144,6 +145,10 @@ public class GrpcIntegrationAnnotationServiceWrapper extends GrpcIntegrationServ
 
         if (expectReject) {
             assertTrue(responseObserver.isError());
+            assertEquals(
+                    "business-rule and validation failures must be sent as REJECT, not ERROR",
+                    ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
+                    responseObserver.getExceptionalResultStatus());
             assertTrue(responseObserver.getErrorMessage().contains(expectedRejectMessage));
         } else {
             assertFalse(responseObserver.getErrorMessage(), responseObserver.isError());
@@ -322,6 +327,10 @@ public class GrpcIntegrationAnnotationServiceWrapper extends GrpcIntegrationServ
 
         if (expectReject) {
             assertTrue(responseObserver.isError());
+            assertEquals(
+                    "business-rule and validation failures must be sent as REJECT, not ERROR",
+                    ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
+                    responseObserver.getExceptionalResultStatus());
             assertFalse(expectedRejectMessage.isBlank());
             assertTrue(responseObserver.getErrorMessage().contains(expectedRejectMessage));
         } else {
@@ -817,6 +826,10 @@ public class GrpcIntegrationAnnotationServiceWrapper extends GrpcIntegrationServ
 
         if (expectReject) {
             assertTrue(responseObserver.isError());
+            assertEquals(
+                    "business-rule and validation failures must be sent as REJECT, not ERROR",
+                    ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
+                    responseObserver.getExceptionalResultStatus());
             assertTrue(responseObserver.getErrorMessage().contains(expectedRejectMessage));
             assertNull(responseObserver.getPvName());
             return null;
@@ -899,6 +912,10 @@ public class GrpcIntegrationAnnotationServiceWrapper extends GrpcIntegrationServ
 
         if (expectReject) {
             assertTrue(responseObserver.isError());
+            assertEquals(
+                    "business-rule and validation failures must be sent as REJECT, not ERROR",
+                    ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
+                    responseObserver.getExceptionalResultStatus());
             assertTrue(responseObserver.getErrorMessage().contains(expectedRejectMessage));
             return null;
         }
@@ -1230,6 +1247,10 @@ public class GrpcIntegrationAnnotationServiceWrapper extends GrpcIntegrationServ
 
         if (expectReject) {
             assertTrue(responseObserver.isError());
+            assertEquals(
+                    "business-rule and validation failures must be sent as REJECT, not ERROR",
+                    ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
+                    responseObserver.getExceptionalResultStatus());
             assertTrue(responseObserver.getErrorMessage().contains(expectedRejectMessage));
             assertNull(responseObserver.getConfigurationName());
             return null;
@@ -1311,6 +1332,10 @@ public class GrpcIntegrationAnnotationServiceWrapper extends GrpcIntegrationServ
 
         if (expectReject) {
             assertTrue(responseObserver.isError());
+            assertEquals(
+                    "business-rule and validation failures must be sent as REJECT, not ERROR",
+                    ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
+                    responseObserver.getExceptionalResultStatus());
             assertTrue(responseObserver.getErrorMessage().contains(expectedRejectMessage));
             return null;
         }
@@ -1365,6 +1390,10 @@ public class GrpcIntegrationAnnotationServiceWrapper extends GrpcIntegrationServ
 
         if (expectReject) {
             assertTrue(responseObserver.isError());
+            assertEquals(
+                    "business-rule and validation failures must be sent as REJECT, not ERROR",
+                    ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
+                    responseObserver.getExceptionalResultStatus());
             assertTrue(responseObserver.getErrorMessage().contains(expectedRejectMessage));
             assertNull(responseObserver.getClientActivationId());
             return null;
@@ -1475,6 +1504,10 @@ public class GrpcIntegrationAnnotationServiceWrapper extends GrpcIntegrationServ
 
         if (expectReject) {
             assertTrue(responseObserver.isError());
+            assertEquals(
+                    "business-rule and validation failures must be sent as REJECT, not ERROR",
+                    ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
+                    responseObserver.getExceptionalResultStatus());
             assertTrue(responseObserver.getErrorMessage().contains(expectedRejectMessage));
             return null;
         }
@@ -1503,6 +1536,10 @@ public class GrpcIntegrationAnnotationServiceWrapper extends GrpcIntegrationServ
 
         if (expectReject) {
             assertTrue(responseObserver.isError());
+            assertEquals(
+                    "business-rule and validation failures must be sent as REJECT, not ERROR",
+                    ExceptionalResult.ExceptionalResultStatus.RESULT_STATUS_REJECT,
+                    responseObserver.getExceptionalResultStatus());
             assertTrue(responseObserver.getErrorMessage().contains(expectedRejectMessage));
             return null;
         }

--- a/src/test/java/com/ospreydcs/dp/service/annotation/AnnotationTestBase.java
+++ b/src/test/java/com/ospreydcs/dp/service/annotation/AnnotationTestBase.java
@@ -7,6 +7,7 @@ import com.ospreydcs.dp.grpc.v1.annotation.*;
 import com.ospreydcs.dp.grpc.v1.common.CalculationsSpec;
 import com.ospreydcs.dp.grpc.v1.common.DataColumn;
 import com.ospreydcs.dp.grpc.v1.common.DoubleColumn;
+import com.ospreydcs.dp.grpc.v1.common.ExceptionalResult;
 import com.ospreydcs.dp.grpc.v1.common.Timestamp;
 import com.ospreydcs.dp.service.common.bson.column.DataColumnDocument;
 import com.ospreydcs.dp.service.common.bson.bucket.BucketDocument;
@@ -58,6 +59,8 @@ public class AnnotationTestBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<ExceptionalResult.ExceptionalResultStatus> resultStatusList =
+                Collections.synchronizedList(new ArrayList<>());
         private final List<String> dataSetIdList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -81,6 +84,11 @@ public class AnnotationTestBase {
             }
         }
 
+        /** Wire status of the ExceptionalResult, or null if the response was not exceptional. */
+        public ExceptionalResult.ExceptionalResultStatus getExceptionalResultStatus() {
+            return resultStatusList.isEmpty() ? null : resultStatusList.get(0);
+        }
+
         public String getDataSetId() {
             if (!dataSetIdList.isEmpty()) {
                 return dataSetIdList.get(0);
@@ -97,6 +105,7 @@ public class AnnotationTestBase {
             new Thread(() -> {
 
                 if (response.hasExceptionalResult()) {
+                    resultStatusList.add(response.getExceptionalResult().getExceptionalResultStatus());
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
@@ -310,6 +319,8 @@ public class AnnotationTestBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<ExceptionalResult.ExceptionalResultStatus> resultStatusList =
+                Collections.synchronizedList(new ArrayList<>());
         private final List<String> annotationIdList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -333,6 +344,11 @@ public class AnnotationTestBase {
             }
         }
 
+        /** Wire status of the ExceptionalResult, or null if the response was not exceptional. */
+        public ExceptionalResult.ExceptionalResultStatus getExceptionalResultStatus() {
+            return resultStatusList.isEmpty() ? null : resultStatusList.get(0);
+        }
+
         public String getAnnotationId() {
             if (!annotationIdList.isEmpty()) {
                 return annotationIdList.get(0);
@@ -349,6 +365,7 @@ public class AnnotationTestBase {
             new Thread(() -> {
 
                 if (response.hasExceptionalResult()) {
+                    resultStatusList.add(response.getExceptionalResult().getExceptionalResultStatus());
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
@@ -1157,6 +1174,8 @@ public class AnnotationTestBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<ExceptionalResult.ExceptionalResultStatus> resultStatusList =
+                Collections.synchronizedList(new ArrayList<>());
         private final List<String> pvNameList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -1176,6 +1195,11 @@ public class AnnotationTestBase {
             return errorMessageList.isEmpty() ? "" : errorMessageList.get(0);
         }
 
+        /** Wire status of the ExceptionalResult, or null if the response was not exceptional. */
+        public ExceptionalResult.ExceptionalResultStatus getExceptionalResultStatus() {
+            return resultStatusList.isEmpty() ? null : resultStatusList.get(0);
+        }
+
         public String getPvName() {
             return pvNameList.isEmpty() ? null : pvNameList.get(0);
         }
@@ -1184,6 +1208,7 @@ public class AnnotationTestBase {
         public void onNext(SavePvMetadataResponse response) {
             new Thread(() -> {
                 if (response.hasExceptionalResult()) {
+                    resultStatusList.add(response.getExceptionalResult().getExceptionalResultStatus());
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
@@ -1362,6 +1387,8 @@ public class AnnotationTestBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<ExceptionalResult.ExceptionalResultStatus> resultStatusList =
+                Collections.synchronizedList(new ArrayList<>());
         private final List<String> pvNameList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -1381,6 +1408,11 @@ public class AnnotationTestBase {
             return errorMessageList.isEmpty() ? "" : errorMessageList.get(0);
         }
 
+        /** Wire status of the ExceptionalResult, or null if the response was not exceptional. */
+        public ExceptionalResult.ExceptionalResultStatus getExceptionalResultStatus() {
+            return resultStatusList.isEmpty() ? null : resultStatusList.get(0);
+        }
+
         public String getDeletedPvName() {
             return pvNameList.isEmpty() ? null : pvNameList.get(0);
         }
@@ -1389,6 +1421,7 @@ public class AnnotationTestBase {
         public void onNext(DeletePvMetadataResponse response) {
             new Thread(() -> {
                 if (response.hasExceptionalResult()) {
+                    resultStatusList.add(response.getExceptionalResult().getExceptionalResultStatus());
                     final String errorMsg = "onNext received exceptional response: "
                             + response.getExceptionalResult().getMessage();
                     System.err.println(errorMsg);
@@ -1574,6 +1607,8 @@ public class AnnotationTestBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<ExceptionalResult.ExceptionalResultStatus> resultStatusList =
+                Collections.synchronizedList(new ArrayList<>());
         private final List<String> configNameList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -1582,12 +1617,18 @@ public class AnnotationTestBase {
         }
         public boolean isError() { return isError.get(); }
         public String getErrorMessage() { return errorMessageList.isEmpty() ? "" : errorMessageList.get(0); }
+
+        /** Wire status of the ExceptionalResult, or null if the response was not exceptional. */
+        public ExceptionalResult.ExceptionalResultStatus getExceptionalResultStatus() {
+            return resultStatusList.isEmpty() ? null : resultStatusList.get(0);
+        }
         public String getConfigurationName() { return configNameList.isEmpty() ? null : configNameList.get(0); }
 
         @Override
         public void onNext(SaveConfigurationResponse response) {
             new Thread(() -> {
                 if (response.hasExceptionalResult()) {
+                    resultStatusList.add(response.getExceptionalResult().getExceptionalResultStatus());
                     isError.set(true);
                     errorMessageList.add(response.getExceptionalResult().getMessage());
                     finishLatch.countDown();
@@ -1692,6 +1733,8 @@ public class AnnotationTestBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<ExceptionalResult.ExceptionalResultStatus> resultStatusList =
+                Collections.synchronizedList(new ArrayList<>());
         private final List<String> configNameList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -1700,12 +1743,18 @@ public class AnnotationTestBase {
         }
         public boolean isError() { return isError.get(); }
         public String getErrorMessage() { return errorMessageList.isEmpty() ? "" : errorMessageList.get(0); }
+
+        /** Wire status of the ExceptionalResult, or null if the response was not exceptional. */
+        public ExceptionalResult.ExceptionalResultStatus getExceptionalResultStatus() {
+            return resultStatusList.isEmpty() ? null : resultStatusList.get(0);
+        }
         public String getConfigurationName() { return configNameList.isEmpty() ? null : configNameList.get(0); }
 
         @Override
         public void onNext(DeleteConfigurationResponse response) {
             new Thread(() -> {
                 if (response.hasExceptionalResult()) {
+                    resultStatusList.add(response.getExceptionalResult().getExceptionalResultStatus());
                     isError.set(true);
                     errorMessageList.add(response.getExceptionalResult().getMessage());
                     finishLatch.countDown();
@@ -1809,6 +1858,8 @@ public class AnnotationTestBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<ExceptionalResult.ExceptionalResultStatus> resultStatusList =
+                Collections.synchronizedList(new ArrayList<>());
         private final List<String> idList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -1817,12 +1868,18 @@ public class AnnotationTestBase {
         }
         public boolean isError() { return isError.get(); }
         public String getErrorMessage() { return errorMessageList.isEmpty() ? "" : errorMessageList.get(0); }
+
+        /** Wire status of the ExceptionalResult, or null if the response was not exceptional. */
+        public ExceptionalResult.ExceptionalResultStatus getExceptionalResultStatus() {
+            return resultStatusList.isEmpty() ? null : resultStatusList.get(0);
+        }
         public String getClientActivationId() { return idList.isEmpty() ? null : idList.get(0); }
 
         @Override
         public void onNext(SaveConfigurationActivationResponse response) {
             new Thread(() -> {
                 if (response.hasExceptionalResult()) {
+                    resultStatusList.add(response.getExceptionalResult().getExceptionalResultStatus());
                     isError.set(true);
                     errorMessageList.add(response.getExceptionalResult().getMessage());
                     finishLatch.countDown();
@@ -1931,6 +1988,8 @@ public class AnnotationTestBase {
         private final CountDownLatch finishLatch = new CountDownLatch(1);
         private final AtomicBoolean isError = new AtomicBoolean(false);
         private final List<String> errorMessageList = Collections.synchronizedList(new ArrayList<>());
+        private final List<ExceptionalResult.ExceptionalResultStatus> resultStatusList =
+                Collections.synchronizedList(new ArrayList<>());
         private final List<String> idList = Collections.synchronizedList(new ArrayList<>());
 
         public void await() {
@@ -1939,12 +1998,18 @@ public class AnnotationTestBase {
         }
         public boolean isError() { return isError.get(); }
         public String getErrorMessage() { return errorMessageList.isEmpty() ? "" : errorMessageList.get(0); }
+
+        /** Wire status of the ExceptionalResult, or null if the response was not exceptional. */
+        public ExceptionalResult.ExceptionalResultStatus getExceptionalResultStatus() {
+            return resultStatusList.isEmpty() ? null : resultStatusList.get(0);
+        }
         public String getClientActivationId() { return idList.isEmpty() ? null : idList.get(0); }
 
         @Override
         public void onNext(DeleteConfigurationActivationResponse response) {
             new Thread(() -> {
                 if (response.hasExceptionalResult()) {
+                    resultStatusList.add(response.getExceptionalResult().getExceptionalResultStatus());
                     isError.set(true);
                     errorMessageList.add(response.getExceptionalResult().getMessage());
                     finishLatch.countDown();


### PR DESCRIPTION
Fixes #235.

Business-rule rejections detected inside `MongoSyncAnnotationClient` reached clients as `RESULT_STATUS_ERROR` instead of `RESULT_STATUS_REJECT`, because `MongoSaveResult`/`MongoDeleteResult` carried a single `isError` boolean that could not distinguish "this request violates a rule" from "the database failed". Validation failures caught earlier in the job were already sent as REJECT, so the naming and the wire status disagreed — and nothing asserted the status, which is why it went unnoticed.

## Approach

The three result wrappers gain an `isReject` flag alongside `isError`, with `reject()`/`error()` factories, and the eight `Save*`/`Delete*` dispatchers route it. `isReject` implies `isError`, so callers reading only `isError` see no change; the existing constructors are kept, so the ~50 untouched call sites are unaffected.

`MongoCountResult` is included even though none of its current sites are misclassified — it was added by #238 after the ticket was written, and leaving one wrapper out of the pattern would let the next business rule on the sample status path reproduce the bug.

## Classification

All 38 `isError=true` sites in `MongoSyncAnnotationClient` were audited ([full table on the issue](https://github.com/osprey-dcs/dp-service/issues/235#issuecomment-5388554838)). Six are business rules; the other 32 are genuine infrastructure failures and stay as errors:

| Method | Condition |
|---|---|
| `saveDataSet` | no DataSetDocument found with id |
| `saveAnnotation` | no AnnotationDocument found with id |
| `saveConfiguration` | category change blocked by activations |
| `deleteConfiguration` | delete blocked by activations |
| `saveConfigurationActivation` | referenced Configuration not found |
| `saveConfigurationActivation` | overlapping activation exists |

The issue named two of these and anticipated a third; the audit added the rest.

### The two not-found sites needed more than reclassification

`saveDataSet`/`saveAnnotation` reached "not found" through `findDataSet()`/`findAnnotation()`, which catch every exception and return `null`. A Mongo outage was therefore indistinguishable from an absent document. Reclassifying those alone would have reported a database failure as *"your id does not exist"* — a worse answer than the current one, and the opposite of the retry decision this change exists to get right.

Both save methods now use private `lookupDataSet()`/`lookupAnnotation()` variants that throw `DpException` on query failure. `find*` keeps its null-on-failure contract for its other callers.

## Second commit: `upsert(true)` on an `_id` filter

Picked up on this ticket rather than filed as a follow-up, per discussion — it lives in the same two methods.

Both update paths called `replaceOne()` with `upsert(true)` on `eq(_id, existingDocumentId)`, then treated `modifiedCount != 1` as a failure. An upsert filtered by *natural key* re-creates the same logical record, which is what `savePvMetadata`/`saveConfiguration`/`saveConfigurationActivation` rely on. An upsert filtered by `_id` cannot: if the document is deleted between the lookup and the write, Mongo inserts a **different** document under a newly generated id and reports `matchedCount=0, modifiedCount=0, upsertedCount=1`. The old code then returned an error reading "unexpected modified count" — having silently written a stray document, and echoing back an id that no longer refers to anything.

The upsert is dropped (both call sites already confirmed existence, so it could only ever mask a race) and the check is now `getMatchedCount() == 0`, reported as a rejection. The three natural-key upserts are unchanged.

Driver semantics were verified against a live mongod rather than assumed: an identical-content replace reports `modifiedCount=1`, so there is no benign-no-op false positive today. The check is on `matchedCount` regardless, so it does not depend on these documents always refreshing `updatedAt`.

Also corrects `saveAnnotation`'s replace filter, which used `BSON_KEY_DATA_SET_ID` against the annotations collection — harmless, since both constants are `"_id"`, but the filter is load-bearing now that the upsert is gone.

## Tests

The `sendAndVerify*` wrappers for the eight affected methods now assert `RESULT_STATUS_REJECT` in their `expectReject` branch, and the corresponding `AnnotationTestBase` observers capture `getExceptionalResultStatus()`. Previously `expectReject` asserted only `isError()` and a message substring.

**The guard was mutation-checked**: each fix was reverted in turn and the matching tests confirmed to fail with `expected:<RESULT_STATUS_REJECT> but was:<RESULT_STATUS_ERROR>`, then restored. This caught one case where the assertion was passing vacuously — the `saveAnnotation` not-found sites turn out to be unreachable, since `MongoAnnotationHandler.validateSaveAnnotationRequest()` rejects both ids up front.

Also added:
- regression tests for the two activation guards, which had no coverage at all
- a status assertion to `testSaveActivationRejectUnresolvedConfigurationName`, which was named after a reject but never checked for one
- renamed `testApiResultStatusErrorOnOverlapConstraint` → `...RejectOnOverlapConstraint` (it deliberately pinned the old behavior)

No test accompanies the `upsert` fix: the surviving branch is reachable only through a real TOCTOU race between the lookup and the replace, which an integration test cannot produce deterministically without instrumenting the client. A re-save test was written first, found to pass against both the old and new code, and removed rather than left implying coverage it did not provide.

**Results:** 389 unit tests, 234 integration tests (181 annotation ITs re-run against the final tree) — all green.

## Compatibility

This is a wire-visible change for six failure paths. Per the analysis on the issue it is invisible to any caller reading only `isError` and the message — which is every current `dp-desktop-app` caller — but a caller branching on `ExceptionalResultStatus` will see these move from `ERROR` to `REJECT`. That is the point of the fix.

## Notes for review

- The `saveDataSet`/`saveAnnotation` not-found sites are correct now but unreachable, since the handler validates those ids first. Worth knowing before someone tries to write a test for them.
- `CLAUDE.md` gains a "Reject vs. Error in the Mongo Client" section covering the classification rule, the swallowed-exception trap, and the upsert-on-`_id` hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VfZCRz47s9dvoV3Zz6qiv
